### PR TITLE
ri-handlers-state-shape: type RI handler state via HandlerState widening (#71)

### DIFF
--- a/packages/reactive-intelligence/src/controller/handler-state.ts
+++ b/packages/reactive-intelligence/src/controller/handler-state.ts
@@ -1,0 +1,39 @@
+import type { KernelStateLike } from "@reactive-agents/core";
+
+/**
+ * State shape visible to RI intervention handlers.
+ *
+ * `KernelStateLike` (in @reactive-agents/core) is the trimmed structural type
+ * shared across the boundary; the real kernel state object carries additional
+ * patch-managed and run-tracking fields that handlers need to read:
+ *
+ *   - `currentOptions`     — managed by `patch-applier.ts:20,37` (set-temperature patches).
+ *   - `activatedSkills`    — managed by `patch-applier.ts:64` (inject-skill-content patches).
+ *   - `controllerDecisionLog` — carried by `act.ts:181,204`; declared on
+ *     `ArbitratorContext`/`VetoEvaluatorContext` in arbitrator.ts.
+ *   - `currentStrategy`    — legacy fixture alias of `strategy`; some tests
+ *     pass it instead of the canonical `strategy` field.
+ *
+ * Extending `KernelStateLike` in `@reactive-agents/core` would cross packages
+ * and propagate optional fields to every consumer of the structural type. The
+ * local widening (mirroring `PatchedState` at `patch-applier.ts:4`) keeps the
+ * scope inside `reactive-intelligence` and gives handlers proper field types
+ * without per-site `(state as any)` reads.
+ */
+export type HandlerState = Readonly<KernelStateLike> & {
+  readonly currentOptions?: { readonly temperature?: number } & Readonly<Record<string, unknown>>;
+  readonly activatedSkills?: ReadonlyArray<{ readonly id: string; readonly content: string }>;
+  readonly controllerDecisionLog?: readonly string[];
+  readonly currentStrategy?: string;
+};
+
+/**
+ * Single named boundary cast. Intervention handlers receive
+ * `Readonly<KernelStateLike>`; this widens to `HandlerState` so the extra
+ * patch-managed / log fields can be read with proper types. Use this
+ * function in every handler instead of inline `(state as any)` or
+ * `as unknown as { ... }` narrowings.
+ */
+export const asHandlerState = (
+  state: Readonly<KernelStateLike>,
+): HandlerState => state as HandlerState;

--- a/packages/reactive-intelligence/src/controller/handlers/context-compress.ts
+++ b/packages/reactive-intelligence/src/controller/handlers/context-compress.ts
@@ -8,7 +8,7 @@ export const contextCompressHandler: InterventionHandler<"compress"> = {
   description: "Compress message history when tokens trend high",
   defaultMode: "dispatch",
   execute: (decision, state, _ctx) => {
-    const currentTokens = (state as any).tokens as number ?? 0
+    const currentTokens = state.tokens ?? 0
     const estimatedSavings = decision.estimatedSavings
     if (estimatedSavings <= COMPRESS_COST_TOKENS * 2) {
       return Effect.succeed({

--- a/packages/reactive-intelligence/src/controller/handlers/harness-harm-detector.ts
+++ b/packages/reactive-intelligence/src/controller/handlers/harness-harm-detector.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { InterventionHandler } from "../intervention.js";
+import { asHandlerState } from "../handler-state.js";
 
 export interface HarmSignals {
   readonly interventionCount: number;
@@ -28,7 +29,7 @@ export const harnessHarmDetectorHandler: InterventionHandler<"harness-harm"> = {
   description: "Circuit-breaks RI interventions when harness is provably making model performance worse",
   defaultMode: "dispatch",
   execute: (_decision, state, _ctx) => {
-    const decisionLog = (state as unknown as { controllerDecisionLog?: readonly string[] }).controllerDecisionLog ?? [];
+    const decisionLog = asHandlerState(state).controllerDecisionLog ?? [];
     const harmDecisions = decisionLog.filter((e) => e.startsWith("harness-harm")).length;
 
     // controllerDecisionLog is pre-populated before dispatch fires, so harmDecisions >= 1 on first fire.

--- a/packages/reactive-intelligence/src/controller/handlers/skill-activate.ts
+++ b/packages/reactive-intelligence/src/controller/handlers/skill-activate.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect"
 import type { InterventionHandler } from "../intervention.js"
+import { asHandlerState } from "../handler-state.js"
 import { loadSkillContent } from "./skill-loader.js"
 
 export const skillActivateHandler: InterventionHandler<"skill-activate"> = {
@@ -19,9 +20,7 @@ export const skillActivateHandler: InterventionHandler<"skill-activate"> = {
         }
       }
 
-      const activatedSkills = (state as any).activatedSkills as
-        | Array<{ id: string; content: string }>
-        | undefined
+      const activatedSkills = asHandlerState(state).activatedSkills
       const already = (activatedSkills ?? []).some((s) => s.id === skillName)
       if (already) {
         return {

--- a/packages/reactive-intelligence/src/controller/handlers/stall-detector.ts
+++ b/packages/reactive-intelligence/src/controller/handlers/stall-detector.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import type { InterventionHandler } from "../intervention.js";
+import { asHandlerState } from "../handler-state.js";
 
 export function jaccardSimilarity(a: string, b: string): number {
   const tokensA = new Set(a.toLowerCase().split(/\s+/).filter(Boolean));
@@ -38,7 +39,7 @@ export const stallDetectorHandler: InterventionHandler<"stall-detect"> = {
   description: "Detects when model repeats content without progress; escalates to early-stop on second fire",
   defaultMode: "dispatch",
   execute: (decision, state, _ctx) => {
-    const decisionLog = (state as unknown as { controllerDecisionLog?: readonly string[] }).controllerDecisionLog ?? [];
+    const decisionLog = asHandlerState(state).controllerDecisionLog ?? [];
     // controllerDecisionLog is pre-populated before dispatch fires, so priorStalls >= 1 on first fire.
     const priorStalls = decisionLog.filter((e) => e.startsWith("stall-detect")).length;
     const isEscalation = priorStalls >= 2;

--- a/packages/reactive-intelligence/src/controller/handlers/switch-strategy.ts
+++ b/packages/reactive-intelligence/src/controller/handlers/switch-strategy.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect"
 import type { InterventionHandler } from "../intervention.js"
+import { asHandlerState } from "../handler-state.js"
 
 export const switchStrategyHandler: InterventionHandler<"switch-strategy"> = {
   type: "switch-strategy",
@@ -8,8 +9,8 @@ export const switchStrategyHandler: InterventionHandler<"switch-strategy"> = {
   execute: (decision, state, _ctx) => {
     const to = decision.to
     // `state.strategy` is the canonical field on KernelStateLike; tests may pass `currentStrategy`
-    const current: string | undefined =
-      state.strategy ?? (state as unknown as Record<string, unknown>).currentStrategy as string | undefined
+    const s = asHandlerState(state)
+    const current: string | undefined = s.strategy ?? s.currentStrategy
     if (!to || to === current) {
       return Effect.succeed({
         applied: false,

--- a/packages/reactive-intelligence/src/controller/handlers/temp-adjust.ts
+++ b/packages/reactive-intelligence/src/controller/handlers/temp-adjust.ts
@@ -1,12 +1,13 @@
 import { Effect } from "effect"
 import type { InterventionHandler } from "../intervention.js"
+import { asHandlerState } from "../handler-state.js"
 
 export const tempAdjustHandler: InterventionHandler<"temp-adjust"> = {
   type: "temp-adjust",
   description: "Adjust LLM temperature to break repetition or overconfidence",
   defaultMode: "dispatch",
   execute: (decision, state, _ctx) => {
-    const current = (state as any).currentOptions?.temperature ?? 0.7
+    const current = asHandlerState(state).currentOptions?.temperature ?? 0.7
     const { delta } = decision
     if (Math.abs(delta) < 0.05) {
       return Effect.succeed({

--- a/packages/reactive-intelligence/src/controller/handlers/tool-failure-redirect.ts
+++ b/packages/reactive-intelligence/src/controller/handlers/tool-failure-redirect.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect"
 import type { InterventionHandler } from "../intervention.js"
+import { asHandlerState } from "../handler-state.js"
 
 export const toolFailureRedirectHandler: InterventionHandler<"tool-failure-redirect"> = {
   type: "tool-failure-redirect",
@@ -12,7 +13,7 @@ export const toolFailureRedirectHandler: InterventionHandler<"tool-failure-redir
     // budget.interventionsFiredThisRun (now tracked in W3 FIX-23 via
     // KernelState.meta.riBudget) counts ALL prior fires across decision types,
     // which is too broad for re-fire detection of a single decision class.
-    const decisionLog = (state as unknown as { controllerDecisionLog?: readonly string[] }).controllerDecisionLog ?? [];
+    const decisionLog = asHandlerState(state).controllerDecisionLog ?? [];
     const priorRedirects = decisionLog.filter((e) => e.startsWith("tool-failure-redirect")).length;
     const isEscalation = priorRedirects >= 1;
 

--- a/wiki/Planning/Implementation-Plans/2026-05-21-ri-handlers-state-shape.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-21-ri-handlers-state-shape.md
@@ -1,0 +1,50 @@
+# Bundle: ri-handlers-state-shape
+Date: 2026-05-21
+Budget: 90 min
+Issues: #71
+
+## Acceptance criteria (per issue)
+- **#71 HS-06:** `grep -c '(state as any)' packages/reactive-intelligence/src/controller/handlers/` returns 0; `grep -c 'as unknown as {' packages/reactive-intelligence/src/controller/handlers/` returns 0; all 7 untyped reads (`currentOptions`, `tokens`, `activatedSkills`, `controllerDecisionLog`, `currentStrategy`) go through a single named `HandlerState` widening type; tests + typecheck stay green.
+
+## Baseline (pre-execute)
+- `bun test packages/reactive-intelligence/` → **455 pass / 3 skip / 0 fail**
+- `bunx turbo run typecheck --filter=@reactive-agents/reactive-intelligence` → **6/6 successful**
+- `grep -rn '(state as any)' …/handlers/` → 3 sites (temp-adjust.ts:9, context-compress.ts:11, skill-activate.ts:22)
+- `grep -rn 'as unknown as {' …/handlers/` → 4 sites (switch-strategy.ts:12 partial, harness-harm-detector.ts:31, stall-detector.ts:41, tool-failure-redirect.ts:15)
+- Total: **7 sites**, matches issue body exactly.
+
+## Architectural decision
+Cross-package extension of `KernelStateLike` (in `@reactive-agents/core`) is forbidden by Phase 2 hard gate. Local widening type in `reactive-intelligence` is the issue body's stated alternative ("OR define `ExtendedControllerState`"). Pattern mirrors `PatchedState` already used at `patch-applier.ts:4`.
+
+## Execution units (ordered)
+1. **Unit 1 — Define `HandlerState` widening + `asHandlerState` boundary** (≤10 min)
+   - New file: `packages/reactive-intelligence/src/controller/handler-state.ts`
+   - Exports `HandlerState = Readonly<KernelStateLike> & { currentOptions?, activatedSkills?, controllerDecisionLog?, currentStrategy? }` and `asHandlerState(state)` helper (single named cast point).
+2. **Unit 2 — Migrate 7 handler files** (≤25 min)
+   - `temp-adjust.ts:9` → `const s = asHandlerState(state); s.currentOptions?.temperature`
+   - `context-compress.ts:11` → `state.tokens` (already on KernelStateLike — drop cast entirely)
+   - `skill-activate.ts:22` → `asHandlerState(state).activatedSkills`
+   - `switch-strategy.ts:12` → `const s = asHandlerState(state); s.strategy ?? s.currentStrategy`
+   - `stall-detector.ts:41` → `asHandlerState(state).controllerDecisionLog ?? []`
+   - `harness-harm-detector.ts:31` → same as above
+   - `tool-failure-redirect.ts:15` → same as above
+3. **Unit 3 — Verify** (≤5 min)
+   - Grep counts → 0; reactive-intelligence tests 455/0; build green.
+
+## Risk register
+- **Risk:** `context-compress.ts` access `state.tokens` is required on `KernelStateLike` but tests pass partial fixtures (`{} as any`) where it's `undefined`. **Mitigation:** keep the `?? 0` defensive coalesce; TS allows it on `number` (no warning under current config) and runtime stays safe.
+- **Risk:** Test fixtures cast `as any` (e.g. `skill-activate.test.ts:9`) — typing the production code stricter could expose stale fixture shapes. **Mitigation:** tests remain `as any` (out of scope per issue); production cast moves behind named boundary.
+- **Risk:** `index.ts` has 9 `as unknown as InterventionHandler` lines for handler registry — that's a separate concern (TDecision parametrization), not HS-06. **Mitigation:** explicitly out of scope; verified-by greps target handler files only.
+
+## Verification protocol (cross-cutting)
+- `rtk bun test packages/reactive-intelligence/` — no net-new failures vs 455/0 baseline
+- `rtk bun run build` — full monorepo green
+- `rtk bunx turbo run typecheck --filter=@reactive-agents/reactive-intelligence` — green
+- `{ rtk grep -rn '(state as any)' packages/reactive-intelligence/src/controller/handlers/ || true; }` — returns 0 lines
+- `{ rtk grep -rn 'as unknown as {' packages/reactive-intelligence/src/controller/handlers/ || true; }` — returns 0 lines
+
+## Out-of-scope (explicit)
+- Extending `KernelStateLike` in `@reactive-agents/core` — cross-package, forbidden by gate; revisit when next bundle takes core changes.
+- `handlers/index.ts` `as unknown as InterventionHandler` — registry-level concern, not state-shape.
+- Test fixture `as any` casts — production typing is the contract; tests intentionally pass partial shapes.
+- Other `as any` outside `controller/handlers/` (separate HS-NN findings).


### PR DESCRIPTION
## Bundle: ri-handlers-state-shape

Closes #71

## Summary
Introduce `HandlerState` widening type + `asHandlerState` boundary helper in `packages/reactive-intelligence/src/controller/handler-state.ts`. Replaces 7 untyped reads across 7 RI intervention handlers with proper field types (`currentOptions`, `tokens`, `activatedSkills`, `controllerDecisionLog`, `currentStrategy`). Mirrors the `PatchedState` pattern already used in `patch-applier.ts`. Stays single-package — `KernelStateLike` in `@reactive-agents/core` untouched (cross-package extension was the issue body's "OR" alternative).

## Verification
- `bun run build` ✅ (38/38)
- `bun test packages/reactive-intelligence/` ✅ (455 pass / 3 skip / 0 fail, matches baseline)
- `bunx turbo run typecheck --filter=@reactive-agents/reactive-intelligence` ✅ (6/6)

Verified-by recheck (per issue #71):
- `grep -rn '(state as any)' packages/reactive-intelligence/src/controller/handlers/` → **0** (was 3)
- `grep -rn 'as unknown as {' packages/reactive-intelligence/src/controller/handlers/` → **0** (was 4)
- Total 7 sites → 1 named boundary cast (`asHandlerState`).

## Plan + Retro
- Plan: `wiki/Planning/Implementation-Plans/2026-05-21-ri-handlers-state-shape.md`
- Retro: `wiki/Research/Debriefs/2026-05-21-ri-handlers-state-shape-execution-debrief.md` (follow-up commit)
