### PR TITLE
test(vue): add smoke + behavioral coverage; fix StreamError swallow (HS-26 vue portion)

### DIFF
--- a/.agents/skills/execute-backlog/SKILL.md
+++ b/.agents/skills/execute-backlog/SKILL.md
@@ -84,6 +84,15 @@ If the **sum** of equivalence-class matches reproduces the claimed count, procee
 
 Output: candidate set, sorted by `priority:p0` > `p1` > `p2` > `p3`, then by `verified` label (verified issues rank higher), then drift-clean before drift-detected.
 
+**Cross-package consistency probe (added 2026-05-22 v9).** When the issue touches per-framework / per-platform packages providing equivalent APIs (e.g., `@reactive-agents/react` + `@reactive-agents/svelte` + `@reactive-agents/vue` all exporting `useAgentStream`-style hooks/factories), briefly diff the impl shape across siblings:
+
+```bash
+# Side-by-side compare of equivalent files
+diff packages/<sibling-a>/src/<file>.ts packages/<sibling-b>/src/<file>.ts | head -40
+```
+
+Same name + equivalent signature + **divergent behavior** = latent defect. Surface in the plan's "Adjacent improvement found" section. Fix opportunistically per the test+fix combo rule (Phase 4 v9). (Reason: 2026-05-22 #82 closeout — vue's `useAgentStream.StreamError` branch threw + was caught by inner try/catch; svelte's equivalent branch used direct `next.error = …; next.status = "error"` and worked correctly. Sibling diff would have flagged the divergence before the test had to.)
+
 ---
 
 ## Phase 2 — BUNDLE
@@ -285,10 +294,18 @@ Failing any of these means the deletion missed adjacent dead-code; either expand
 - Test suite gains net-new failures → same as above
 - Effort blows past unit estimate by 2× → mark issue `over-budget` label, defer, continue
 
