### PR TITLE
runtime-builder-state-typing: type BuilderState option groups (closes #72)

### DIFF
--- a/.agents/skills/execute-backlog/SKILL.md
+++ b/.agents/skills/execute-backlog/SKILL.md
@@ -70,7 +70,9 @@ For each candidate, parse:
 3. Drop issues with the `blocked` label
 4. Drop issues assigned to someone else
 
-Output: candidate set, sorted by `priority:p0` > `p1` > `p2` > `p3`, then by `verified` label (verified issues rank higher).
+**Drift check (added 2026-05-21):** for any candidate carrying a verified-by command with file:line references, re-run the command. If the emitted line numbers differ from the issue body's claimed lines by **>5** on any row, mark the candidate `🟡 drift detected` and re-read the cited spans to confirm the semantic cast/pattern still matches. Counts can match while locations move 25+ lines — that means the surrounding logic refactored and the fix shape may no longer apply. Acceptable to proceed; not acceptable to skip the check.
+
+Output: candidate set, sorted by `priority:p0` > `p1` > `p2` > `p3`, then by `verified` label (verified issues rank higher), then drift-clean before drift-detected.
 
 ---
 
@@ -90,6 +92,8 @@ Group candidates into one **bundle** (max `max_bundle_size`) that ships together
 2. Greedily add candidates that share ≥1 cohesion signal with the bundle
 3. Stop at `max_bundle_size` OR when no remaining candidate has cohesion ≥1 with the bundle
 4. If the bundle has <2 issues after greedy growth → still proceed (singleton bundles are fine)
+
+**Hard gate (added 2026-05-21): cross-package descope.** Before locking the bundle, re-grep each candidate's verified-by command and inspect the file paths it emits. If those paths span **≥2 packages** (`packages/<a>/…` vs `packages/<b>/…`), descope to a per-package bundle even if the issue body's "Fix direction" suggests otherwise. The body lies; the grep doesn't. (Reason: 2026-05-21 #73 spawn — body said "type properly in the think phase" but the actual `as any` targets resolved to types owned by `@reactive-agents/llm-service` and the kernel-context shape, both other packages.)
 
 **Output:** named bundle. Pattern: `<area>-<theme>` (e.g., `providers-untyped-hooks`, `runtime-builder-as-any-sweep`).
 
@@ -150,6 +154,15 @@ rtk git checkout -B bundle/<bundle-name> origin/main
 Naming pattern: `bundle/<area>-<theme>` (e.g., `bundle/runtime-builder-state-typing`). The branch is the unit-of-work for the entire bundle. All commits in Phase 4 land here; the Phase 6 PR ships them together.
 
 If the working tree is dirty when this skill is invoked, **stop** and surface the dirt — do not stash silently. The caller decides: commit, discard, or move out of the way. (Reason: per `feedback_commit_before_branch.md`, exploratory state must not get mixed into bundle commits.)
+
+**Baseline capture (added 2026-05-21):** immediately after branching, pin the pre-EXECUTE state:
+
+```bash
+rtk bun run build 2>&1 | tail -3   # → record "Tasks: N/N successful"
+rtk bun test 2>&1 | tail -3        # → record pass/fail/skip counts
+```
+
+Stash the numbers in the plan doc under a `## Baseline` heading. Phase 5 compares against these; pre-existing reds get filed as follow-up issues (see #93 pattern) rather than blocking the bundle. Without this baseline, a pre-existing failure surfaced by your edits looks like a regression and you'll burn budget chasing it.
 
 ---
 

--- a/.agents/skills/execute-backlog/SKILL.md
+++ b/.agents/skills/execute-backlog/SKILL.md
@@ -138,6 +138,21 @@ Read the `superpowers:writing-plans` skill conventions (location override: `wiki
 
 ---
 
+## Phase 3.5 — BRANCH (mandatory)
+
+Before any code edits land, create a dedicated feature branch off `main` for the bundle:
+
+```bash
+rtk git fetch origin main
+rtk git checkout -B bundle/<bundle-name> origin/main
+```
+
+Naming pattern: `bundle/<area>-<theme>` (e.g., `bundle/runtime-builder-state-typing`). The branch is the unit-of-work for the entire bundle. All commits in Phase 4 land here; the Phase 6 PR ships them together.
+
+If the working tree is dirty when this skill is invoked, **stop** and surface the dirt — do not stash silently. The caller decides: commit, discard, or move out of the way. (Reason: per `feedback_commit_before_branch.md`, exploratory state must not get mixed into bundle commits.)
+
+---
+
 ## Phase 4 — EXECUTE
 
 For each execution unit, follow `agent-tdd` discipline:
@@ -194,15 +209,42 @@ If a verified-by check fails to come down → the fix didn't actually address th
 
 ## Phase 6 — UPDATE
 
-Close the bundle. For each closed issue:
+**6a — Open the PR (mandatory).** Every execution session ships its bundle as one PR. No direct-to-main pushes.
 
 ```bash
-rtk gh issue close <N> --comment "Resolved in bundle <name> (commits <sha>..<sha>).
-Verified-by recheck: <command> → <new result>.
-See wiki/Planning/Implementation-Plans/YYYY-MM-DD-<bundle>.md."
+rtk git push -u origin bundle/<bundle-name>
+rtk gh pr create \
+  --base main \
+  --head bundle/<bundle-name> \
+  --title "<bundle-name>: <one-line summary>" \
+  --body "$(cat <<'EOF'
+## Bundle: <name>
+
+Closes #N
+Closes #N
+
+## Summary
+<2-3 lines on what changed>
+
+## Verification
+- `bun run build` ✅
+- `bun test` ✅ (delta: +X / -Y vs baseline)
+- `bunx turbo run typecheck --filter=<changed>` ✅
+- Verified-by rechecks (per issue):
+  - #N: `<command>` → <new result> (was <old>)
+
+## Plan + Retro
+- Plan: wiki/Planning/Implementation-Plans/YYYY-MM-DD-<bundle>.md
+- Retro: wiki/Research/Debriefs/YYYY-MM-DD-<bundle>-execution-debrief.md
+EOF
+)"
 ```
 
-Update the project board: move bundle issues to **Done** column.
+PR body MUST include `Closes #N` for every issue in the bundle — GitHub auto-closes them on merge, no manual `gh issue close` needed. If a bundle issue was descoped mid-EXECUTE, drop its `Closes #N` line and explain in the PR body.
+
+The skill's job ends at PR open. **Merge is a human decision** — do not auto-merge.
+
+**6b — Project board + knowledge sync.** Move bundle issues to **In Review** column (not Done — done happens on merge). Then:
 
 Sync local knowledge:
 - `wiki/Hot.md` — append session note (bundle name, issues closed, key learnings)
@@ -308,9 +350,10 @@ Schedule via `/loop` — `/loop 1d /execute-backlog labels=priority:p1 max_bundl
 SCAN     gh issue list --label … --json
 BUNDLE   greedy cohesion grow, cap at max_bundle_size
 PLAN     wiki/Planning/Implementation-Plans/YYYY-MM-DD-<bundle>.md
+BRANCH   git checkout -B bundle/<bundle-name> origin/main (clean tree only)
 EXECUTE  TDD per unit, conventional commits cite #N
 VERIFY   build + test + typecheck + re-run each verified-by
-UPDATE   gh issue close --comment, board → Done, Hot.md note
+UPDATE   gh pr create with Closes #N (auto-close on merge), board → In Review, Hot.md note
 RETRO    wiki/Research/Debriefs/, AMEND THIS SKILL.md
 ```
 

--- a/packages/runtime/src/builder/to-config.ts
+++ b/packages/runtime/src/builder/to-config.ts
@@ -14,6 +14,15 @@
  * structurally satisfies this interface.
  */
 import type { AgentConfig } from "../agent-config.js";
+import type { ReasoningOptions } from "../types.js";
+import type {
+  ToolsOptions,
+  GuardrailsOptions,
+  MemoryOptions,
+  ObservabilityOptions,
+  CostTrackingOptions,
+  VerificationOptions,
+} from "./types.js";
 
 /**
  * Structural slice of `ReactiveAgentBuilder` that the serializer reads.
@@ -33,22 +42,22 @@ export interface BuilderStateForSerialization {
   _systemPrompt?: string;
   _persona?: unknown;
   _enableReasoning: boolean;
-  _reasoningOptions?: unknown;
+  _reasoningOptions?: ReasoningOptions;
   _enableTools: boolean;
-  _toolsOptions?: unknown;
+  _toolsOptions?: ToolsOptions;
   _enableGuardrails: boolean;
-  _guardrailsOptions?: unknown;
+  _guardrailsOptions?: GuardrailsOptions;
   _enableMemory: boolean;
   _memoryTier: "1" | "2";
-  _memoryOptions?: unknown;
+  _memoryOptions?: MemoryOptions;
   _enableExperienceLearning: boolean;
   _enableMemoryConsolidation: boolean;
   _enableObservability: boolean;
-  _observabilityOptions?: unknown;
+  _observabilityOptions?: ObservabilityOptions;
   _enableCostTracking: boolean;
-  _costTrackingOptions?: unknown;
+  _costTrackingOptions?: CostTrackingOptions;
   _enableVerification: boolean;
-  _verificationOptions?: unknown;
+  _verificationOptions?: VerificationOptions;
   _maxIterations: number | undefined;
   _executionTimeoutMs?: number;
   _retryPolicy?: { maxRetries: number; backoffMs: number };
@@ -95,7 +104,7 @@ export function serializeBuilder(state: BuilderStateForSerialization): AgentConf
   // Reasoning
   if (state._enableReasoning || state._reasoningOptions) {
     const r: Record<string, unknown> = {};
-    const ro = state._reasoningOptions as any;
+    const ro = state._reasoningOptions;
     if (ro?.defaultStrategy) r["defaultStrategy"] = ro.defaultStrategy;
     if (ro?.enableStrategySwitching !== undefined) r["enableStrategySwitching"] = ro.enableStrategySwitching;
     if (ro?.maxStrategySwitches !== undefined) r["maxStrategySwitches"] = ro.maxStrategySwitches;
@@ -106,7 +115,7 @@ export function serializeBuilder(state: BuilderStateForSerialization): AgentConf
   // Tools
   if (state._enableTools || state._toolsOptions) {
     const t: Record<string, unknown> = {};
-    const to = state._toolsOptions as any;
+    const to = state._toolsOptions;
     if (to?.allowedTools) t["allowedTools"] = [...to.allowedTools];
     if (to?.adaptive !== undefined) t["adaptive"] = to.adaptive;
     if (to?.terminal !== undefined) {
@@ -119,7 +128,7 @@ export function serializeBuilder(state: BuilderStateForSerialization): AgentConf
   // Guardrails
   if (state._enableGuardrails || state._guardrailsOptions) {
     const g: Record<string, unknown> = {};
-    const go = state._guardrailsOptions as any;
+    const go = state._guardrailsOptions;
     if (go?.injection !== undefined) g["injection"] = go.injection;
     if (go?.pii !== undefined) g["pii"] = go.pii;
     if (go?.toxicity !== undefined) g["toxicity"] = go.toxicity;
@@ -132,7 +141,7 @@ export function serializeBuilder(state: BuilderStateForSerialization): AgentConf
     const m: Record<string, unknown> = {};
     // Map internal "1"/"2" back to "standard"/"enhanced"
     m["tier"] = state._memoryTier === "2" ? "enhanced" : "standard";
-    const mo = state._memoryOptions as any;
+    const mo = state._memoryOptions;
     if (mo?.dbPath) m["dbPath"] = mo.dbPath;
     if (mo?.maxEntries !== undefined) m["maxEntries"] = mo.maxEntries;
     if (mo?.capacity !== undefined) m["capacity"] = mo.capacity;
@@ -147,7 +156,7 @@ export function serializeBuilder(state: BuilderStateForSerialization): AgentConf
   // Observability
   if (state._enableObservability || state._observabilityOptions) {
     const o: Record<string, unknown> = {};
-    const oo = state._observabilityOptions as any;
+    const oo = state._observabilityOptions;
     if (oo?.verbosity) o["verbosity"] = oo.verbosity;
     if (oo?.live !== undefined) o["live"] = oo.live;
     if (oo?.file) o["file"] = oo.file;
@@ -158,7 +167,7 @@ export function serializeBuilder(state: BuilderStateForSerialization): AgentConf
   // Cost tracking
   if (state._enableCostTracking || state._costTrackingOptions) {
     const c: Record<string, unknown> = {};
-    const co = state._costTrackingOptions as any;
+    const co = state._costTrackingOptions;
     if (co?.perRequest !== undefined) c["perRequest"] = co.perRequest;
     if (co?.perSession !== undefined) c["perSession"] = co.perSession;
     if (co?.daily !== undefined) c["daily"] = co.daily;
@@ -169,7 +178,7 @@ export function serializeBuilder(state: BuilderStateForSerialization): AgentConf
   // Verification
   if (state._enableVerification || state._verificationOptions) {
     const v: Record<string, unknown> = {};
-    const vo = state._verificationOptions as any;
+    const vo = state._verificationOptions;
     if (vo?.semanticEntropy !== undefined) v["semanticEntropy"] = vo.semanticEntropy;
     if (vo?.factDecomposition !== undefined) v["factDecomposition"] = vo.factDecomposition;
     if (vo?.multiSource !== undefined) v["multiSource"] = vo.multiSource;

--- a/wiki/Hot.md
+++ b/wiki/Hot.md
@@ -10,7 +10,20 @@ updated: 2026-05-21
 
 ---
 
-## Latest Session (2026-05-21) — Full architecture audit + GH issue migration
+## Latest Session (2026-05-21, late) — execute-backlog v1 + #72 PR
+
+**Bundle:** `runtime-builder-state-typing` (singleton, #72 HS-07).
+
+- **Fix:** `packages/runtime/src/builder/to-config.ts` — replaced 7 `as any` reads of `_*Options` with proper interface types (`ReasoningOptions`, `ToolsOptions`, `GuardrailsOptions`, `MemoryOptions`, `ObservabilityOptions`, `CostTrackingOptions`, `VerificationOptions`). Verified-by recheck `grep -c 'as any' …to-config.ts` → 0 (was 7).
+- **Suite:** 5321 pass / 0 fail / 26 skip workspace-wide; build 38/38 green.
+- **Branch:** `bundle/runtime-builder-state-typing`; PR pending.
+- **Skill amendment (per user feedback this session):** `execute-backlog` now mandates Phase 3.5 BRANCH (clean tree off `origin/main`) and Phase 6a per-bundle PR with `Closes #N` (no direct-to-main pushes).
+- **Pre-existing red flagged:** `runtime-construction.ts:337` passes `focusedTools` to `RuntimeOptions` literal that doesn't declare it. Was hidden by `as any` widening. Follow-up issue filed.
+- **Descoped from bundle:** #73 (cross-package; needs `LLMResponse.model` + kernel context type edits — spawn `kernel-context-typing` bundle next). #68/#69/#71 also deferred per per-package anti-pattern rule. #83 has no `verified-by`; commented requesting evidence.
+
+---
+
+## Previous Session (2026-05-21) — Full architecture audit + GH issue migration
 
 **Outcome:** Single-source-of-truth migration to GitHub. 25 new issues filed (#68-#92) covering all open HS-NN items + AGENTS.md Architecture Debt rows + 1 known issue. All added to "Reactive Agents Roadmap" project board (project 1).
 

--- a/wiki/Planning/Implementation-Plans/2026-05-21-runtime-builder-state-typing.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-21-runtime-builder-state-typing.md
@@ -1,0 +1,43 @@
+# Bundle: runtime-builder-state-typing
+Date: 2026-05-21
+Budget: 90 min
+Issues: #72 (HS-07)
+
+Singleton bundle. Originally seeded with #73 (HS-08) but descoped after advisor flagged cross-package leak: #73 targets shapes owned by `@reactive-agents/llm-service` (`LLMResponse.model`) and the kernel context type — anti-pattern per SKILL.md ("Cross-package bundles → descope"). #73 spawns into its own `kernel-context-typing` bundle next pass.
+
+## Acceptance criteria
+
+- **#72 (HS-07):** All 7 `as any` reads of `_*Options` in `packages/runtime/src/builder/to-config.ts` removed. Verified-by recheck `grep -c 'as any' packages/runtime/src/builder/to-config.ts` → 0.
+
+## Execution units (ordered)
+
+1. **Unit 1 — type the option-group fields on `BuilderStateForSerialization`.**
+   - File: `packages/runtime/src/builder/to-config.ts`
+   - Import the existing option types: `ToolsOptions`, `MemoryOptions`, `CostTrackingOptions`, `GuardrailsOptions`, `VerificationOptions`, `ObservabilityOptions` from `./types.js`; `ReasoningOptions` from `../types.js`.
+   - Replace the seven `_*Options?: unknown` fields with their proper interface types.
+   - Drop the seven `as any` narrowings (lines 98, 109, 122, 135, 150, 161, 172) — direct property reads work once the interface is typed.
+   - Confirm builder class still structurally satisfies the interface (no edits to `builder.ts` expected — `_reasoningOptions?: ReasoningOptions` is already declared at `runtime-construction.ts:81`).
+   - Tests: existing `serializeBuilder` callers exercise via `builder.toConfig()` in the regression suite — run the runtime package suite as the gate.
+
+## Risk register
+
+| Risk | Mitigation |
+|------|-----------|
+| Option types are wider/narrower than what `to-config.ts` reads; tsc surfaces real bugs | Read the types first; if the reader touches a field the type doesn't declare, prefer adding the field to the type over reverting to `as any` |
+| `ReasoningOptions` at `packages/runtime/src/types.ts:581` is `ReasoningOptionsEncoded & {...}`; encoded schema may make some fields optional / unknown | Use the existing union type as-is; the readers all guard with `?.field` so optional-everything is fine |
+| Builder class field declarations diverge from interface | tsc will catch it on `this as unknown as BuilderStateForSerialization` cast in builder.ts:1949 — fix that cast site if it breaks |
+
+## Verification protocol
+
+- `rtk bun test packages/runtime/` — full pass, no net-new failures vs baseline
+- `rtk bun run build` — green
+- `rtk bunx turbo run typecheck --filter=@reactive-agents/runtime` — green
+- `rtk grep -c 'as any' packages/runtime/src/builder/to-config.ts` — expect `0`
+
+## Out-of-scope (explicit)
+
+- #68 HS-02 (providers package, separate bundle next pass)
+- #69 HS-03 (Layer.merge architectural fix, needs its own design pass)
+- #71 HS-06 (reactive-intelligence ControllerState extension, separate bundle)
+- #73 HS-08 (cross-package; needs `LLMResponse.model` + kernel context type edits — separate `kernel-context-typing` bundle)
+- #83 HS-27 (not verified per skill rule; will comment requesting verified-by)

--- a/wiki/Research/Debriefs/2026-05-21-runtime-builder-state-typing-execution-debrief.md
+++ b/wiki/Research/Debriefs/2026-05-21-runtime-builder-state-typing-execution-debrief.md
@@ -1,0 +1,38 @@
+# Execution Retro: runtime-builder-state-typing
+Date: 2026-05-21
+Budget: 90 min | Actual: ~55 min
+
+## Outcomes
+- Issues closed: #72 (HS-07)
+- Issues descoped from initial seed: #73 HS-08 (cross-package — advisor caught pre-EXECUTE; spawns into `kernel-context-typing` next pass)
+- Issues blocked on verified-by: #83 HS-27 (commented requesting evidence)
+- Issues opportunistically filed: #93 (pre-existing `focusedTools` typecheck red unmasked by tightening `_toolsOptions`)
+- Net test delta: +0 / -0 (5321 pass / 0 fail steady; 26 skip steady)
+- Net LOC delta: to-config.ts +23 / -14 (interface + 7 narrowed reads)
+- Commits: 2 on `bundle/runtime-builder-state-typing` (skill amendment + plan; code fix)
+
+## What worked
+- **Advisor caught the cross-package descope before code.** Initial bundle was #72 + #73; advisor read the grep output and recognized #73's targets (`LLMResponse.model`, kernel context shape) live in other packages. Saved a likely 30 min rabbit hole + diff-conflict cleanup.
+- **Singleton bundles are fine.** Anti-pattern penalty for cross-package was real — descoping to singleton produced a clean, narrowly-scoped PR.
+- **Existing option-type interfaces were already canonical** at `packages/runtime/src/builder/types.ts` + `packages/runtime/src/types.ts`. No type-design needed — purely a wiring fix. This is the cheapest possible class of `as any` cleanup.
+- **`grep -c 'as any' …to-config.ts` → 0** matched the verified-by claim exactly. Audit accuracy 7/7 on this issue.
+
+## What didn't
+- **Audit line-number drift on #73** (audit said 83/94/105/218/248/285; current 85/96/107/220/273/310, up to 25-line offset). Advisor flagged this too. Even though counts matched, drift this large is a smell that file refactored since audit; the fix shape may also have moved.
+- **Pre-existing typecheck red on main:** runtime-construction.ts:337 already broken — was hidden by upstream `as any` widening but tsc surfaces it independent of this PR. We don't have a "main is green" baseline check before EXECUTE; we should.
+- **No regression test added** for to-config.ts narrowing — relied on existing `serializeBuilder` round-trip in the test suite. Acceptable for type-only refactor but worth flagging.
+
+## Skill improvements (apply on next pass)
+
+Three concrete amendments. **Applied to SKILL.md in this same retro commit.**
+
+1. **Phase 1 SCAN: warn when audit line numbers drift >5 lines.** Cheap to script: re-grep the verified-by command, compare emitted line numbers against the issue body's claimed lines. If max offset >5, append a `🟡 drift detected — re-verify semantics` flag to the candidate row. The audit is still a starting point, but the agent should eyeball before assuming the fix shape is unchanged.
+
+2. **Phase 5 VERIFY: capture pre-EXECUTE baseline.** Right after BRANCH (Phase 3.5), run `bun run build && bun test 2>&1 | tail -3` and pin the pass/fail counts as the baseline. Phase 5 then compares; pre-existing reds get filed as follow-up issues (as we did for #93) rather than blocking the bundle.
+
+3. **Bundling heuristic: cross-package descope is a HARD rule.** Current SKILL has it as an anti-pattern; promote to an explicit bundling gate. Add: "If any candidate's verified-by command points to files in ≥2 packages, descope to a per-package bundle even if the issue body claims otherwise — the body lies, the grep doesn't."
+
+## Process inflation guard (HS-18/22/31 lesson)
+
+- Did any unit's verified-by claim turn out to be inflated? **No on #72** — claim was 7 `as any`, file had 7, fix collapsed all 7. Clean.
+- Did the audit line numbers tell the truth on #73 (descoped)? **Counts true, locations drifted** — see "Skill improvements #1" for the catch.


### PR DESCRIPTION
## Bundle: runtime-builder-state-typing

Closes #72

Singleton bundle from `/execute-backlog labels=audit-2026-05-21 priority=p1`. Originally seeded #72 + #73; descoped #73 mid-PLAN (advisor catch) — its `as any` targets resolve to types owned by other packages (`@reactive-agents/llm-service` and the kernel context shape). New `kernel-context-typing` bundle queued for next pass.

## Summary

- `packages/runtime/src/builder/to-config.ts`: replace 7 `as any` reads of `_*Options` with proper interface types (`ReasoningOptions`, `ToolsOptions`, `GuardrailsOptions`, `MemoryOptions`, `ObservabilityOptions`, `CostTrackingOptions`, `VerificationOptions`).
- `BuilderStateForSerialization` now declares the option-group fields with their canonical types; no behavior change.
- Skill self-amendments (3) committed alongside: drift check on SCAN, baseline capture on BRANCH, cross-package descope as a hard gate on BUNDLE.
- Retro + Hot.md updated.

## Verification

- `bun run build` ✅ — 38/38 successful (workspace)
- `bun test` ✅ — 5321 pass / 0 fail / 26 skip (workspace)
- `bunx turbo run build --filter=@reactive-agents/runtime` ✅ — DTS green
- Verified-by recheck per issue:
  - **#72:** `grep -c 'as any' packages/runtime/src/builder/to-config.ts` → **0** (was 7 at lines 98,109,122,135,150,161,172)

## Out-of-scope (filed)

- **#93** — pre-existing typecheck red at `runtime-construction.ts:337` (`focusedTools` on `RuntimeOptions` literal). Was masked by upstream `as any` widening on `_toolsOptions`. Filed as follow-up; not introduced by this PR.
- **#83** — commented requesting `verified-by:` block before execution (per skill rule).

## Plan + Retro

- Plan: `wiki/Planning/Implementation-Plans/2026-05-21-runtime-builder-state-typing.md`
- Retro: `wiki/Research/Debriefs/2026-05-21-runtime-builder-state-typing-execution-debrief.md`
