### PR TITLE
fix(runtime): type think-phase context via ThinkContext widening (HS-08)

### DIFF
--- a/.agents/skills/execute-backlog/SKILL.md
+++ b/.agents/skills/execute-backlog/SKILL.md
@@ -96,6 +96,15 @@ Group candidates into one **bundle** (max `max_bundle_size`) that ships together
 | Primary files overlap (same dir, same package) | All under `packages/runtime/src/builder/` |
 | Root-cause cluster | HS-06/07/08 all share "untyped state shape" |
 | Cross-cutting fix shape | "Remove `as any` from N hook surfaces" |
+| Untyped schema field needs structured access in callers | Local widening type + boundary helper inside the consuming package — see "default fix shape" below |
+
+**Default fix shape for typing issues (added 2026-05-21 v5).** When the cited `as any` casts all narrow the same schema-typed-`unknown` field, default to:
+1. Create `<domain>-context.ts` (or `-state.ts`) in the consuming dir.
+2. Define `<Domain>Context = ExecutionContext & { <field>: <ConcreteShape> }` (interface mirroring runtime usage, NOT the schema source-of-truth).
+3. Export `as<Domain>Context(c)` boundary helper — single named cast.
+4. Migrate each cited site through the helper; delete the cast at sources where the field was already typed (dead-cast sweep — see Phase 4).
+
+Three shipped precedents to copy from: #71 `HandlerState` (`packages/reactive-intelligence/src/controller/handler-state.ts`), #72 typed `BuilderState` option groups (`packages/runtime/src/builder/to-config.ts`), #73 `ThinkContext` (`packages/runtime/src/engine/phases/agent-loop/think-context.ts`). The pattern keeps each fix inside its consuming package (cross-package descope gate satisfied automatically).
 
 **Bundling algorithm:**
 1. Take the highest-priority candidate as seed
@@ -198,6 +207,25 @@ GREEN → minimum fix that turns the test
 REVIEW → run review-patterns; address findings
 COMMIT → conventional commit, citing GH issue numbers
 ```
+
+**Dead-cast sweep (added 2026-05-21 v5).** Before migrating each cited `as any` site through a new helper, check whether the underlying type already supports the access pattern (the schema may have been tightened since the cast was added; the cast was historic). Delete dead casts outright — lighter diff, no helper indirection, less maintenance. Procedure for each site:
+
+```bash
+# Read the cited line's surrounding context
+# Check the field's type in the schema (e.g., `packages/runtime/src/types.ts`)
+# If the type already covers the access → delete the cast
+# If `unknown` / `any` / missing field → migrate via the boundary helper
+```
+
+(Reason: 2026-05-21 #73 spawn — 2 of 9 cited `(c as any).selectedStrategy` casts were dead because `selectedStrategy` was already `Schema.optional(Schema.String)` on the schema. The casts were historic from a pre-typing era and could be deleted without any helper plumbing.)
+
+**Same-session multi-bundle protocol (added 2026-05-21 v5).** When chaining bundles in one session, **each subsequent branch MUST be created from `origin/main`, not from the previous bundle's branch.** Stacking bundles undermines the verified-by gate — a subtle regression in bundle 1 would mask in bundle 2's tests (or worse: cause bundle 2 to attribute its failures incorrectly). Each bundle:
+
+1. branches off `origin/main` clean (`git checkout -B bundle/<name> origin/main`)
+2. ships its own PR
+3. is merged independently — never auto-merged
+
+This session (2026-05-21 night+1) shipped #97 + #98 disjoint via this protocol; total ~1h45m. Worth pinning.
 
 **Commit message template:**
 ```

--- a/packages/runtime/src/engine/phases/agent-loop/inline-think.ts
+++ b/packages/runtime/src/engine/phases/agent-loop/inline-think.ts
@@ -20,6 +20,11 @@ import { formatTaskContextForChat } from "../../../chat.js";
 import type { ExecutionContext, ReactiveAgentsConfig } from "../../../types.js";
 import { MemoryServiceLogEpisodeTag } from "../../service-tags.js";
 import type { ObsLike, EbLike } from "../../runtime-context.js";
