### PR TITLE
providers-adapter-typing: type M12 hook params as unknown (#68)

### DIFF
--- a/packages/llm-provider/src/adapter.ts
+++ b/packages/llm-provider/src/adapter.ts
@@ -101,7 +101,7 @@ export interface ProviderAdapter {
    * Called after LLM response parsing. Return undefined for no normalization.
    */
   parseToolCalls?(
-    response: any,
+    response: unknown,
     modelId?: string
   ): Array<{ name: string; arguments: Record<string, unknown> }> | undefined;
 
@@ -110,7 +110,7 @@ export interface ProviderAdapter {
    * Called during streaming to reassemble text-only output from mixed parts.
    * Return undefined if not applicable.
    */
-  extractText?(parts: any, modelId?: string): string | undefined;
+  extractText?(parts: unknown, modelId?: string): string | undefined;
 
   /**
    * (M12 Hook 3/7) Compute token cost from input/output token counts.
@@ -123,7 +123,7 @@ export interface ProviderAdapter {
    * Called after parsing. Return validation result or undefined if not applicable.
    */
   validateResponse?(
-    response: any,
+    response: unknown,
     modelId?: string
   ): { valid: boolean; error?: string } | undefined;
 
@@ -142,7 +142,7 @@ export interface ProviderAdapter {
    * Called on error. Return classification {retryable, errorType} or undefined.
    */
   handleError?(
-    error: any,
+    error: unknown,
     modelId?: string
   ): { retryable: boolean; errorType: string } | undefined;
 
@@ -151,7 +151,7 @@ export interface ProviderAdapter {
    * Called during streaming. Return StreamEvent[] or undefined if not streaming.
    */
   streamSupport?(
-    chunk: any,
+    chunk: unknown,
     modelId?: string
   ): Array<{ type: "text_delta" | "tool_call_start" | "tool_call_delta"; text?: string }> | undefined;
 }

--- a/wiki/Planning/Implementation-Plans/2026-05-21-providers-adapter-typing.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-21-providers-adapter-typing.md
@@ -1,0 +1,36 @@
+# Bundle: providers-adapter-typing
+Date: 2026-05-21
+Budget: 90 min
+Issues: #68
+
+## Acceptance criteria (per issue)
+- **#68 HS-02:** `grep -c ': any' packages/llm-provider/src/adapter.ts` returns 0; all M12 hook parameters (`response`, `parts`, `error`, `chunk`) typed as `unknown`; existing tests + typecheck stay green; no production callsite breakage (none exist today).
+
+## Baseline (pre-execute)
+- `bun test packages/llm-provider/tests/m12-provider-adapter-hooks.test.ts` → **26 pass / 0 fail** (52 expects)
+- `bunx turbo run typecheck --filter=@reactive-agents/llm-provider` → **4/4 successful**
+- `grep -c ': any' packages/llm-provider/src/adapter.ts` → **5**
+- `grep -n ': any' packages/llm-provider/src/adapter.ts` lines: 104, 113, 126, 145, 154 (drift-confirmed against issue body)
+
+## Execution units (ordered)
+1. **Unit 1 — Type M12 hooks `unknown`** (≤20 min)
+   - Files: `packages/llm-provider/src/adapter.ts`
+   - Edits: 5× `: any` → `: unknown` at lines 104, 113, 126, 145, 154
+   - Tests: existing `m12-provider-adapter-hooks.test.ts` covers all five hooks; no new test needed (RED phase = baseline grep ≥1)
+   - GREEN = grep returns 0 + tests stay 26/0 + typecheck 4/4
+
+## Risk register
+- **Risk:** Test helper `createTestAdapterWithHooks` declares its own `: any` annotations in impl callbacks → could fail under method-bivariance check. **Mitigation:** TS treats `any ↔ unknown` as bivariant on method shorthand; baseline test command will catch any regression immediately.
+- **Risk:** Hidden consumer outside `packages/llm-provider/` that destructures hook params relies on implicit `any`. **Mitigation:** grep showed no production consumers; workspace-wide typecheck (`bun run build`) is the gate.
+
+## Verification protocol (cross-cutting)
+- `rtk bun test packages/llm-provider/` — full pkg suite, no net-new failures vs baseline
+- `rtk bun run build` — full monorepo green (catches any downstream type leak)
+- `rtk bunx turbo run typecheck --filter=@reactive-agents/llm-provider` — green
+- `rtk grep -c ': any' packages/llm-provider/src/adapter.ts` — must return 0
+
+## Out-of-scope (explicit)
+- Discriminated `RawProviderResponse` / `RawStreamChunk` union — overdesign with zero production impls; revisit when first concrete adapter overrides these hooks.
+- Centralizing into `@reactive-agents/core` — cross-package work, separate bundle.
+- Test-file `: any` annotations on local callback params — not in issue scope; tests aren't part of public contract.
+- Other `: any` in llm-provider outside `adapter.ts` (separate finding; not HS-02).


### PR DESCRIPTION
## Bundle: providers-adapter-typing

Closes #68

## Summary
Replace 5× `: any` with `unknown` on `ProviderAdapter` M12 extension hooks (`parseToolCalls`, `extractText`, `validateResponse`, `handleError`, `streamSupport`). Hooks are raw provider-shaped data — `unknown` forces consumers to narrow before use; no production impls exist yet, so zero migration burden.

## Verification
- `bun run build` ✅ (38/38)
- `bun test packages/llm-provider/` ✅ (254/254, delta 0)
- `bun test packages/llm-provider/tests/m12-provider-adapter-hooks.test.ts` ✅ (26/0, matches baseline)
- `bunx turbo run typecheck --filter=@reactive-agents/llm-provider` ✅ (4/4)

Verified-by recheck:
- #68: `grep -c ': any' packages/llm-provider/src/adapter.ts` → **0** (was 5)

## Plan + Retro
- Plan: `wiki/Planning/Implementation-Plans/2026-05-21-providers-adapter-typing.md`
- Retro: `wiki/Research/Debriefs/2026-05-21-providers-adapter-typing-execution-debrief.md` (added in follow-up commit)
