### PR TITLE
test(svelte): add smoke + behavioral coverage (HS-26 svelte portion)

### DIFF
--- a/.agents/skills/execute-backlog/SKILL.md
+++ b/.agents/skills/execute-backlog/SKILL.md
@@ -159,6 +159,18 @@ Issues: #N, #N, #N
 - If any unit depends on infra not in the repo → mark `blocked` on that issue, drop from bundle
 - If two units conflict (same file, conflicting changes) → sequence them, never parallelize
 
+**Substrate-aware test strategy (added 2026-05-22 v8).** When the bundle adds tests to a new framework/package, identify the test substrate up front. Three classes:
+
+| Substrate | Examples | Default coverage |
+|-----------|----------|------------------|
+| **Render-bound** | React hooks, Vue `setup()`, web components | Public-surface smoke + type contracts. Behavioral via render = follow-up bundle (justify the `@testing-library/X` + happy-dom investment separately). |
+| **Framework-agnostic** | Svelte stores (`writable`), Solid signals, Effect.Effect | Behavioral coverage with mocked I/O (e.g., `globalThis.fetch = async () => new Response(...)`). No DOM/render needed. |
+| **Pure** | Plain JS factories, helpers, parsers | Behavioral coverage directly. No mocking infrastructure beyond stub inputs. |
+
+Picking the wrong default = scope creep (render-bound bundle pulled into the test-infra rabbit hole) or coverage gap (framework-agnostic bundle capped at smoke when behavioral was cheap). (Reason: 2026-05-22 #82 spawn — react bundle (#100) capped at 6 smoke cases due to render-context requirement; svelte bundle (#101) shipped 13 cases including 9 behavioral because stores work in any runtime. Coverage gap would have been ~half if both bundles defaulted to "smoke only".)
+
+When in doubt, write one case at the framework-agnostic tier and see if it runs under bare `bun:test`. If yes, proceed behavioral. If "Invalid hook call" / setup errors → drop to smoke + name the follow-up bundle.
+
 Read the `superpowers:writing-plans` skill conventions (location override: `wiki/Planning/Implementation-Plans/`).
 
 **Fire-site reachability check (added 2026-05-21 v4):** before designing integration-style tests for any unit, grep the call graph to verify the test scenario will actually exercise the code under fix. A hook/handler/wrapper can be **registered** without being **fired** if the test scenario routes through an alternate code path (e.g., `withTestScenario` short-circuits the reactive loop and bypasses `runner.ts:683` `runPhaseHooks`). Quick check:

--- a/packages/svelte/tests/smoke.test.ts
+++ b/packages/svelte/tests/smoke.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Smoke + behavioral coverage for `@reactive-agents/svelte` — closes HS-26
+ * (svelte portion of #82). Vue portion tracked as separate follow-up bundle.
+ *
+ * Unlike React hooks, Svelte store factories (`createAgent`, `createAgentStream`)
+ * are pure functions — no render context required, so we can call them
+ * directly under `bun:test`. This gives real behavioral coverage of state
+ * transitions via `subscribe` callbacks + a mocked `fetch`.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  createAgent,
+  createAgentStream,
+  type AgentStreamEvent,
+  type AgentHookState,
+  type UseAgentReturn,
+  type UseAgentStreamReturn,
+  type AgentState,
+  type AgentStreamState,
+} from "../src/index.js";
+
+type FetchFn = typeof globalThis.fetch;
+
+function captureSubscribe<T>(store: { subscribe: (cb: (v: T) => void) => () => void }) {
+  const states: T[] = [];
+  const unsub = store.subscribe((s) => states.push(s));
+  return { states, unsub };
+}
+
+describe("@reactive-agents/svelte — public surface", () => {
+  it("exports createAgent + createAgentStream as functions", () => {
+    expect(typeof createAgent).toBe("function");
+    expect(typeof createAgentStream).toBe("function");
+  });
+
+  it("type-checks AgentHookState union", () => {
+    const states: AgentHookState[] = ["idle", "streaming", "completed", "error"];
+    expect(states.length).toBe(4);
+  });
+
+  it("type-checks AgentStreamEvent._tag variants (load-bearing SSE contract)", () => {
+    const td: AgentStreamEvent = { _tag: "TextDelta", text: "x" } as AgentStreamEvent;
+    const sc: AgentStreamEvent = { _tag: "StreamCompleted", output: "y" } as AgentStreamEvent;
+    const sx: AgentStreamEvent = { _tag: "StreamCancelled" } as AgentStreamEvent;
+    const se: AgentStreamEvent = { _tag: "StreamError", cause: "boom" } as AgentStreamEvent;
+    expect([td._tag, sc._tag, sx._tag, se._tag]).toEqual([
+      "TextDelta",
+      "StreamCompleted",
+      "StreamCancelled",
+      "StreamError",
+    ]);
+  });
+
+  it("type-checks UseAgentReturn + UseAgentStreamReturn shapes (re-exported from runtime SSE contract)", () => {
+    const _useAgent: () => UseAgentReturn = () => ({
+      output: null,
+      loading: false,
+      error: null,
+      run: async () => "",
+    });
+    const _useStream: () => UseAgentStreamReturn = () => ({
+      text: "",
+      events: [],
+      status: "idle",
+      error: null,
+      output: null,
+      run: () => undefined,
+      cancel: () => undefined,
+    });
+    expect(typeof _useAgent).toBe("function");
+    expect(typeof _useStream).toBe("function");
+  });
+});
+
+describe("createAgent — behavioral", () => {
+  let originalFetch: FetchFn | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it("returns a store with subscribe + run", () => {
+    const agent = createAgent("/api/agent");
+    expect(typeof agent.subscribe).toBe("function");
+    expect(typeof agent.run).toBe("function");
+  });
+
+  it("initializes store with idle shape", () => {
+    const agent = createAgent("/api/agent");
+    const { states, unsub } = captureSubscribe<AgentState>(agent);
+    expect(states[0]).toEqual({ output: null, loading: false, error: null });
+    unsub();
+  });
+
+  it("transitions loading → output on successful fetch", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ output: "hello world" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as FetchFn;
+
+    const agent = createAgent("/api/agent");
+    const { states, unsub } = captureSubscribe<AgentState>(agent);
+
+    const result = await agent.run("hi");
+    expect(result).toBe("hello world");
+
+    // Expect: idle → loading → completed
+    expect(states[0]).toEqual({ output: null, loading: false, error: null });
+    expect(states.some((s) => s.loading === true)).toBe(true);
+    const final = states[states.length - 1]!;
+    expect(final.loading).toBe(false);
+    expect(final.output).toBe("hello world");
+    expect(final.error).toBeNull();
+
+    unsub();
+  });
+
+  it("transitions to error state on non-OK response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("nope", { status: 500, statusText: "Internal Server Error" })) as FetchFn;
+
+    const agent = createAgent("/api/agent");
+    const { states, unsub } = captureSubscribe<AgentState>(agent);
+
+    await expect(agent.run("hi")).rejects.toThrow(/HTTP 500/);
+
+    const final = states[states.length - 1]!;
+    expect(final.loading).toBe(false);
+    expect(final.error).toContain("HTTP 500");
+    expect(final.output).toBeNull();
+
+    unsub();
+  });
+});
+
+describe("createAgentStream — behavioral", () => {
+  let originalFetch: FetchFn | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it("returns a store with subscribe + run + cancel", () => {
+    const agent = createAgentStream("/api/agent");
+    expect(typeof agent.subscribe).toBe("function");
+    expect(typeof agent.run).toBe("function");
+    expect(typeof agent.cancel).toBe("function");
+  });
+
+  it("initializes store with idle shape", () => {
+    const agent = createAgentStream("/api/agent");
+    const { states, unsub } = captureSubscribe<AgentStreamState>(agent);
+    expect(states[0]).toEqual({
+      text: "",
+      events: [],
+      status: "idle",
+      error: null,
+      output: null,
+    });
+    unsub();
+  });
+
+  it("accumulates TextDelta events and completes on StreamCompleted", async () => {
+    // Encode an SSE stream with 3 deltas + a completion event
+    const sseBody = [
+      `data: ${JSON.stringify({ _tag: "TextDelta", text: "Hel" })}`,
+      "",
+      `data: ${JSON.stringify({ _tag: "TextDelta", text: "lo " })}`,
+      "",
+      `data: ${JSON.stringify({ _tag: "TextDelta", text: "world" })}`,
+      "",
+      `data: ${JSON.stringify({ _tag: "StreamCompleted", output: "Hello world" })}`,
+      "",
+    ].join("\n");
+
+    globalThis.fetch = (async () =>
+      new Response(sseBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as FetchFn;
+
+    const agent = createAgentStream("/api/agent");
+    const { states, unsub } = captureSubscribe<AgentStreamState>(agent);
+
+    await agent.run("hi");
+
+    const final = states[states.length - 1]!;
+    expect(final.status).toBe("completed");
+    expect(final.text).toBe("Hello world");
+    expect(final.output).toBe("Hello world");
+    expect(final.events.length).toBe(4);
+    expect(final.events.map((e) => e._tag)).toEqual([
+      "TextDelta",
+      "TextDelta",
+      "TextDelta",
+      "StreamCompleted",
+    ]);
+
+    unsub();
+  });
+
+  it("transitions to error state on StreamError event", async () => {
+    const sseBody = [
+      `data: ${JSON.stringify({ _tag: "StreamError", cause: "model exploded" })}`,
+      "",
+    ].join("\n");
+
+    globalThis.fetch = (async () =>
+      new Response(sseBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as FetchFn;
+
+    const agent = createAgentStream("/api/agent");
+    const { states, unsub } = captureSubscribe<AgentStreamState>(agent);
+
+    await agent.run("hi");
+
+    const final = states[states.length - 1]!;
+    expect(final.status).toBe("error");
+    expect(final.error).toBe("model exploded");
+
+    unsub();
+  });
+
+  it("cancel() returns the store to idle", () => {
+    const agent = createAgentStream("/api/agent");
+    const { states, unsub } = captureSubscribe<AgentStreamState>(agent);
+
+    agent.cancel();
+
+    const final = states[states.length - 1]!;
+    expect(final.status).toBe("idle");
+
+    unsub();
+  });
+});

--- a/wiki/Hot.md
+++ b/wiki/Hot.md
@@ -10,7 +10,29 @@ updated: 2026-05-21
 
 ---
 
-## Latest Session (2026-05-22, mid) — execute-backlog v7 + #100 PR
+## Latest Session (2026-05-22, mid+1) — execute-backlog v8 + #101 PR
+
+**Bundle:** `svelte-smoke-tests` (#82 partial, svelte portion).
+
+- **Fix:** `packages/svelte/tests/smoke.test.ts` — 13 cases: 4 public-surface + 4 `createAgent` behavioral + 5 `createAgentStream` behavioral. Mock `globalThis.fetch` with `new Response(...)` (JSON + SSE bodies). State transitions captured via `subscribe`.
+- **Substrate decision:** Svelte stores are pure JS factories (no render context). Behavioral coverage cheap — got 9 behavioral cases above the smoke ceiling. Stronger than react bundle (#100, 6 smoke only) because the substrate allowed it.
+- **SSE happy-path covered;** chunked-buffer fuzz deferred (deltas split across read boundaries — needs multi-chunk fetch mock).
+- **Verified-by recheck:** `find packages/svelte -name '*.test.ts*'` → 1 (was 0). Suite: svelte 13/0; build 38/38.
+- **Branch:** `bundle/svelte-smoke-tests`; **PR:** #101 (companion to PR #100).
+- **Skill amendment (v8):** Phase 3 PLAN — codify substrate-aware test strategy. Three substrate classes (render-bound / framework-agnostic / pure). Default coverage tier matches substrate. Picking wrong tier = scope creep or coverage gap. Bundle #100 vs #101 = case study.
+
+### Session arc (5 bundles, 6 PRs queued)
+- 2026-05-21 night → `bundle/harness-lifecycle-hook-errors` (#74 HS-14) → PR #97
+- 2026-05-21 night+1 → `bundle/runtime-think-phase-typing` (#73 HS-08) → PR #98
+- 2026-05-22 early → `bundle/tests-stale-m1-red-cleanup` (#80 HS-24) → PR #99
+- 2026-05-22 mid → `bundle/react-smoke-tests` (#82 react) → PR #100
+- 2026-05-22 mid+1 → `bundle/svelte-smoke-tests` (#82 svelte) → PR #101
+
+Total ~2h40m wall clock. Skill v3→v8 over 5 PRs. Next promised: `bundle/vue-smoke-tests` to fully close #82.
+
+---
+
+## Previous Session (2026-05-22, mid) — execute-backlog v7 + #100 PR
 
 **Bundle:** `react-smoke-tests` (#82 partial, react portion only).
 

--- a/wiki/Planning/Implementation-Plans/2026-05-22-svelte-smoke-tests.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-22-svelte-smoke-tests.md
@@ -1,0 +1,49 @@
+# Bundle: svelte-smoke-tests
+
+Date: 2026-05-22
+Budget: 30 min
+Issues: #82 (HS-26) — svelte portion only
+
+## Acceptance criteria
+
+- **#82 (svelte portion):** `packages/svelte/` ships at least one `*.test.ts` file. `find packages/svelte -name '*.test.ts'` returns ≥1 (was 0).
+
+## Cross-package descope
+
+Same as react bundle (`bundle/react-smoke-tests`, PR #100). Vue portion ships next as `bundle/vue-smoke-tests`.
+
+## Test-strategy decision
+
+Svelte stores (`writable` from `svelte/store`) are pure JS — work in any runtime, no render context required. **Behavioral coverage available without test-infra investment.** Three categories of tests:
+
+1. **Public-surface smoke** — export presence, type contracts for `AgentStreamEvent._tag` and `AgentHookState` (parity with react bundle for SSE contract drift detection).
+2. **`createAgent` behavioral** — store initial shape, loading/success/error state transitions via mocked `fetch`.
+3. **`createAgentStream` behavioral** — store initial shape, SSE parsing (TextDelta accumulation, StreamCompleted, StreamError), `cancel()` → idle.
+
+This is meaningfully stronger than the react bundle (which capped at smoke due to "Invalid hook call" outside render). Svelte's pure-function factory makes behavioral coverage cheap — no excuse to skip it.
+
+## Execution units
+
+1. **Unit 1 — `packages/svelte/tests/smoke.test.ts`.** 13 cases:
+   - 4 public-surface
+   - 4 `createAgent` (returns shape, idle init, success path, error path)
+   - 5 `createAgentStream` (returns shape, idle init, SSE delta+complete, SSE error, cancel)
+
+## Verification protocol
+
+- `rtk bun test packages/svelte/` → 13 pass / 0 fail
+- `rtk bun run typecheck` (in packages/svelte) → clean
+- `rtk bunx turbo run build` → 38/38
+- Verified-by recheck: `find packages/svelte -name '*.test.ts*'` → 1 result (was 0)
+
+## Out of scope (explicit)
+
+- `packages/vue/` smoke tests — follow-up bundle `bundle/vue-smoke-tests`
+- E2E test inside an actual Svelte component runtime — not needed; stores are framework-agnostic
+- Stress/edge SSE parsing (chunked deltas split across buffer boundaries) — current tests cover the happy path; chunked-buffer fuzz is a separate concern
+
+## Baseline (pre-EXECUTE)
+
+- `find packages/svelte -name '*.test.ts*'` → 0 results
+- Workspace test (root, prior session): 5334/0/26-skip (with intermittent diagnose flake — pre-existing)
+- Svelte package isolated: no tests, no test script

--- a/wiki/Research/Debriefs/2026-05-22-svelte-smoke-tests-execution-debrief.md
+++ b/wiki/Research/Debriefs/2026-05-22-svelte-smoke-tests-execution-debrief.md
@@ -1,0 +1,31 @@
+# Execution Retro: svelte-smoke-tests
+
+Date: 2026-05-22
+Budget: 30 min | Actual: ~20 min
+
+## Outcomes
+
+- Issues partially closed: #82 (HS-26) — svelte portion; vue portion remains as `bundle/vue-smoke-tests`
+- Net test delta: +13 / 0 (packages/svelte: 0 → 13 tests, file count: 0 → 1)
+- Net LOC delta: +295 (test + plan)
+- Verified-by recheck: `find packages/svelte -name '*.test.ts*'` → 1 (was 0)
+
+## What worked
+
+- **Behavioral over export-only because the substrate allowed it.** Svelte stores are pure JS — `writable` works in any runtime, no DOM. Skipped the export-presence-only ceiling that constrained the react bundle and got 9 behavioral cases for free.
+- **Native `Response`/`fetch` mocking is a one-liner per case.** No mocking library needed; `globalThis.fetch = async () => new Response(...)` covers both JSON and SSE bodies. The SSE-stream test passes a multi-event body as a single string and the existing parser handles `\n`-split lines + `data: ` prefix correctly.
+- **PR cross-link to companion bundle.** PR #101 references PR #100 (react portion) in the description. Reviewers see the full #82 closeout in two PRs without needing to chase issue comments.
+
+## What didn't
+
+- **Initial test for `cancel()` had a subtle race risk.** First draft called `cancel()` after `run()` was in-flight — but `run()` is async fire-and-forget (returns nothing), so capturing the cancellation transition was timing-dependent. Resolved by testing `cancel()` from idle state instead (it still flips `status` to `'idle'` defensively, even when no fetch is in flight, per the impl at `agent-stream.ts:38`). Coverage of `cancel()` mid-stream stays available for a follow-up.
+- **SSE happy-path only.** Did not exercise the chunked-buffer path where SSE deltas split across read boundaries. The current impl handles it via `buffer = lines.pop() ?? ""` — would need a stream that yields multiple chunks to test, not the single-`Response` body I used. Worth a follow-up if SSE issues surface, but pinning the basic contract is the higher-value first step.
+
+## Skill improvements (apply on next pass)
+
+1. **Phase 3 PLAN: codify "substrate-aware test strategy" as a checklist item.** When adding tests to a new framework/package, the first question is "does the substrate require a render context?" For React/Vue (render-bound), behavioral coverage is gated on test-infra investment. For Svelte stores / pure factory functions / Effect.Effect chains, behavioral coverage is free. Add to the PLAN section: *"Identify the test substrate: render-bound (React render context, Vue setup), framework-agnostic (Svelte store, plain JS factory), or pure (Effect/function). For framework-agnostic + pure, default to behavioral coverage; for render-bound, default to public-surface smoke + named follow-up bundle for behavioral via @testing-library/X."* Documents the cap that drove the react bundle's smaller scope vs svelte's stronger coverage.
+
+## Process inflation guard (HS-18/22/31 lesson)
+
+- Was the verified-by inflated? **No.** Same clean evidence as react bundle. Audit grep matched current state.
+- Document the inflation shape: **none**.


### PR DESCRIPTION
## Bundle: svelte-smoke-tests

Closes #82 (svelte portion only — vue portion ships as separate follow-up bundle `bundle/vue-smoke-tests`).
Companion to PR #100 (react portion).

## Summary

`packages/svelte/` previously had 0 test files. Added `packages/svelte/tests/smoke.test.ts` with **13 tests** — meaningfully stronger than the react bundle because Svelte stores are pure JS factories (no render context required, so behavioral coverage is cheap).

## Coverage

**Public-surface smoke (4)** — parity with react bundle for SSE contract drift detection:
- `createAgent` + `createAgentStream` exported as functions
- `AgentHookState` union covers `idle`/`streaming`/`completed`/`error`
- `AgentStreamEvent._tag` covers `TextDelta`/`StreamCompleted`/`StreamCancelled`/`StreamError` (load-bearing)
- `UseAgentReturn` + `UseAgentStreamReturn` shapes reachable at compile time

**`createAgent` behavioral (4)** via mocked `fetch`:
- `subscribe` + `run` shape
- idle initial state
- loading → output transitions on successful response
- non-OK response → error state (rejects + final store has `error`)

**`createAgentStream` behavioral (5)** via mocked SSE `fetch`:
- `subscribe` + `run` + `cancel` shape
- idle initial state
- SSE `TextDelta` accumulation + `StreamCompleted` transition (text builds across deltas, `status` flips to `completed`)
- `StreamError` event → error state
- `cancel()` → idle

## Verification

- `bun test packages/svelte/` ✅ — 13 pass / 0 fail
- `bun run typecheck` (packages/svelte) ✅ — clean
- `bunx turbo run build` ✅ — 38/38
- Verified-by recheck: `find packages/svelte -name '*.test.ts*'` → 1 (was 0)

## Out of scope (deferred)

- `packages/vue/` smoke tests — follow-up `bundle/vue-smoke-tests`
- E2E inside a Svelte component runtime — not needed; stores are framework-agnostic
- Chunked-buffer SSE fuzz (deltas split across read boundaries) — current tests cover happy path

## Plan + Retro

- Plan: `wiki/Planning/Implementation-Plans/2026-05-22-svelte-smoke-tests.md`
- Retro: Phase 7 to come post-PR