+**Test+fix combo bundles (added 2026-05-22 v9).** When a behavioral RED test surfaces an impl bug during a test-coverage bundle, the fix lands in the same PR. The PR title combines verbs: `test(X): add coverage; fix Y`. Allowed when **all** apply:
+
+1. The fix is ≤10 lines.
+2. The fix mirrors an existing-working pattern in a sibling package, OR passes a code-reviewer agent for correctness.
+3. The fix is covered by the same test that surfaced it (test serves as regression check).
+
+If any of those fail, **descope**: file the bug as a separate issue and ship the bundle with the test marked `test.skip` / `xfail` referencing the new issue. (Reason: 2026-05-22 #82 vue portion — behavioral SSE-error test failed because `use-agent-stream.ts:76-78` threw inside an inner `JSON.parse try/catch` that swallowed it. Svelte sibling used direct assignment, no throw. 2-line mirror fix landed in PR #102 alongside the regression test. Defended over "test-only PR + separate fix PR" because the swallow is invisible to types and would have stayed latent.)
+
 **Do NOT:**
 - Skip tests for time pressure
 - Use `as any` to silence types from the very issues you're closing
-- Mix unrelated changes into a single commit
+- Mix unrelated changes into a single commit (test+fix combo is NOT mixed — it's one observably-correct concern)
 
 ---
 

--- a/packages/vue/src/use-agent-stream.ts
+++ b/packages/vue/src/use-agent-stream.ts
@@ -74,7 +74,9 @@ export function useAgentStream(
               status.value = "completed";
               return;
             } else if (event._tag === "StreamError" && "cause" in event) {
-              throw new Error((event as { cause: string }).cause);
+              error.value = (event as { cause: string }).cause;
+              status.value = "error";
+              return;
             } else if (event._tag === "StreamCancelled") {
               status.value = "idle";
               return;

--- a/packages/vue/tests/smoke.test.ts
+++ b/packages/vue/tests/smoke.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Smoke + behavioral coverage for `@reactive-agents/vue` — closes HS-26
+ * vue portion (completes #82 with PRs #100 (react) + #101 (svelte)).
+ *
+ * Vue's Composition API `ref()` from `vue/reactivity` works outside a
+ * component `setup()` scope — same framework-agnostic substrate as svelte
+ * stores. Behavioral coverage is cheap via mocked `fetch` + `.value` reads.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  useAgent,
+  useAgentStream,
+  type AgentStreamEvent,
+  type AgentHookState,
+} from "../src/index.js";
+
+type FetchFn = typeof globalThis.fetch;
+
+describe("@reactive-agents/vue — public surface", () => {
+  it("exports useAgent + useAgentStream as functions", () => {
+    expect(typeof useAgent).toBe("function");
+    expect(typeof useAgentStream).toBe("function");
+  });
+
+  it("type-checks AgentHookState union", () => {
+    const states: AgentHookState[] = ["idle", "streaming", "completed", "error"];
+    expect(states.length).toBe(4);
+  });
+
+  it("type-checks AgentStreamEvent._tag variants (load-bearing SSE contract)", () => {
+    const td: AgentStreamEvent = { _tag: "TextDelta", text: "x" } as AgentStreamEvent;
+    const sc: AgentStreamEvent = { _tag: "StreamCompleted", output: "y" } as AgentStreamEvent;
+    const sx: AgentStreamEvent = { _tag: "StreamCancelled" } as AgentStreamEvent;
+    const se: AgentStreamEvent = { _tag: "StreamError", cause: "boom" } as AgentStreamEvent;
+    expect([td._tag, sc._tag, sx._tag, se._tag]).toEqual([
+      "TextDelta",
+      "StreamCompleted",
+      "StreamCancelled",
+      "StreamError",
+    ]);
+  });
+});
+
+describe("useAgent — behavioral", () => {
+  let originalFetch: FetchFn | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it("returns readonly refs + run function", () => {
+    const agent = useAgent("/api/agent");
+    expect(typeof agent.run).toBe("function");
+    // Refs are objects with a `.value` accessor
+    expect(agent.output.value).toBeNull();
+    expect(agent.loading.value).toBe(false);
+    expect(agent.error.value).toBeNull();
+  });
+
+  it("flips loading.value during fetch and resolves output on success", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ output: "vue says hi" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as FetchFn;
+
+    const agent = useAgent("/api/agent");
+    const promise = agent.run("hi");
+    expect(agent.loading.value).toBe(true);
+
+    const result = await promise;
+    expect(result).toBe("vue says hi");
+    expect(agent.loading.value).toBe(false);
+    expect(agent.output.value).toBe("vue says hi");
+    expect(agent.error.value).toBeNull();
+  });
+
+  it("captures error.value + re-throws on non-OK response", async () => {
+    globalThis.fetch = (async () =>
+      new Response("nope", { status: 503, statusText: "Service Unavailable" })) as FetchFn;
+
+    const agent = useAgent("/api/agent");
+    await expect(agent.run("hi")).rejects.toThrow(/HTTP 503/);
+    expect(agent.loading.value).toBe(false);
+    expect(agent.error.value).toContain("HTTP 503");
+    expect(agent.output.value).toBeNull();
+  });
+
+  it("falls back to data.result when data.output is absent", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ result: "fallback" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as FetchFn;
+
+    const agent = useAgent("/api/agent");
+    const result = await agent.run("hi");
+    expect(result).toBe("fallback");
+    expect(agent.output.value).toBe("fallback");
+  });
+});
+
+describe("useAgentStream — behavioral", () => {
+  let originalFetch: FetchFn | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it("returns readonly refs + run + cancel", () => {
+    const agent = useAgentStream("/api/agent");
+    expect(typeof agent.run).toBe("function");
+    expect(typeof agent.cancel).toBe("function");
+    expect(agent.text.value).toBe("");
+    expect(agent.events.value).toEqual([]);
+    expect(agent.status.value).toBe("idle");
+    expect(agent.error.value).toBeNull();
+    expect(agent.output.value).toBeNull();
+  });
+
+  it("accumulates TextDelta + completes on StreamCompleted", async () => {
+    const sseBody = [
+      `data: ${JSON.stringify({ _tag: "TextDelta", text: "Hel" })}`,
+      "",
+      `data: ${JSON.stringify({ _tag: "TextDelta", text: "lo " })}`,
+      "",
+      `data: ${JSON.stringify({ _tag: "TextDelta", text: "vue" })}`,
+      "",
+      `data: ${JSON.stringify({ _tag: "StreamCompleted", output: "Hello vue" })}`,
+      "",
+    ].join("\n");
+
+    globalThis.fetch = (async () =>
+      new Response(sseBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as FetchFn;
+
+    const agent = useAgentStream("/api/agent");
+    await agent.run("hi");
+
+    expect(agent.status.value).toBe("completed");
+    expect(agent.text.value).toBe("Hello vue");
+    expect(agent.output.value).toBe("Hello vue");
+    expect(agent.events.value.length).toBe(4);
+    expect(agent.events.value.map((e) => e._tag)).toEqual([
+      "TextDelta",
+      "TextDelta",
+      "TextDelta",
+      "StreamCompleted",
+    ]);
+  });
+
+  it("flips status.value to 'error' on StreamError event", async () => {
+    const sseBody = [
+      `data: ${JSON.stringify({ _tag: "StreamError", cause: "vue boom" })}`,
+      "",
+    ].join("\n");
+
+    globalThis.fetch = (async () =>
+      new Response(sseBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      })) as FetchFn;
+
+    const agent = useAgentStream("/api/agent");
+    await agent.run("hi");
+
+    expect(agent.status.value).toBe("error");
+    expect(agent.error.value).toBe("vue boom");
+  });
+
+  it("captures error.value when fetch rejects (non-OK status)", async () => {
+    globalThis.fetch = (async () =>
+      new Response("err", { status: 502, statusText: "Bad Gateway" })) as FetchFn;
+
+    const agent = useAgentStream("/api/agent");
+    await agent.run("hi");
+
+    expect(agent.status.value).toBe("error");
+    expect(agent.error.value).toContain("HTTP 502");
+  });
+
+  it("cancel() flips status.value to 'idle'", () => {
+    const agent = useAgentStream("/api/agent");
+    agent.cancel();
+    expect(agent.status.value).toBe("idle");
+  });
+});

--- a/wiki/Hot.md
+++ b/wiki/Hot.md
@@ -10,7 +10,37 @@ updated: 2026-05-21
 
 ---
 
-## Latest Session (2026-05-22, mid+1) — execute-backlog v8 + #101 PR
+## Latest Session (2026-05-22, mid+2) — execute-backlog v9 + #102 PR + #103 flake issue
+
+**Bundle:** `vue-smoke-tests` (closes #82 entirely alongside #100 + #101).
+
+- **Coverage:** `packages/vue/tests/smoke.test.ts` — 12 tests, 3 surface + 9 behavioral via mocked `fetch`. Vue refs framework-agnostic (per v8 substrate classification).
+- **Bug fixed (test+fix combo):** `packages/vue/src/use-agent-stream.ts:76-78` `StreamError` branch threw `new Error(cause)` inside inner JSON.parse try/catch → swallowed → status stuck at `"streaming"` forever. Fix mirrors svelte impl: direct `error.value`/`status.value` assignment. 2-line behavior fix; the failing test is now the regression check.
+- **Verified-by recheck:** `find packages/vue -name '*.test.ts*'` → 1 (was 0). Suite: vue 12/0; build 38/38.
+- **Branch:** `bundle/vue-smoke-tests`; **PR:** #102.
+- **Filed follow-up:** **#103** — recurring `httpbin.org` external-network flake in `packages/tools/tests/builtin-handlers.test.ts`. Confirmed ≥2 occurrences (PR #99 initial CI, this session's workspace run). First instance of skill v7 "track recurring flakes in own issue" rule firing in practice.
+- **Skill amendments (v9):** (1) Phase 4 test+fix combo bundles — when behavioral RED surfaces a real bug, fix lands same PR if ≤10 lines + mirrors existing-working sibling + same test acts as regression check; otherwise descope to separate issue. (2) Phase 1 cross-package consistency probe — diff equivalent files across sibling per-framework packages before locking the bundle; divergent behavior in equivalent APIs = latent defect signal.
+
+### Session arc (6 bundles, 6 PRs queued, 1 issue filed)
+- 2026-05-21 night → `bundle/harness-lifecycle-hook-errors` (#74 HS-14) → PR #97
+- 2026-05-21 night+1 → `bundle/runtime-think-phase-typing` (#73 HS-08) → PR #98
+- 2026-05-22 early → `bundle/tests-stale-m1-red-cleanup` (#80 HS-24) → PR #99
+- 2026-05-22 mid → `bundle/react-smoke-tests` (#82 react) → PR #100
+- 2026-05-22 mid+1 → `bundle/svelte-smoke-tests` (#82 svelte) → PR #101
+- 2026-05-22 mid+2 → `bundle/vue-smoke-tests` (#82 vue, +bug fix) → PR #102 + filed #103 (flake)
+
+Total ~3h wall clock for 6 bundles. Skill v3 → v9 across 6 PRs. CI on #97-#101 all green; #102 pending.
+
+### Pattern this session
+PRs alternated between two shapes: **typing/refactor bundles** (#97, #98, #99, #80 cleanup) and **test-coverage bundles** (#100/#101/#102 closing #82). Skill amendments specifically codify the shape differences:
+- Local widening + boundary helper for typing (v5)
+- Dead-code sweep + pure-deletion verified-by triad (v6)
+- Substrate-aware test strategy + multi-package split (v7-v8)
+- Test+fix combo + cross-package consistency probe (v9)
+
+---
+
+## Previous Session (2026-05-22, mid+1) — execute-backlog v8 + #101 PR
 
 **Bundle:** `svelte-smoke-tests` (#82 partial, svelte portion).
 
@@ -20,15 +50,6 @@ updated: 2026-05-21
 - **Verified-by recheck:** `find packages/svelte -name '*.test.ts*'` → 1 (was 0). Suite: svelte 13/0; build 38/38.
 - **Branch:** `bundle/svelte-smoke-tests`; **PR:** #101 (companion to PR #100).
 - **Skill amendment (v8):** Phase 3 PLAN — codify substrate-aware test strategy. Three substrate classes (render-bound / framework-agnostic / pure). Default coverage tier matches substrate. Picking wrong tier = scope creep or coverage gap. Bundle #100 vs #101 = case study.
-
-### Session arc (5 bundles, 6 PRs queued)
-- 2026-05-21 night → `bundle/harness-lifecycle-hook-errors` (#74 HS-14) → PR #97
-- 2026-05-21 night+1 → `bundle/runtime-think-phase-typing` (#73 HS-08) → PR #98
-- 2026-05-22 early → `bundle/tests-stale-m1-red-cleanup` (#80 HS-24) → PR #99
-- 2026-05-22 mid → `bundle/react-smoke-tests` (#82 react) → PR #100
-- 2026-05-22 mid+1 → `bundle/svelte-smoke-tests` (#82 svelte) → PR #101
-
-Total ~2h40m wall clock. Skill v3→v8 over 5 PRs. Next promised: `bundle/vue-smoke-tests` to fully close #82.
 
 ---
 
@@ -44,14 +65,6 @@ Total ~2h40m wall clock. Skill v3→v8 over 5 PRs. Next promised: `bundle/vue-sm
 - **Branch:** `bundle/react-smoke-tests`; **PR:** #100.
 - **Skill amendments (v7):** (1) Phase 5 workspace-test-flake protocol — accept workspace failures when isolation passes + failure isn't in touched package + not a verified-by recheck. Track recurring flakes in own issue. (2) Phase 2 multi-package test-infra split — same descope rule as typing applies to test-infra issues.
 
-### Session arc (4 bundles, 2 calendar days)
-- 2026-05-21 night → `bundle/harness-lifecycle-hook-errors` (#74 HS-14) → PR #97
-- 2026-05-21 night+1 → `bundle/runtime-think-phase-typing` (#73 HS-08) → PR #98
-- 2026-05-22 early → `bundle/tests-stale-m1-red-cleanup` (#80 HS-24) → PR #99
-- 2026-05-22 mid → `bundle/react-smoke-tests` (#82 react portion) → PR #100
-
-All four branched off `origin/main` clean. Total ~2h15m wall clock. Skill SKILL.md amendments accumulated v3→v7 across the four PRs; each PR carries its own delta — when all merge, deltas compose on main.
-
 ---
 
 ## Previous Session (2026-05-22, early) — execute-backlog v6 + #99 PR
@@ -64,13 +77,6 @@ All four branched off `origin/main` clean. Total ~2h15m wall clock. Skill SKILL.
 - **Suite:** reactive-intelligence 455/0/2-skip; build 38/38. File LOC 257 → 77.
 - **Branch:** `bundle/tests-stale-m1-red-cleanup`; **PR:** #99.
 - **Skill amendments (v6):** (1) Phase 4 dead-code sweep generalized from dead-cast — applies to `test.skip`, helpers, interfaces, TODOs. (2) Phase 5 pure-deletion verified-by — strengthen with test-count delta + zero inbound refs + zero dangling imports.
-
-### Session arc (3 bundles, 2 calendar days)
-- 2026-05-21 night → `bundle/harness-lifecycle-hook-errors` (#74 HS-14) → PR #97
-- 2026-05-21 night+1 → `bundle/runtime-think-phase-typing` (#73 HS-08) → PR #98
-- 2026-05-22 early → `bundle/tests-stale-m1-red-cleanup` (#80 HS-24) → PR #99
-
-All three branched off `origin/main` clean per same-session multi-bundle protocol (v5). Disjoint scopes, independent PRs, ~2h wall clock total.
 
 ---
 

--- a/wiki/Planning/Implementation-Plans/2026-05-22-vue-smoke-tests.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-22-vue-smoke-tests.md
@@ -1,0 +1,49 @@
+# Bundle: vue-smoke-tests
+
+Date: 2026-05-22
+Budget: 30 min
+Issues: #82 (HS-26) — vue portion (completes #82 with PRs #100 + #101)
+
+## Acceptance criteria
+
+- **#82 (vue portion):** `packages/vue/` ships ≥1 `*.test.ts`. `find packages/vue -name '*.test.ts'` returns ≥1 (was 0).
+- Bug surfaced during test authoring: `StreamError` event in `useAgentStream` was silently swallowed (throw inside loop caught by inner try/catch). Fixed.
+
+## Cross-package descope
+
+Final partition of #82 (third bundle).
+
+## Test-strategy decision
+
+Vue Composition API `ref()` from `vue/reactivity` works outside `setup()` scope — same framework-agnostic substrate as svelte stores (skill v8). Behavioral coverage is the default tier.
+
+## Execution units
+
+1. **Unit 1 — `packages/vue/tests/smoke.test.ts`.** 12 cases:
+   - 3 public-surface
+   - 4 `useAgent` behavioral (refs shape, loading→output, error path, `data.result` fallback)
+   - 5 `useAgentStream` behavioral (refs shape, SSE deltas+complete, SSE error, HTTP error, cancel→idle)
+2. **Unit 2 — fix `useAgentStream` StreamError swallow.** Mirror svelte impl: direct `error.value`/`status.value` assignment instead of throwing (which was caught + swallowed by the inner `try{JSON.parse}catch` block).
+
+## Verification protocol
+
+- `rtk bun test packages/vue/` → 12 pass / 0 fail
+- `rtk bun run typecheck` (packages/vue) → clean
+- `rtk bunx turbo run build` → 38/38
+- Verified-by recheck: `find packages/vue -name '*.test.ts*'` → 1 (was 0)
+
+## Out of scope (explicit)
+
+- E2E inside a Vue component runtime — not needed; refs are reactivity-only, no `setup()` dependency
+- Chunked-buffer SSE fuzz — same scope as svelte bundle's deferral
+- Behavioral coverage equivalent for `packages/react/` — blocked by render context, follow-up `bundle/react-behavioral-tests`
+
+## Baseline (pre-EXECUTE)
+
+- `find packages/vue -name '*.test.ts*'` → 0 results
+- Workspace test (root, prior session): 5334/0/26-skip with intermittent pre-existing flakes
+- Vue package isolated: no tests, no test script
+
+## Adjacent improvement found
+
+`packages/vue/src/use-agent-stream.ts:76-78` — `StreamError` branch threw inside the JSON.parse try/catch. Inner catch swallowed it. Result: any SSE `StreamError` event in vue UIs was silently dropped — `status` stayed `streaming`, `error` stayed `null`, never recovered. Fixed by mirroring the svelte pattern (`error.value = ...; status.value = "error"; return;`).

--- a/wiki/Research/Debriefs/2026-05-22-vue-smoke-tests-execution-debrief.md
+++ b/wiki/Research/Debriefs/2026-05-22-vue-smoke-tests-execution-debrief.md
@@ -1,0 +1,34 @@
+# Execution Retro: vue-smoke-tests
+
+Date: 2026-05-22
+Budget: 30 min | Actual: ~25 min
+
+## Outcomes
+
+- Issue closed (entirely): #82 (HS-26) — vue portion finishes the trilogy alongside PR #100 + PR #101
+- Bug fixed: `packages/vue/src/use-agent-stream.ts` `StreamError` swallow (surfaced by RED, GREEN'd with svelte-pattern mirror)
+- Issue filed: #103 (recurring `httpbin.org` flake — first instance of the skill v7 "track recurring flakes in own issue" rule)
+- Net test delta: +12 / 0 (packages/vue: 0 → 12 tests, file count: 0 → 1)
+- Net LOC delta: +249
+
+## What worked
+
+- **Behavioral RED found a real bug, not a false positive.** The `StreamError → status: 'error'` test failed with `Received: "streaming"`. First instinct could have been "adjust test to match impl"; instead, traced through the SSE parser and found the inner JSON.parse `try/catch` swallowed the rethrow. Compared to svelte's working impl (direct assignment, no throw) — one-line fix. Test became the regression check. Real defect would have hit prod silently otherwise.
+- **Svelte-as-reference pattern.** When the vue bundle's coverage spec mirrored the svelte bundle's, divergent behavior surfaced quickly. Cross-package consistency check fell out of the test work for free.
+- **v6 dead-code/improvement-during-refactor rule activated.** Skill memory `feedback_flag_improvements_during_refactor.md` says: while in the code, fix adjacent small issues. Did exactly that. 2-line behavior fix landed in the same PR as the test that caught it.
+- **v7 flake-tracking rule fired correctly.** User reported 2 httpbin failures mid-bundle. Skill v7 says: workspace flakes unrelated to touched package don't block, but track recurring flakes in their own issue. Filed #103 with verified-by evidence (PR #99 + this session) and three fix-direction options. Skill text drove the right action without re-thinking the protocol.
+
+## What didn't
+
+- **Initial test missed the swallow path.** First draft of the SSE-error test passed because I wrote it against the assumed-correct contract, not the actual impl. Only when I ran it did RED appear. Lesson: in behavioral tests for parser-like code with try/catch boundaries, write the test against the SPEC (what should happen), then run — RED that surfaces a swallow is the test doing its job. (This is the inverse of writing the test against the current impl and trusting whatever it does.)
+- **One-line behavior change shipped in a "tests" bundle.** The PR title says `test(vue): ...; fix StreamError swallow` — mixing test+fix is borderline scope creep. Defended by: (a) RED would have stayed RED without the fix, (b) skill v6 explicitly allows adjacent improvements during refactors, (c) the fix is 2 lines mirroring an existing-working impl. Worth tracking if this pattern recurs — if 3+ bundles ship "test+fix" combos, the skill should codify the bundle type.
+
+## Skill improvements (apply on next pass)
+
+1. **Phase 4 EXECUTE: codify "test+fix combo bundle" as a recognized type.** When a behavioral RED surfaces an impl bug during a test-coverage bundle, the fix goes in the same PR (single concern: "make this code observably correct"). Add to Phase 4 EXECUTE: *"Behavioral test that fails on a real bug → the fix lands in the same bundle. The PR title combines verbs (`test(X): add coverage; fix Y`). The fix must be (a) ≤10 lines, (b) mirror an existing-working pattern in a sibling package OR pass a code-reviewer agent for correctness, (c) covered by the same test that surfaced it. If any of those fail, descope: file the bug as a separate issue and ship the bundle with the test marked `xfail` / `test.skip` referencing the new issue."*
+2. **Phase 1 SCAN: cross-package consistency probe.** When the issue touches per-framework packages (react/svelte/vue/solid/...) doing similar work, briefly compare the impl shape across siblings. Divergent behavior in the "same" abstraction is a defect signal. Add to Phase 1: *"For per-framework / per-platform packages providing equivalent APIs, diff the source files. Same name + same signature + different behavior = latent defect. Surface in the plan, fix opportunistically per the test+fix combo rule."*
+
+## Process inflation guard (HS-18/22/31 lesson)
+
+- Was the verified-by inflated? **No.** Original audit said zero tests in three packages; current state confirms it. Three follow-up bundles each closed one third cleanly.
+- **NEW inflation-shape category discovered.** The vue `StreamError` swallow was *latent* — the code looked correct on visual inspection (mirrored react's pattern roughly), and the impl is unreachable from typed exports (status remains "streaming" forever, but no compile-time error). A code review would have flagged it; the audit didn't because the file is small and superficially correct. Document: **"silent state-machine stuck states" can hide behind correct-looking code that catches its own errors.** Add to the audit-finding template's tip list.


### PR DESCRIPTION
## Bundle: vue-smoke-tests

Closes #82 (vue portion — final piece alongside PR #100 (react) and PR #101 (svelte)).

## Summary

`packages/vue/` previously had 0 test files. Added `packages/vue/tests/smoke.test.ts` with **12 tests** — parity with the svelte bundle (behavioral coverage via mocked fetch; vue refs are framework-agnostic, no setup() context needed).

## Bug found + fixed during test authoring

`packages/vue/src/use-agent-stream.ts:76-78` — the `StreamError` branch threw `new Error(cause)` inside the inner JSON.parse `try/catch`. The inner catch swallowed the throw. Result: any SSE `StreamError` event in vue UIs was silently dropped — `status` stayed `\"streaming\"`, `error` stayed `null`, never recovered.

**Fix:** mirror the svelte impl — direct `error.value = cause; status.value = \"error\"; return;` (no throw, no swallow). Surfaced by the SSE-error behavioral test; first assertion failed with `Expected: \"error\" / Received: \"streaming\"`. Real defect, not a test issue.

## Coverage

**Public-surface (3):**
- `useAgent` + `useAgentStream` exported as functions
- `AgentHookState` union covers `idle`/`streaming`/`completed`/`error`
- `AgentStreamEvent._tag` covers `TextDelta`/`StreamCompleted`/`StreamCancelled`/`StreamError` (load-bearing)

**`useAgent` behavioral (4):**
- refs shape (`.output.value`, `.loading.value`, `.error.value`)
- `loading.value` flips during fetch, `output.value` resolves on success
- captures `error.value` + re-throws on non-OK response
- falls back to `data.result` when `data.output` absent

**`useAgentStream` behavioral (5):**
- refs shape (text/events/status/error/output + run/cancel)
- SSE `TextDelta` accumulation + `StreamCompleted` transition
- `StreamError` event → status flips to `\"error\"` (regression test for the bug above)
- HTTP error → status `\"error\"` + error message captured
- `cancel()` → status `\"idle\"`

## Verification

- `bun test packages/vue/` ✅ — 12 pass / 0 fail
- `bun run typecheck` (packages/vue) ✅ — clean
- `bunx turbo run build` ✅ — 38/38
- Verified-by recheck: `find packages/vue -name '*.test.ts*'` → 1 (was 0)

## Out of scope (deferred)

- E2E inside Vue component runtime — refs are reactivity-only, no `setup()` dependency
- Chunked-buffer SSE fuzz — same deferral as svelte bundle
- React behavioral coverage — blocked by render context, follow-up `bundle/react-behavioral-tests` if/when test-infra investment justified

## Plan + Retro

- Plan: `wiki/Planning/Implementation-Plans/2026-05-22-vue-smoke-tests.md`
- Retro: Phase 7 to come post-PR