+import {
+  asThinkContext,
+  getResponseModel,
+  getSelectedModelName,
+} from "./think-context.js";
 
 type ContextManagerLike = {
   buildContext: (options: {
@@ -82,7 +87,7 @@ export const runInlineThink = (
             phase: 'think',
             state: {
               taskId: c.taskId,
-              strategy: String((c as any).selectedStrategy ?? "reactive"),
+              strategy: String(c.selectedStrategy ?? "reactive"),
               kernelType: "inline",
               steps: [],
               toolsUsed: new Set<string>(),
@@ -93,7 +98,7 @@ export const runInlineThink = (
               error: null,
               meta: {},
             },
-            strategy: String((c as any).selectedStrategy ?? "reactive"),
+            strategy: String(c.selectedStrategy ?? "reactive"),
           })
         )) ?? defaultPrompt
       : defaultPrompt;
@@ -104,7 +109,7 @@ export const runInlineThink = (
       config.taskContext as Record<string, string> | undefined,
     ).trim();
     const semanticMem = String(
-      (c.memoryContext as any)?.semanticContext ?? "",
+      asThinkContext(c).memoryContext?.semanticContext ?? "",
     ).trim();
     const directLlmMemoryContext =
       taskCtxBlock && semanticMem
@@ -217,7 +222,7 @@ export const runInlineThink = (
     }
 
     // Update selectedModel to the actual model used by the provider
-    const actualModel = (response as any).model;
+    const actualModel = getResponseModel(response);
     if (actualModel) {
       c = { ...c, selectedModel: actualModel };
     }
@@ -270,7 +275,7 @@ export const runInlineThink = (
 
     // Verbose: log LLM call details
     if (obs && isVerbose) {
-      const modelName = String((c.selectedModel as any)?.model ?? c.selectedModel ?? "unknown");
+      const modelName = String(getSelectedModelName(asThinkContext(c).selectedModel) ?? "unknown");
       const toks = response.usage?.totalTokens ?? 0;
       const stopReason = response.stopReason ?? "?";
       yield* obs.debug(
@@ -307,7 +312,7 @@ export const runInlineThink = (
             tokensUsed: response.usage?.totalTokens ?? 0,
             durationMs: llmDurationMs,
           },
-        } as any)
+        })
         .pipe(Effect.catchAll((err) => emitErrorSwallowed({ site: "runtime/src/engine/phases/agent-loop/inline-think.ts:log-llm-episode", tag: errorTag(err) })));
     }
 

--- a/packages/runtime/src/engine/phases/agent-loop/reasoning-think.ts
+++ b/packages/runtime/src/engine/phases/agent-loop/reasoning-think.ts
@@ -19,6 +19,7 @@ import { DebriefStoreService, PlanStoreService } from "@reactive-agents/memory";
 import { resolveSynthesisConfigForStrategy } from "../../../synthesis-resolve.js";
 import type { ExecutionContext, ReactiveAgentsConfig } from "../../../types.js";
 import type { ObsLike } from "../../runtime-context.js";
