### PR TITLE
test(react): add public-surface smoke coverage (HS-26 react portion)

### DIFF
--- a/.agents/skills/execute-backlog/SKILL.md
+++ b/.agents/skills/execute-backlog/SKILL.md
@@ -114,6 +114,8 @@ Three shipped precedents to copy from: #71 `HandlerState` (`packages/reactive-in
 
 **Hard gate (added 2026-05-21): cross-package descope.** Before locking the bundle, re-grep each candidate's verified-by command and inspect the file paths it emits. If those paths span **≥2 packages** (`packages/<a>/…` vs `packages/<b>/…`), descope to a per-package bundle even if the issue body's "Fix direction" suggests otherwise. The body lies; the grep doesn't. (Reason: 2026-05-21 #73 spawn — body said "type properly in the think phase" but the actual `as any` targets resolved to types owned by `@reactive-agents/llm-service` and the kernel-context shape, both other packages.)
 
+**Multi-package test-infra split (added 2026-05-22 v7).** The cross-package gate isn't only for typing/refactor issues — it applies the same way when an issue cites adding tests / infra / docs to N packages. Ship N bundles (one per package), each with its own PR. Name the follow-up bundles in the seed bundle's PR description so the queue is explicit. (Reason: 2026-05-22 #82 spawn — issue cited zero tests across `packages/react/`, `packages/svelte/`, `packages/vue/`. Shipped `bundle/react-smoke-tests` first; named `bundle/svelte-smoke-tests` and `bundle/vue-smoke-tests` as follow-ups in the PR body. Disjoint scopes, independent CI, no cross-package merge conflicts.)
+
 **Output:** named bundle. Pattern: `<area>-<theme>` (e.g., `providers-untyped-hooks`, `runtime-builder-as-any-sweep`).
 
 Open a new GH issue or use an existing tracker as the *bundle parent* — link it to all members via `Tracks: #N` lines. Apply the `tracking` label.
@@ -297,6 +299,16 @@ new check:                  `grep -c "as any" packages/X/Y.ts` → 0
 ```
 
 If a verified-by check fails to come down → the fix didn't actually address the claim. Reopen the issue with the new count + commit ref.
+
+**Workspace-test-flake protocol (added 2026-05-22 v7).** When `bun test` (workspace, run from repo root) shows failures but per-package isolation runs clean, treat as test-order / fixture-state flake. Verification is acceptable when:
+
+1. The bundle's touched package suite passes in isolation: `rtk bun test packages/<touched>/` → 0 fail.
+2. The failing tests live in packages NOT touched by the bundle. (`rtk bun test packages/<failing-pkg>/` → 0 fail confirms it's flake, not real.)
+3. The failing tests are not the verified-by recheck for any bundle issue.
+
+Document the flake in the PR body (test name + isolation evidence). Do NOT block the bundle. CI may surface the same flake; if so, rerun the failed job. (Reason: 2026-05-22 #82 spawn — workspace `bun test` showed 2 fails in `packages/diagnose/`; `rtk bun test packages/diagnose/` → 35/0. Pre-existing test-order issue, unrelated to the react smoke bundle. CI on #100 will rerun cleanly. Same pattern surfaced on #99 — `httpbin.org` external-network flake resolved on rerun.)
+
+Track flakes that recur across ≥2 bundles in their own follow-up issue (e.g., "test-order flake in packages/diagnose under workspace `bun test`") — separately from any active bundle.
 
 ---
 

--- a/packages/react/tests/smoke.test.ts
+++ b/packages/react/tests/smoke.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Smoke coverage for `@reactive-agents/react` — closes HS-26 / issue #82
+ * (for the react package; svelte + vue tracked as separate per-package
+ * bundles per the cross-package descope gate).
+ *
+ * Verifies the public surface: named exports exist, are the expected
+ * runtime shapes, and TypeScript types compile against the documented
+ * contract. Does NOT render hooks — React hooks require a render context
+ * (`useState`/`useCallback` throw "Invalid hook call" outside one), and
+ * pulling in `@testing-library/react` + `happy-dom` for a smoke test is
+ * scope creep. A follow-up bundle can extract the fetch core into a pure
+ * helper for behavioral coverage.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  useAgent,
+  useAgentStream,
+  type AgentStreamEvent,
+  type AgentHookState,
+  type UseAgentReturn,
+  type UseAgentStreamReturn,
+} from "../src/index.js";
+
+describe("@reactive-agents/react — public surface", () => {
+  it("exports useAgent as a function", () => {
+    expect(typeof useAgent).toBe("function");
+    // Hook signature: (endpoint: string, requestInit?: RequestInit) => UseAgentReturn
+    expect(useAgent.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("exports useAgentStream as a function", () => {
+    expect(typeof useAgentStream).toBe("function");
+    expect(useAgentStream.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("type-checks the documented AgentHookState union", () => {
+    const idle: AgentHookState = "idle";
+    const streaming: AgentHookState = "streaming";
+    const completed: AgentHookState = "completed";
+    const error: AgentHookState = "error";
+    expect([idle, streaming, completed, error]).toEqual([
+      "idle",
+      "streaming",
+      "completed",
+      "error",
+    ]);
+  });
+
+  it("type-checks the documented AgentStreamEvent _tag variants", () => {
+    // The hook switches on these `_tag` strings — the SSE contract is
+    // hand-coupled to the runtime's AgentStream emission. If the runtime
+    // renames a variant, this test fails at compile time before runtime
+    // surfaces a silent SSE parse miss.
+    const textDelta: AgentStreamEvent = { _tag: "TextDelta", text: "hi" } as AgentStreamEvent;
+    const completed: AgentStreamEvent = {
+      _tag: "StreamCompleted",
+      output: "done",
+    } as AgentStreamEvent;
+    const cancelled: AgentStreamEvent = { _tag: "StreamCancelled" } as AgentStreamEvent;
+    const error: AgentStreamEvent = {
+      _tag: "StreamError",
+      cause: "x",
+    } as AgentStreamEvent;
+    expect([textDelta._tag, completed._tag, cancelled._tag, error._tag]).toEqual([
+      "TextDelta",
+      "StreamCompleted",
+      "StreamCancelled",
+      "StreamError",
+    ]);
+  });
+
+  it("type-checks UseAgentReturn fields are reachable from the hook return", () => {
+    // Compile-time check via a function-typed reference (zero runtime cost).
+    const _check: () => UseAgentReturn = () => ({
+      output: null,
+      loading: false,
+      error: null,
+      run: async () => "",
+    });
+    expect(typeof _check).toBe("function");
+  });
+
+  it("type-checks UseAgentStreamReturn shape (run + cancel callbacks)", () => {
+    const _check: () => UseAgentStreamReturn = () => ({
+      text: "",
+      events: [],
+      status: "idle",
+      error: null,
+      output: null,
+      run: () => undefined,
+      cancel: () => undefined,
+    });
+    expect(typeof _check).toBe("function");
+  });
+});

--- a/wiki/Hot.md
+++ b/wiki/Hot.md
@@ -10,7 +10,29 @@ updated: 2026-05-21
 
 ---
 
-## Latest Session (2026-05-22, early) — execute-backlog v6 + #99 PR
+## Latest Session (2026-05-22, mid) — execute-backlog v7 + #100 PR
+
+**Bundle:** `react-smoke-tests` (#82 partial, react portion only).
+
+- **Fix:** `packages/react/tests/smoke.test.ts` — 6 public-surface cases (export presence + `AgentStreamEvent._tag` + `AgentHookState` union + return-type shapes). Previously: 0 test files in `packages/react/`.
+- **Strategy decision:** pure smoke (no React render). React hooks throw "Invalid hook call" outside render context; adding `@testing-library/react` + `happy-dom` for one smoke test = scope creep. `AgentStreamEvent._tag` assertion IS load-bearing — hook's SSE parser switches on these strings, so type drift surfaces at compile time before silent prod misses.
+- **Cross-package descope:** issue cites 3 packages (react/svelte/vue); shipped react only. `bundle/svelte-smoke-tests` + `bundle/vue-smoke-tests` named as follow-ups in PR body.
+- **Verified-by recheck:** `find packages/react -name '*.test.ts*'` → 1 (was 0). Suite: react 6/0; build 38/38.
+- **Workspace test flake observed:** `packages/diagnose/` shows 2 fails in workspace `bun test` mode but 35/0 in isolation. Same flake class as #99 httpbin. Skill v7 codifies the protocol.
+- **Branch:** `bundle/react-smoke-tests`; **PR:** #100.
+- **Skill amendments (v7):** (1) Phase 5 workspace-test-flake protocol — accept workspace failures when isolation passes + failure isn't in touched package + not a verified-by recheck. Track recurring flakes in own issue. (2) Phase 2 multi-package test-infra split — same descope rule as typing applies to test-infra issues.
+
+### Session arc (4 bundles, 2 calendar days)
+- 2026-05-21 night → `bundle/harness-lifecycle-hook-errors` (#74 HS-14) → PR #97
+- 2026-05-21 night+1 → `bundle/runtime-think-phase-typing` (#73 HS-08) → PR #98
+- 2026-05-22 early → `bundle/tests-stale-m1-red-cleanup` (#80 HS-24) → PR #99
+- 2026-05-22 mid → `bundle/react-smoke-tests` (#82 react portion) → PR #100
+
+All four branched off `origin/main` clean. Total ~2h15m wall clock. Skill SKILL.md amendments accumulated v3→v7 across the four PRs; each PR carries its own delta — when all merge, deltas compose on main.
+
+---
+
+## Previous Session (2026-05-22, early) — execute-backlog v6 + #99 PR
 
 **Bundle:** `tests-stale-m1-red-cleanup` (singleton, #80 HS-24).
 

--- a/wiki/Planning/Implementation-Plans/2026-05-22-react-smoke-tests.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-22-react-smoke-tests.md
@@ -1,0 +1,54 @@
+# Bundle: react-smoke-tests
+
+Date: 2026-05-22
+Budget: 30 min
+Issues: #82 (HS-26) — react portion only
+
+## Acceptance criteria
+
+- **#82 (react portion):** `packages/react/` ships at least one `*.test.ts` file exercising the public surface. `find packages/react -name '*.test.ts'` returns ≥1 (was 0).
+
+## Cross-package descope
+
+Issue #82 cites three packages: `packages/react/`, `packages/svelte/`, `packages/vue/`. Per Phase 2 hard gate (cross-package descope), restrict bundle to **react only**. `svelte` + `vue` ship as follow-up per-package bundles (`bundle/svelte-smoke-tests`, `bundle/vue-smoke-tests`). Each gets its own PR.
+
+## Test-strategy decision
+
+React hooks (`useState` / `useCallback`) throw "Invalid hook call" outside a render context. Three viable approaches:
+
+1. **Full render via `@testing-library/react` + `happy-dom`** — true behavioral coverage but adds 2 dev deps + setup for one smoke test → scope creep.
+2. **Pure-function extraction** — refactor fetch/SSE logic out of the hooks into pure helpers, test those — best long-term but expands bundle scope past "add tests".
+3. **Public-surface smoke** — assert named exports exist, function arity, type-contract for `AgentStreamEvent._tag` variants and `AgentHookState` union — true smoke (zero deps, fast).
+
+Pick (3) for this bundle. Hardening via (1) or (2) → follow-up bundle.
+
+The `AgentStreamEvent._tag` contract IS load-bearing: the hook's SSE parser switches on `_tag` strings. If the runtime's `AgentStream` emission renames a variant (e.g., `StreamCompleted` → `Completed`), the hook silently misses events. The type-contract assertion catches that at compile time even though it doesn't execute the hook.
+
+## Execution units
+
+1. **Unit 1 — `packages/react/tests/smoke.test.ts`.** 6 cases:
+   - `useAgent` exported as function, arity ≥1
+   - `useAgentStream` exported as function, arity ≥1
+   - `AgentHookState` union covers `idle` / `streaming` / `completed` / `error`
+   - `AgentStreamEvent._tag` covers `TextDelta` / `StreamCompleted` / `StreamCancelled` / `StreamError`
+   - `UseAgentReturn` shape reachable at compile time
+   - `UseAgentStreamReturn` shape reachable at compile time
+
+## Verification protocol
+
+- `rtk bun test packages/react/` → 6 pass / 0 fail
+- `rtk bunx turbo run typecheck --filter=@reactive-agents/react` → no new errors
+- `rtk bunx turbo run build` → 38/38
+- Verified-by recheck: `find packages/react -name '*.test.ts*'` → 1 result (was 0)
+
+## Out of scope (explicit)
+
+- `packages/svelte/` smoke tests — follow-up bundle `bundle/svelte-smoke-tests`
+- `packages/vue/` smoke tests — follow-up bundle `bundle/vue-smoke-tests`
+- Behavioral coverage of the hooks via React render — follow-up bundle `bundle/react-behavioral-tests` once test-infra investment is justified
+- Extracting fetch/SSE logic into pure helpers — refactor, separate from #82's "add tests" scope
+
+## Baseline (pre-EXECUTE)
+
+- `find packages/react -name '*.test.ts*'` → 0 results
+- Workspace test (root): baseline at prior session ~5334/0/26-skip; current run shows a separate `packages/diagnose/` test-order flake (workspace mode only; 35/0 in isolation) — pre-existing, not blocking this bundle.

--- a/wiki/Research/Debriefs/2026-05-22-react-smoke-tests-execution-debrief.md
+++ b/wiki/Research/Debriefs/2026-05-22-react-smoke-tests-execution-debrief.md
@@ -1,0 +1,34 @@
+# Execution Retro: react-smoke-tests
+
+Date: 2026-05-22
+Budget: 30 min | Actual: ~25 min
+
+## Outcomes
+
+- Issues partially closed: #82 (HS-26) — react portion; svelte + vue tracked as follow-up bundles via PR description
+- Issues descoped: none (the cross-package split IS the bundle's structure, not a punted fix)
+- Net test delta: +6 / 0 (packages/react: 0 → 6 tests, file count: 0 → 1)
+- Net LOC delta: +149 (one test file + plan doc)
+- Verified-by recheck: `find packages/react -name '*.test.ts*'` → 1 (was 0)
+
+## What worked
+
+- **Cross-package descope cleanly executed.** Issue cites 3 packages; bundle ships 1. PR description names the follow-up bundles (`bundle/svelte-smoke-tests`, `bundle/vue-smoke-tests`) so the queue is explicit. Skill v3+v5's cross-package gate carried over to "test infra" issues, not just typing.
+- **Test-strategy decision documented up front.** The plan called out 3 strategies (full render / pure-fn extraction / public-surface smoke) and committed to (3) with reasoning. Future bundles touching React testing won't need to relitigate; the followup work is named (`bundle/react-behavioral-tests` for full render).
+- **Load-bearing type contract test.** The `AgentStreamEvent._tag` assertion isn't theatre — it catches runtime/hook contract drift at compile time. Hook's SSE parser hard-codes those strings. If `AgentStream` emission renames a variant, this test fails before silent prod misses occur. Cheaper than a render-based test that does the same job.
+- **Bun runs subpackage tests without per-package script.** Root `bun test` auto-discovers `tests/*.test.ts` everywhere. No package.json `test` script needed in `packages/react/`. One file added → CI picks it up.
+
+## What didn't
+
+- **Workspace test mode shows pre-existing `packages/diagnose/` flake.** `bun test` from root → 2 fails. `bun test packages/diagnose/` → 35/0. Test-order or fixture-state contention. Second occurrence this session (first was the #99 httpbin flake). CI rerun resolved #99; this one likely will too. **Pattern emerging**: workspace test mode is less reliable than per-package runs.
+- **Smoke test feels theatrical for export-presence.** Cases 1, 2, 5, 6 are "function exists / shape compiles" — a tsc check covers them implicitly. Cases 3, 4 (the union assertions) have real signal. The export-presence cases stay because they're cheap and ensure the package isn't tree-shaken to nothing in a future build, but I'd rate the bundle B+ on signal density.
+
+## Skill improvements (apply on next pass)
+
+1. **Phase 5 VERIFY: workspace-test-flake protocol.** When `bun test` (workspace) shows failures but per-package isolation passes, treat as test-order/fixture flake. Verification is acceptable when (a) isolated package suite is clean, AND (b) the failing tests aren't in the package the bundle touches. Document with one sentence + sample command in Phase 5: *"If workspace `bun test` shows failures unrelated to the touched package, verify by re-running the affected package's tests in isolation (`bun test packages/<failing-pkg>/`). If isolated suite is clean, mark workspace failure as test-order flake; CI rerun typically resolves. Do NOT block the bundle on workspace-only flakes that don't touch your fix surface."*
+2. **Phase 2 BUNDLE: codify "split by package" as the standard descope for multi-package test-infra issues.** Add a row to the cross-package descope examples: *"Issue cites adding tests/infra to N packages → ship N bundles (one per package), each with its own PR. Name follow-up bundles in the PR description so the queue is explicit."* This wasn't a typing issue but the same gate applied — the skill should mention it for test-infra context.
+
+## Process inflation guard (HS-18/22/31 lesson)
+
+- Was the verified-by inflated? **No.** Issue cited `find packages/{react,svelte,vue} -name '*.test.ts*'` → 0 results. Re-running today: still 0. Clean evidence, no drift.
+- Document the inflation shape: **none**. Clean audit finding.


### PR DESCRIPTION
## Bundle: react-smoke-tests

Closes #82 (react portion only — svelte + vue ship as separate follow-up PRs per cross-package descope gate)

## Summary

`packages/react/` previously had 0 test files. Added `packages/react/tests/smoke.test.ts` with 6 cases covering the public surface — exports exist, arity is right, type contracts compile.

Strategy: pure smoke (no React render). React hooks throw \"Invalid hook call\" outside a render context, and pulling in `@testing-library/react` + `happy-dom` for one smoke test is scope creep. The `AgentStreamEvent._tag` contract IS load-bearing (the hook's SSE parser switches on these strings) and the compile-time check catches runtime renames before prod silently misses events.

## Verification

- `bun test packages/react/` ✅ — 6 pass / 0 fail
- `bunx turbo run typecheck --filter=@reactive-agents/react` ✅
- `bunx turbo run build` ✅ — 38/38
- Verified-by recheck: `find packages/react -name '*.test.ts*'` → 1 (was 0)

## Test coverage

| # | Case |
|---|------|
| 1 | `useAgent` exported as function, arity ≥1 |
| 2 | `useAgentStream` exported as function, arity ≥1 |
| 3 | `AgentHookState` union covers `idle`/`streaming`/`completed`/`error` |
| 4 | `AgentStreamEvent._tag` covers `TextDelta`/`StreamCompleted`/`StreamCancelled`/`StreamError` |
| 5 | `UseAgentReturn` shape reachable at compile time |
| 6 | `UseAgentStreamReturn` shape reachable at compile time |

## Out of scope (deferred)

- `packages/svelte/` smoke tests — follow-up bundle `bundle/svelte-smoke-tests`
- `packages/vue/` smoke tests — follow-up bundle `bundle/vue-smoke-tests`
- Behavioral hook coverage via React render — follow-up bundle once test-infra investment is justified
- Extracting fetch/SSE logic into pure helpers — refactor, separate from #82's \"add tests\" scope

## Note on workspace test flake

`packages/diagnose/` shows 2 failures in workspace test mode (`bun test` from root) that don't reproduce in isolation (`bun test packages/diagnose/` → 35/0). Pre-existing test-order flake unrelated to this bundle. Same flake class as the prior #99 httpbin issue (passed on retry).

## Plan + Retro

- Plan: `wiki/Planning/Implementation-Plans/2026-05-22-react-smoke-tests.md`
- Retro: Phase 7 to come post-PR