### PR TITLE
fix(release): bump to v0.6.1 — correct npm dependency versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,8 @@ jobs:
             "packages/orchestration"
             "packages/prompts"
             "packages/a2a"
+            "packages/gateway"
+            "packages/testing"
             "packages/runtime"
             "packages/reactive-agents"
             "apps/cli"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 
 ---
 
+## [0.6.1] - 2026-03-05
+
+Patch release — fixes npm dependency resolution. v0.6.0 was published with stale `workspace:^` resolutions pointing to `^0.5.5` instead of `^0.6.0`. Also adds `@reactive-agents/gateway` and `@reactive-agents/testing` to the publish workflow (were missing from the PACKAGES list).
+
+### Fixed
+
+- All cross-package dependencies now resolve to `^0.6.1` (was `^0.5.5` in 0.6.0)
+- `@reactive-agents/gateway` added to npm publish workflow
+- `@reactive-agents/testing` added to npm publish workflow
+
+---
+
 ## [0.6.0] - 2026-03-04
 
 Agent Streaming, Gateway persistent agent harness, Composable Kernel Architecture, Structured Plan Engine, Strategy SDK Refactor, Foundation Fixes, documentation pass with 13 agent skills. 20 packages bumped to 0.6.0, 1,381 tests across 180 files.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/cli",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "bin": {

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/a2a",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/core",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/cost/package.json
+++ b/packages/cost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/cost",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/eval",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/gateway",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/guardrails/package.json
+++ b/packages/guardrails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/guardrails",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/identity",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/interaction",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/llm-provider/package.json
+++ b/packages/llm-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/llm-provider",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/memory",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/observability",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/orchestration",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/prompts",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/reactive-agents/package.json
+++ b/packages/reactive-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reactive-agents",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/reasoning/package.json
+++ b/packages/reasoning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/reasoning",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/runtime",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/testing",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/verification/package.json
+++ b/packages/verification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/verification",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
v0.6.0 was published with stale workspace:^ resolutions (^0.5.5) because the first tag push triggered CI before the version bump commit. This patch re-publishes all packages with correct ^0.6.1 cross-dependencies.

Also adds gateway and testing to the publish workflow PACKAGES list.