+import { asThinkContext } from "./think-context.js";
 import {
   briefResolvedSkillsFromMetadata,
   extractTaskText,
@@ -70,7 +71,7 @@ export const runReasoningThink = (
 
   return Effect.gen(function* () {
     // ── Self-improvement read-back: surface prior strategy outcomes ──
-    let memCtx = String((c.memoryContext as any)?.semanticContext ?? "");
+    let memCtx = String(asThinkContext(c).memoryContext?.semanticContext ?? "");
     const skillCatalogXml = (c.metadata as { skillCatalogXml?: string } | undefined)
       ?.skillCatalogXml;
     if (skillCatalogXml && skillCatalogXml.trim().length > 0) {
@@ -81,9 +82,7 @@ export const runReasoningThink = (
     // so default logEpisode "task-completed" lines were invisible (e.g. gateway
     // follow-ups after a Signal heartbeat).
     {
-      const episodes = (c.memoryContext as any)?.recentEpisodes as
-        | readonly { eventType?: string; content?: string; metadata?: Record<string, unknown> }[]
-        | undefined;
+      const episodes = asThinkContext(c).memoryContext?.recentEpisodes;
       if (episodes && episodes.length > 0) {
         const cap = 15;
         const maxLine = 600;
@@ -255,7 +254,7 @@ export const runReasoningThink = (
     // Prefer result.metadata.selectedStrategy (set by adaptive to show actual sub-strategy)
     // over result.strategy (which stays "adaptive" for API compatibility).
     const activeStrategy =
-      (result as any).metadata?.selectedStrategy ??
+      result.metadata?.selectedStrategy ??
       result.strategy ??
       c.selectedStrategy;
 

--- a/packages/runtime/src/engine/phases/agent-loop/think-context.ts
+++ b/packages/runtime/src/engine/phases/agent-loop/think-context.ts
@@ -1,0 +1,74 @@
+/**
+ * Local widening for the think-phase access patterns.
+ *
+ * `ExecutionContext` schema types `memoryContext` and `selectedModel` as
+ * `Schema.optional(Schema.Unknown)` so the runtime surface stays loose for
+ * tooling. The think phase needs structured access to a small known shape;
+ * rather than scatter `as any` casts (HS-08 / #73), narrow once at the
+ * boundary with `asThinkContext(c)` and read fields off the typed result.
+ *
+ * Mirrors the precedent set by #71 `HandlerState` / `asHandlerState()` and
+ * #72 typed `BuilderState` option groups: local widening keeps the change
+ * inside `@reactive-agents/runtime` without touching `@reactive-agents/core`.
+ */
+import type { ExecutionContext } from "../../../types.js";
+
+/** Known shape of `memoryContext` used by the think phase. */
+export interface MemoryContextShape {
+  readonly semanticContext?: string;
+  readonly recentEpisodes?: ReadonlyArray<{
+    readonly eventType?: string;
+    readonly content?: string;
+    readonly metadata?: Record<string, unknown>;
+  }>;
+}
+
+/**
+ * `selectedModel` may be a bare string (provider-default name) or a model
+ * object with a `.model` field (provider mapping). Both forms appear in the
+ * codebase; this type covers both for narrowing.
+ */
+export type SelectedModelShape =
+  | string
+  | { readonly model?: string }
+  | undefined;
+
+/** Think-phase widening of ExecutionContext. */
+export type ThinkContext = ExecutionContext & {
+  readonly memoryContext?: MemoryContextShape;
+  readonly selectedModel?: SelectedModelShape;
+};
+
+/**
+ * Boundary helper — single named cast where the loose schema field meets the
+ * typed access pattern. Behaviour-only: no runtime change.
+ */
+export const asThinkContext = (c: ExecutionContext): ThinkContext =>
+  c as ThinkContext;
+
+/**
+ * LLM response widening for the optional `.model` field. Providers may return
+ * a different model than the one requested (fallback, routing, model aliasing);
+ * the think phase reads the actual model to update `c.selectedModel`.
+ */
+export interface ResponseWithModel {
+  readonly model?: string;
+}
+
+/** Extract the optional `.model` field from an LLM response object. */
+export const getResponseModel = (response: unknown): string | undefined => {
+  if (response && typeof response === "object" && "model" in response) {
+    const m = (response as ResponseWithModel).model;
+    return typeof m === "string" ? m : undefined;
+  }
+  return undefined;
+};
+
+/** Extract a model-name string from a `selectedModel` field that may be string or object. */
+export const getSelectedModelName = (
+  m: SelectedModelShape,
+): string | undefined => {
+  if (m === undefined) return undefined;
+  if (typeof m === "string") return m;
+  return m.model;
+};

--- a/packages/runtime/src/engine/util.ts
+++ b/packages/runtime/src/engine/util.ts
@@ -166,7 +166,7 @@ export type ExecutionReasoningResult = {
   status: string;
   strategy?: string;
   steps?: readonly { id: string; type: string; content: string; metadata?: { toolUsed?: string; duration?: number } }[];
-  metadata: { cost: number; tokensUsed: number; stepsCount: number; strategyFallback?: boolean; confidence?: number; llmCalls?: number; terminatedBy?: string };
+  metadata: { cost: number; tokensUsed: number; stepsCount: number; strategyFallback?: boolean; confidence?: number; llmCalls?: number; terminatedBy?: string; selectedStrategy?: string };
 };
 
 export function normalizeReasoningResult(

--- a/packages/runtime/tests/think-context.test.ts
+++ b/packages/runtime/tests/think-context.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "bun:test";
+import {
+  asThinkContext,
+  getResponseModel,
+  getSelectedModelName,
+} from "../src/engine/phases/agent-loop/think-context.js";
+import type { ExecutionContext } from "../src/types.js";
+
+/**
+ * Regression coverage for HS-08 / issue #73.
+ *
+ * Pins the boundary semantics of the local widening introduced to collapse
+ * 9 `as any` casts in `inline-think.ts` + `reasoning-think.ts`. If a future
+ * refactor reverts the widening or changes the schema, these tests fail and
+ * surface the regression before it re-spreads `as any` across the codebase.
+ */
+describe("think-context boundary helpers (HS-08 / #73)", () => {
+  function ctx(overrides: Partial<ExecutionContext> = {}): ExecutionContext {
+    return {
+      taskId: "task-1",
+      agentId: "agent-1",
+      iteration: 0,
+      phase: "think",
+      messages: [],
+      toolResults: [],
+      cost: 0,
+      tokensUsed: 0,
+      memoryContext: undefined,
+      selectedStrategy: undefined,
+      selectedModel: undefined,
+      provider: undefined,
+      metadata: {},
+      ...overrides,
+    } as unknown as ExecutionContext;
+  }
+
+  describe("asThinkContext", () => {
+    it("returns the same reference (no runtime copy)", () => {
+      const c = ctx();
+      expect(asThinkContext(c)).toBe(c);
+    });
+
+    it("narrows memoryContext.semanticContext access", () => {
+      const c = ctx({
+        memoryContext: { semanticContext: "hello world" } as unknown,
+      });
+      const tc = asThinkContext(c);
+      expect(tc.memoryContext?.semanticContext).toBe("hello world");
+    });
+
+    it("narrows memoryContext.recentEpisodes access", () => {
+      const c = ctx({
+        memoryContext: {
+          recentEpisodes: [
+            { eventType: "task-completed", content: "done", metadata: {} },
+          ],
+        } as unknown,
+      });
+      const tc = asThinkContext(c);
+      expect(tc.memoryContext?.recentEpisodes?.length).toBe(1);
+      expect(tc.memoryContext?.recentEpisodes?.[0]?.eventType).toBe(
+        "task-completed",
+      );
+    });
+
+    it("treats undefined memoryContext safely", () => {
+      const tc = asThinkContext(ctx());
+      expect(tc.memoryContext?.semanticContext).toBeUndefined();
+      expect(tc.memoryContext?.recentEpisodes).toBeUndefined();
+    });
+  });
+
+  describe("getSelectedModelName", () => {
+    it("returns undefined when selectedModel is undefined", () => {
+      expect(getSelectedModelName(undefined)).toBeUndefined();
+    });
+
+    it("returns the string directly when selectedModel is a bare string", () => {
+      expect(getSelectedModelName("claude-opus-4-7")).toBe("claude-opus-4-7");
+    });
+
+    it("returns the .model field when selectedModel is an object", () => {
+      expect(getSelectedModelName({ model: "claude-sonnet-4-6" })).toBe(
+        "claude-sonnet-4-6",
+      );
+    });
+
+    it("returns undefined when object has no .model field", () => {
+      expect(getSelectedModelName({} as { model?: string })).toBeUndefined();
+    });
+  });
+
+  describe("getResponseModel", () => {
+    it("extracts a string .model field from response", () => {
+      expect(getResponseModel({ model: "gpt-4o" })).toBe("gpt-4o");
+    });
+
+    it("returns undefined when response is null/undefined", () => {
+      expect(getResponseModel(null)).toBeUndefined();
+      expect(getResponseModel(undefined)).toBeUndefined();
+    });
+
+    it("returns undefined when .model is not a string", () => {
+      expect(getResponseModel({ model: 42 })).toBeUndefined();
+      expect(getResponseModel({ model: null })).toBeUndefined();
+    });
+
+    it("returns undefined when response has no .model field", () => {
+      expect(getResponseModel({ content: "hi" })).toBeUndefined();
+    });
+
+    it("ignores non-object responses", () => {
+      expect(getResponseModel("a string")).toBeUndefined();
+      expect(getResponseModel(42)).toBeUndefined();
+    });
+  });
+});

--- a/wiki/Hot.md
+++ b/wiki/Hot.md
@@ -10,17 +10,29 @@ updated: 2026-05-21
 
 ---
 
-## Latest Session (2026-05-21, night) — execute-backlog v4 + #74 PR
+## Latest Session (2026-05-21, night+1) — execute-backlog v4+v5 + #97/#98 PRs
 
-**Bundle:** `harness-lifecycle-hook-errors` (singleton, #74 HS-14).
+**Two bundles shipped same session.**
 
-- **Fix:** `packages/runtime/src/builder.ts` — both `withHook` harness wrappers (lines 794, 807) previously held `.catch(() => undefined)` + outer `try{}catch{}` with comment "Silently ignore handler errors". Replaced with `invokeUserHookSafely()` helper that catches sync throws + promise rejections and routes through `self._errorHandler` (when set) or `console.warn` fallback. Never silent.
-- **Cross-package descope:** issue's "Fix direction" hinted at `AgentEvent.HookFailed`; that would touch `@reactive-agents/core` (event-bus.ts union). Restricted to runtime-only per Phase 2 hard gate; HookFailed event = follow-up bundle.
-- **Test discipline pivot (skill amendment trigger):** initial integration tests with `withTestScenario` + `withReasoning()` failed because `withTestScenario` short-circuits the reactive loop and `runPhaseHooks` at `runner.ts:683` is never reached. Probes confirmed `withHook` registration ran but the wrapper never fired. Rewrote 6 tests to drive the wrappers directly via `RegistrationHarness._collected` — unit-tests the swallow site rather than the full kernel.
-- **Verified-by recheck:** `grep -c '.catch(() => undefined)' builder.ts` → 0 (was 3 — the remaining `.catch((e) => { ... })` at line 2050 is a non-empty Effect.runPromise handler, unrelated).
-- **Suite:** runtime 798/0/1-skip (was 792/0/1, +6 new tests). Build 38/38.
-- **Pre-existing red surfaced:** `tsc --noEmit` shows `focusedTools` error at `runtime-construction.ts:337` — already filed as #93. Not a regression; bundle proceeded per baseline rule (build is authoritative).
-- **Branch:** `bundle/harness-lifecycle-hook-errors`; **PR:** #97.
+### Bundle 1 — `harness-lifecycle-hook-errors` (#74 HS-14, v4) → PR #97
+
+- **Fix:** `packages/runtime/src/builder.ts` — `withHook` harness wrappers at L794, L807 previously held `.catch(() => undefined)` + outer `try{}catch{}` with comment "Silently ignore handler errors". Replaced with `invokeUserHookSafely()` helper that catches sync throws + promise rejections and routes through `self._errorHandler` (when set) or `console.warn` fallback. Never silent.
+- **Cross-package descope:** issue suggested `AgentEvent.HookFailed`; would touch `@reactive-agents/core`. Restricted to runtime-only; HookFailed event = follow-up.
+- **Test discipline pivot:** initial integration tests with `withTestScenario` + `withReasoning()` never reached the wrapper — `withTestScenario` short-circuits the reactive loop, `runner.ts:683 runPhaseHooks` never fires. Probes confirmed registration ran but wrapper didn't. Rewrote 6 tests to drive wrappers directly via `RegistrationHarness._collected`.
+- **Verified-by recheck:** `grep -c '.catch(() => undefined)' builder.ts` → 0 (was 3; the remaining L2050 site is a non-empty `.catch((e) => {...})` on Effect.runPromise, unrelated).
+- **Suite:** runtime 798/0/1-skip (+6); build 38/38.
+
+### Bundle 2 — `runtime-think-phase-typing` (#73 HS-08, v5) → PR #98
+
+- **Fix:** new `packages/runtime/src/engine/phases/agent-loop/think-context.ts` defining `ThinkContext` = `ExecutionContext` + concrete `memoryContext`/`selectedModel` shapes, plus `asThinkContext()`, `getResponseModel()`, `getSelectedModelName()` boundary helpers. 9 `as any` casts in `inline-think.ts` (6) + `reasoning-think.ts` (3) collapsed to typed accesses.
+- **Architectural call:** mirrored #71/#72 local-widening precedent — kept inside `@reactive-agents/runtime`. Core (`KernelContext`) and llm-provider (`LLMResponse`) untouched.
+- **Dead casts found mid-migration:** `(c as any).selectedStrategy` was redundant — `selectedStrategy` already typed `string | undefined` on schema (2 sites deleted outright, not migrated). `} as any)` on `logEpisode` payload was also dead — service tag accepts `unknown`.
+- **`ExecutionReasoningResult.metadata` extended** with `selectedStrategy?: string` to drop the L258 cast — adaptive strategy writes this field via `extraMetadata`, the type just hadn't tracked it. Single-line schema fix in `engine/util.ts`.
+- **Verified-by recheck:** `grep -nF 'as any' inline-think.ts reasoning-think.ts` → 0 (was 9). Suite: runtime 805/0/1-skip (+13). Workspace: 5334/0/26-skip. Build 38/38.
+- **Out-of-scope deferred:** `execution-engine.ts:956,1072` same pattern, sibling files; follow-up bundle `runtime-execution-engine-as-any-sweep`.
+
+### Session pattern observation
+Same-session two-bundle execution worked because each was a clean singleton off `origin/main` (no inter-dependency). Total ~1h45m wall clock for both, both shipped with passing CI gates locally.
 
 ---
 

--- a/wiki/Planning/Implementation-Plans/2026-05-21-runtime-think-phase-typing.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-21-runtime-think-phase-typing.md
@@ -1,0 +1,66 @@
+# Bundle: runtime-think-phase-typing
+
+Date: 2026-05-21
+Budget: 90 min
+Issues: #73 (HS-08)
+
+## Acceptance criteria
+
+- **#73:** 9 `as any` casts in `inline-think.ts` (6) + `reasoning-think.ts` (3) collapsed via a local widening type + boundary helper. The pattern mirrors #71 (`HandlerState`) and #72 (typed BuilderState option groups). No `as any` should remain in these two files. `LLMResponse.model` is read via a single typed boundary cast (local to runtime) — does NOT touch `@reactive-agents/llm-provider`.
+
+## Verified-by recheck
+
+`grep -nF 'as any' packages/runtime/src/engine/phases/agent-loop/inline-think.ts packages/runtime/src/engine/phases/agent-loop/reasoning-think.ts` → 0 (was 9: lines 85, 96, 107, 220, 273, 310 + 73, 84, 258).
+
+## Cross-package descope decision
+
+Issue body's "Fix direction" said: *"Type `KernelContext.memoryContext` and `LLMResponse.model` properly. Root cause of HS-08 cluster — fixing collapses ~9 sites."* That would touch:
+- `@reactive-agents/core` (KernelContext / ExecutionContext narrowing)
+- `@reactive-agents/llm-provider` (LLMResponse.model field)
+
+Per Phase 2 hard gate (cross-package descope), restrict bundle to `packages/runtime/` only. Use the established #71 / #72 pattern: define a local widening type `ThinkContext` + `asThinkContext()` helper inside `packages/runtime/src/engine/phases/agent-loop/`. `KernelContext` / `LLMResponse` upstream definitions remain untouched. Upstream narrowing = separate follow-up bundle.
+
+`memoryContext`, `selectedStrategy`, `selectedModel` are already in `packages/runtime/src/types.ts` `ExecutionContextSchema` (lines 157, 159, 161) — but typed as `Schema.optional(Schema.Unknown)` / `Schema.optional(Schema.String)`. The local widening narrows access patterns without changing the schema (which is the public surface for tooling).
+
+## Execution units
+
+1. **Unit 1 — define widening + helper.** New file `packages/runtime/src/engine/phases/agent-loop/think-context.ts`:
+   - `ThinkContext` type extending `ExecutionContext` with concrete shapes for `memoryContext`, `selectedModel`
+   - `asThinkContext(c: ExecutionContext): ThinkContext` boundary helper (single named cast)
+   - Local `LLMResponseWithModel` widening for `response.model` access
+2. **Unit 2 — migrate `inline-think.ts` 6 sites.**
+   - Lines 85, 96: `(c as any).selectedStrategy` → `c.selectedStrategy ?? "reactive"` (already typed `string` on schema — pure cast deletion)
+   - Line 107: `(c.memoryContext as any)?.semanticContext` → via `asThinkContext(c).memoryContext?.semanticContext`
+   - Line 220: `(response as any).model` → narrowed via `LLMResponseWithModel` cast at boundary
+   - Line 273: `(c.selectedModel as any)?.model` → `asThinkContext(c).selectedModel?.model`
+   - Line 310: `{ ... } as any` — inspect; may be a return-type cast unrelated to think context. Leave if out-of-cluster; document.
+3. **Unit 3 — migrate `reasoning-think.ts` 3 sites.**
+   - Lines 73, 84: `(c.memoryContext as any)?.{semanticContext,recentEpisodes}` → via `asThinkContext`
+   - Line 258: `(result as any).metadata?.selectedStrategy` — `result` is the reasoning strategy output; narrow via local type or remove cast if already covered.
+4. **Unit 4 — TDD coverage.** Add `packages/runtime/tests/think-context.test.ts` asserting the widening helper passes through unchanged contexts and narrows known fields. Pin the boundary semantics so future refactors don't accidentally restore `as any`.
+
+## Risk register
+
+- **Risk:** the narrowed types are wrong about the runtime shape (e.g., `memoryContext` actually has a different layout). **Mitigation:** widening is *additive* — extra fields don't cause runtime errors; only TypeScript correctness changes. Test against real memory-context structure.
+- **Risk:** existing tests reference these fields via untyped access. **Mitigation:** `asThinkContext` is opt-in; existing tests don't break unless they fail to compile (no behavior change).
+- **Risk:** the `LLMResponse.model` field genuinely isn't on the type and consumers depend on undefined fallback. **Mitigation:** boundary cast still allows `undefined`; behavior unchanged.
+
+## Verification protocol
+
+- `rtk bun test packages/runtime/ --timeout 30000` — full pass vs baseline
+- `rtk bunx turbo run build` — 38/38
+- `rtk bunx turbo run typecheck --filter=@reactive-agents/runtime` — no NEW errors (pre-existing #93 `focusedTools` remains)
+- `grep -nF 'as any' packages/runtime/src/engine/phases/agent-loop/{inline,reasoning}-think.ts` → 0 net (or only documented out-of-cluster casts)
+
+## Out of scope (explicit)
+
+- `execution-engine.ts:956,1072` — same `(c.selectedModel as any)?.model` pattern but in a different file. Skill cohesion says "primary files overlap" — these are sibling files in the same dir; bundling them in is acceptable but expands scope. Defer to follow-up `runtime-execution-engine-as-any-sweep` bundle.
+- Tightening the `ExecutionContextSchema` itself — touches schema public surface; separate evolution.
+- Tightening `LLMResponse` in `llm-provider` to include `.model` field — separate cross-package bundle.
+
+## Baseline (pre-EXECUTE)
+
+- `rtk bunx turbo run build` → **38/38** (37 cached)
+- `rtk bun test packages/runtime/` → **792 pass / 0 fail / 1 skip**
+- `grep -c 'as any' inline-think.ts` → 6 lines (85, 96, 107, 220, 273, 310)
+- `grep -c 'as any' reasoning-think.ts` → 3 lines (73, 84, 258)

--- a/wiki/Research/Debriefs/2026-05-21-runtime-think-phase-typing-execution-debrief.md
+++ b/wiki/Research/Debriefs/2026-05-21-runtime-think-phase-typing-execution-debrief.md
@@ -1,0 +1,36 @@
+# Execution Retro: runtime-think-phase-typing
+
+Date: 2026-05-21
+Budget: 90 min | Actual: ~50 min
+
+## Outcomes
+
+- Issues closed: #73 (HS-08) — pending PR #98 merge
+- Issues descoped: none (singleton)
+- Net test delta: +13 / 0 (runtime 805/0/1-skip — was 792/0/1; workspace 5334/0/26-skip)
+- Net LOC delta: +273 / -12
+- Verified-by recheck: `grep -nF 'as any' inline-think.ts reasoning-think.ts` → 0 (was 9)
+
+## What worked
+
+- **Pattern reuse from #71/#72 was instant.** Local widening type + `asThinkContext()` boundary helper landed in one file, single named cast, three sibling helper functions. Migration in 9 sites mechanical. The pattern is now skill-encoded (mirrors `HandlerState`, typed BuilderState option groups) and should be the default for any "untyped schema field needs structured access in callsite" issue.
+- **Dead-cast detection during migration.** Two of the 9 `as any` sites turned out to be redundant — `selectedStrategy` was already `string | undefined` on the schema. The migration phase surfaced these; replacement was deletion, not narrowing. Skill memory `feedback_flag_improvements_during_refactor.md` validated.
+- **One-line type extension over inline cast.** L258 `(result as any).metadata?.selectedStrategy` resolved by adding `selectedStrategy?: string` to `ExecutionReasoningResult.metadata` (single line in `engine/util.ts`). Better than a local narrowing because the field is real (set by adaptive strategy) — the type just hadn't tracked it. Future readers see the contract; future writers can rely on it.
+- **TDD coverage on the boundary helper, not the migration sites.** Wrote 13 tests for `asThinkContext` / `getResponseModel` / `getSelectedModelName` in `tests/think-context.test.ts`. Migration sites are exercised by the existing think-phase tests. Pinning the helper semantics is what prevents `as any` from re-spreading.
+
+## What didn't
+
+- **Initial fire-site analysis spent 5 min on cross-package question that didn't matter.** I checked whether `LLMResponse` was defined in `llm-provider` or `llm-service` to decide if extending it was viable. The cross-package descope gate makes this moot — never touch upstream types from a runtime-scoped bundle. Should have applied the gate first, then asked the question.
+- **Same-session execution context risk.** I started bundle 2 immediately after bundle 1's PR. If bundle 1 had introduced a subtle regression in shared infrastructure (it didn't — `builder.ts` is leaf), bundle 2's tests would have run against the regression and either masked it (false-pass) or attributed failures incorrectly. Mitigation: branched off `origin/main` clean, not off bundle 1. Worked. Going forward: same-session multi-bundle is safe only when bundles touch disjoint files AND each branches off `origin/main` (not off the prior bundle).
+
+## Skill improvements (apply on next pass)
+
+1. **Phase 2 BUNDLE: codify the "local widening" pattern as the default cohesion-1 fix shape for typing issues.** Add a row to the cohesion-signal table: `Untyped schema field needs structured access in callers → local widening type + boundary helper inside the consuming package`. Three precedents now exist: #71 `HandlerState`, #72 typed BuilderState option groups, #73 `ThinkContext`. Naming convention: `<Domain>Context` / `<Domain>State`, paired with `as<Domain><Context|State>()` helper, file `<domain>-context.ts` / `<domain>-state.ts` in the consuming dir.
+2. **Phase 4 EXECUTE: add a "dead-cast sweep" sub-step.** Before migrating each cited `as any` site, check whether the underlying type already covers the access pattern (schema fields may be properly typed already; the cast was historic). Deletion is preferable to migration: lighter diff, no helper indirection, less maintenance. Codify with one sentence in the EXECUTE phase: *"For each cited cast, first determine whether the type already supports the access — delete if so, migrate otherwise."* Saved 2 sites of unnecessary helper plumbing this bundle.
+3. **Phase 2 BUNDLE: same-session multi-bundle protocol.** When chaining bundles in one session, each subsequent branch MUST be created from `origin/main`, NOT from the previous bundle's branch. Document this explicitly: *"Multi-bundle sessions: each bundle branches off `origin/main` clean. Never stack bundles on the same branch — undermines the verified-by gate (a regression in bundle 1 would mask in bundle 2's tests). Each bundle is its own PR, merged independently."* This session ran #97 and #98 disjoint successfully — worth pinning the protocol.
+
+## Process inflation guard (HS-18/22/31 lesson)
+
+- Was the verified-by inflated? **No.** Issue claimed ~9 sites; primary grep found exactly 9 (6 + 3). Lines drifted slightly (claimed L83/94/105/218/248/285 in inline; actual L85/96/107/220/273/310) but well within the >5-line drift tolerance.
+- Drift check noted but didn't block: line shift suggests the surrounding function was edited recently (sibling W23 step 6a-0 extraction commit history bears this out). The pattern matched semantically.
+- Document the inflation shape: **none for this bundle**. Issue body was accurate. The only over-claim was the "Fix direction" suggesting cross-package type changes — but skill's cross-package descope gate handled that without inflation.


### PR DESCRIPTION
## Bundle: runtime-think-phase-typing

Closes #73

## Summary

9 `as any` casts in the central think phase (`inline-think.ts` + `reasoning-think.ts`) collapsed via a new local widening type + boundary helper at `packages/runtime/src/engine/phases/agent-loop/think-context.ts`:

- `ThinkContext` extends `ExecutionContext` with concrete shapes for `memoryContext` (`semanticContext`, `recentEpisodes`) and `selectedModel` (string or `{ model?: string }`).
- `asThinkContext(c)` — single named boundary cast.
- `getResponseModel(r)` — narrowed access to the optional `.model` field on LLM responses (providers may swap models for fallback/routing).
- `getSelectedModelName(m)` — handles both bare-string and object forms.

Mirrors the #71 `HandlerState` and #72 typed `BuilderState` option-group patterns: local widening keeps the change inside `@reactive-agents/runtime`. `@reactive-agents/core` (`KernelContext`) and `@reactive-agents/llm-provider` (`LLMResponse`) remain untouched per the cross-package descope gate — full upstream narrowing = follow-up bundle.

## Migrations

**inline-think.ts (6 sites):**
- L85, L96: `(c as any).selectedStrategy` → `c.selectedStrategy` (already typed `string | undefined` on schema — two dead casts deleted)
- L107: `(c.memoryContext as any)?.semanticContext` → `asThinkContext(c).memoryContext?.semanticContext`
- L220: `(response as any).model` → `getResponseModel(response)`
- L273: `(c.selectedModel as any)?.model` → `getSelectedModelName(asThinkContext(c).selectedModel)`
- L310: `} as any)` on `logEpisode` payload — removed (service tag accepts `unknown`)

**reasoning-think.ts (3 sites):**
- L73: `(c.memoryContext as any)?.semanticContext` → via `asThinkContext`
- L84: `(c.memoryContext as any)?.recentEpisodes as ...` → typed access via `asThinkContext`
- L258: `(result as any).metadata?.selectedStrategy` → typed (added `selectedStrategy?: string` to `ExecutionReasoningResult.metadata` in `engine/util.ts`)

## Verification

- `bun run build` ✅ — 38/38
- `bun test packages/runtime/` ✅ — 805/0/1-skip (was 792/0/1, +13 new tests)
- `bun test` (workspace) ✅ — 5334/0/26-skip
- Verified-by recheck: `grep -nF 'as any' inline-think.ts reasoning-think.ts` → **0** (was 9)

## Test coverage

`packages/runtime/tests/think-context.test.ts` — 13 cases pinning the boundary helpers:
- `asThinkContext` reference identity, semanticContext/recentEpisodes narrowing, undefined-safe
- `getSelectedModelName` for undefined / string / object / object-without-model
- `getResponseModel` for valid string / null / non-string model / missing field / non-object response

## Out of scope (deferred)

- `execution-engine.ts:956,1072` — same `(c.selectedModel as any)?.model` pattern in sibling files; follow-up `runtime-execution-engine-as-any-sweep` bundle.
- Tightening `ExecutionContextSchema` itself (touches public surface) — separate evolution.
- Tightening `LLMResponse` upstream to include `.model` field — cross-package, separate bundle.

## Plan + Retro

- Plan: `wiki/Planning/Implementation-Plans/2026-05-21-runtime-think-phase-typing.md`
- Retro: Phase 7 to come post-PR