### PR TITLE
refactor(runtime): W26-B builder.ts buildEffect decomposition (-241 LOC)

### DIFF
--- a/packages/runtime/src/builder.ts
+++ b/packages/runtime/src/builder.ts
@@ -1,8 +1,4 @@
-import {
-    Effect,
-    Layer,
-    ManagedRuntime,
-} from 'effect'
+import { Effect, Layer } from 'effect'
 // createRuntime usage extracted to ./builder/build-effect/runtime-construction.ts (W25-B step 7)
 // createLightRuntime is no longer used directly from builder.ts.
 import type { MCPServerConfig } from './runtime.js'
@@ -15,16 +11,6 @@ import {
 // Re-export deriveGoalAchieved (public surface — was exported from builder.ts pre-W25).
 export { deriveGoalAchieved } from './builder/helpers.js'
 import { serializeBuilder } from './builder/to-config.js'
-import {
-    buildSubAgentTask,
-    type SubAgentTaskArgs as ExtractedSubAgentTaskArgs,
-} from './builder/build-effect/sub-agent-executor.js'
-import { createRemoteAgentToolRegistration } from './builder/build-effect/remote-agent-tools.js'
-import {
-    createLocalAgentToolRegistration,
-    createDynamicSpawnRegistrations,
-} from './builder/build-effect/local-agent-tools.js'
-import { buildToolInitLayer } from './builder/build-effect/tool-init-layer.js'
 import { composeHealthLayer } from './builder/build-effect/health-layer.js'
 import { composeTracingLayer } from './builder/build-effect/tracing-layer.js'
 import { ingestRagDocuments } from './builder/build-effect/rag-ingestion.js'
@@ -50,11 +36,9 @@ import type { ContextProfile } from '@reactive-agents/reasoning'
 import type { StrategySynthesisFields } from './reasoning-synthesis-fields.js'
 import type { CalibrationMode } from './types.js'
 import type {
-    ToolDefinition,
     ResultCompressionConfig,
     ShellExecuteConfig,
 } from '@reactive-agents/tools'
-import { shellExecuteTool, shellExecuteHandler } from '@reactive-agents/tools'
 import type { RemoteAgentClient } from '@reactive-agents/tools'
 import type { PromptTemplate } from '@reactive-agents/prompts'
 import type { StreamDensity } from './stream-types.js'

--- a/packages/runtime/src/builder.ts
+++ b/packages/runtime/src/builder.ts
@@ -28,6 +28,7 @@ import { buildToolInitLayer } from './builder/build-effect/tool-init-layer.js'
 import { composeHealthLayer } from './builder/build-effect/health-layer.js'
 import { composeTracingLayer } from './builder/build-effect/tracing-layer.js'
 import { ingestRagDocuments } from './builder/build-effect/rag-ingestion.js'
+import { fetchAndMergePricing } from './builder/build-effect/pricing-fetch.js'
 import { wireRiHooks, type RiHooks } from './builder/ri-wiring.js'
 import {
     buildBaseRuntimeAndEngine,
@@ -2122,23 +2123,15 @@ export class ReactiveAgentBuilder {
                 }
             }
 
-            // Automatically fetch remote pricing if a provider was configured
-            if (self._pricingProvider) {
-                try {
-                    const remotePricing =
-                        yield* self._pricingProvider.fetchPricing()
-                    self._pricingRegistry = {
-                        ...self._pricingRegistry,
-                        ...remotePricing,
-                    }
-                } catch (e) {
-                    if (self._strictValidation) {
-                        return yield* Effect.fail(e as Error)
-                    }
-                    console.warn(
-                        `[Pricing] Failed to fetch dynamic pricing — falling back to static map. ${e}`
-                    )
-                }
+            // Automatically fetch remote pricing if a provider was configured.
+            // Extracted to ./builder/build-effect/pricing-fetch.ts (W26-B step 1).
+            {
+                const { registry } = yield* fetchAndMergePricing({
+                    pricingProvider: self._pricingProvider,
+                    pricingRegistry: self._pricingRegistry,
+                    strict: self._strictValidation,
+                })
+                self._pricingRegistry = registry
             }
 
             const agentId = self._stableAgentId ?? `${self._name}-${Date.now()}`

--- a/packages/runtime/src/builder.ts
+++ b/packages/runtime/src/builder.ts
@@ -29,6 +29,7 @@ import { composeHealthLayer } from './builder/build-effect/health-layer.js'
 import { composeTracingLayer } from './builder/build-effect/tracing-layer.js'
 import { ingestRagDocuments } from './builder/build-effect/rag-ingestion.js'
 import { fetchAndMergePricing } from './builder/build-effect/pricing-fetch.js'
+import { setupParentContext } from './builder/build-effect/parent-context.js'
 import { wireRiHooks, type RiHooks } from './builder/ri-wiring.js'
 import {
     buildBaseRuntimeAndEngine,
@@ -2184,60 +2185,13 @@ export class ReactiveAgentBuilder {
                 yield* engine.registerHook(hook)
             }
 
-            // Mutable ref for parent execution context — updated by the execution
-            // engine during the ACT phase so sub-agent handlers can read the parent's
-            // accumulated tool results and forward them as context.
-            let parentExecutionContextRef: {
-                toolResults: Array<{ toolName: string; result: string }>
-                taskDescription?: string
-            } | null = null
+            // Parent-context wiring for sub-agent registrations.
+            // Extracted to ./builder/build-effect/parent-context.ts (W26-B step 2).
+            const parentCtx = setupParentContext()
+            const getParentContext = parentCtx.getParentContext
 
-            /** Lazily read parent context from the mutable ref. */
-            const getParentContext = ():
-                | import('@reactive-agents/tools').ParentContext
-                | undefined => {
-                if (!parentExecutionContextRef) return undefined
-                const ctx = parentExecutionContextRef
-                const items: Array<{ toolName: string; result: string }> =
-                    ctx.toolResults ?? []
-                if (items.length === 0 && !ctx.taskDescription) return undefined
-                return {
-                    toolResults: items.map((tr) => ({
-                        toolName: tr.toolName,
-                        result: tr.result,
-                    })),
-                    taskDescription: ctx.taskDescription,
-                }
-            }
-
-            // Register internal hook to capture parent context for sub-agent forwarding.
-            // Task description is pre-set by runEffect() before execution starts.
-            // This hook updates tool results after each ACT phase.
             if (agentTools.length > 0 || allowDynamicSubAgents) {
-                yield* engine.registerHook({
-                    phase: 'act' as const,
-                    timing: 'after' as const,
-                    handler: (ctx: ExecutionContext) =>
-                        Effect.sync(() => {
-                            const toolResults = (ctx.toolResults ?? []).map(
-                                (tr: any) => ({
-                                    toolName: String(
-                                        tr.toolName ?? tr.name ?? 'unknown'
-                                    ),
-                                    result: String(
-                                        tr.result ?? tr.output ?? ''
-                                    ).slice(0, 200),
-                                })
-                            )
-                            // Preserve task description set by runEffect(), update tool results
-                            parentExecutionContextRef = {
-                                toolResults,
-                                taskDescription:
-                                    parentExecutionContextRef?.taskDescription,
-                            }
-                            return ctx
-                        }),
-                })
+                yield* parentCtx.registerCaptureHook(engine)
             }
 
             // Register custom prompt templates if configured
@@ -2475,10 +2429,10 @@ export class ReactiveAgentBuilder {
                 // This ensures sub-agents spawned on the very first iteration have the full user prompt.
                 agentTools.length > 0 || allowDynamicSubAgents
                     ? (desc: string) => {
-                          if (parentExecutionContextRef) {
-                              parentExecutionContextRef.taskDescription = desc
+                          if (parentCtx.ref.current) {
+                              parentCtx.ref.current.taskDescription = desc
                           } else {
-                              parentExecutionContextRef = {
+                              parentCtx.ref.current = {
                                   toolResults: [],
                                   taskDescription: desc,
                               }

--- a/packages/runtime/src/builder.ts
+++ b/packages/runtime/src/builder.ts
@@ -31,6 +31,7 @@ import { ingestRagDocuments } from './builder/build-effect/rag-ingestion.js'
 import { fetchAndMergePricing } from './builder/build-effect/pricing-fetch.js'
 import { setupParentContext } from './builder/build-effect/parent-context.js'
 import { buildToolMcpRegistrations } from './builder/build-effect/tool-mcp-registrations.js'
+import { instantiateAgent } from './builder/build-effect/agent-instantiation.js'
 import { wireRiHooks, type RiHooks } from './builder/ri-wiring.js'
 import {
     buildBaseRuntimeAndEngine,
@@ -2255,57 +2256,23 @@ export class ReactiveAgentBuilder {
                 tracingConfig: self._tracingConfig,
             })
 
-            // Create a ManagedRuntime so all facade calls (run, subscribe, pause, etc.)
-            // share the same layer scope and the same service instances
-            // (EventBus, KillSwitch, etc.).
-            //
-            // The cast to `Layer<any, never, never>` collapses three boundary
-            // facts that TS can't see through the `unknown` triple:
-            //   • RIn = never — every dynamically-merged sub-layer in
-            //     createRuntime has had its requirements satisfied internally
-            //     (see runtime.ts), so the composed layer has no unprovided
-            //     deps.
-            //   • E   = never — layer construction is total at this point;
-            //     init failures throw, not flow through E.
-            //   • ROut = any — the materialised service union is opaque (15+
-            //     conditional optional services). ReactiveAgent stores it as
-            //     `ManagedRuntime<any, never>` and resolves services
-            //     on-demand at the `runPromise` boundary.
-            // This single cast replaces the 6× `Layer<any, any>` casts that
-            // previously papered over the same boundary mismatch.
-            const managedRuntime = ManagedRuntime.make(
-                fullRuntime as unknown as Layer.Layer<any, never, never>,
-            )
-            return new ReactiveAgent(
+            // ManagedRuntime + ReactiveAgent construction extracted to
+            // ./builder/build-effect/agent-instantiation.ts (W26-B step 4).
+            return instantiateAgent({
                 engine,
+                fullRuntime,
                 agentId,
-                managedRuntime,
-                mcpServers.map((s) => s.name),
-                !!gatewayOptions,
-                gatewayOptions?.heartbeat?.intervalMs,
-                !!gatewayOptions?.heartbeat?.instruction,
-                gatewayOptions?.persistMemoryAcrossRuns === true,
+                mcpServerNames: mcpServers.map((s) => s.name),
+                gatewayOptions,
                 streamDensity,
-                // Pass a callback so run() can set the task description before execution starts.
-                // This ensures sub-agents spawned on the very first iteration have the full user prompt.
-                agentTools.length > 0 || allowDynamicSubAgents
-                    ? (desc: string) => {
-                          if (parentCtx.ref.current) {
-                              parentCtx.ref.current.taskDescription = desc
-                          } else {
-                              parentCtx.ref.current = {
-                                  toolResults: [],
-                                  taskDescription: desc,
-                              }
-                          }
-                      }
-                    : undefined,
+                hasParentCallbacks: agentTools.length > 0 || allowDynamicSubAgents,
+                parentCtxRef: parentCtx.ref,
                 errorHandler,
                 sessionPersist,
                 sessionMaxAgeDays,
                 ragStore,
-                self._channelsConfig,
-                {
+                channelsConfig: self._channelsConfig,
+                capabilities: {
                     minIterations: self._minIterations,
                     taskContext: self._taskContext,
                     progressCheckpoint: self._progressCheckpoint,
@@ -2313,8 +2280,8 @@ export class ReactiveAgentBuilder {
                     outputValidator: self._outputValidator,
                     outputValidatorOptions: self._outputValidatorOptions,
                     customTermination: self._customTermination,
-                }
-            )
+                },
+            })
         }) as Effect.Effect<ReactiveAgent, Error>
     }
 }

--- a/packages/runtime/src/builder.ts
+++ b/packages/runtime/src/builder.ts
@@ -30,6 +30,7 @@ import { composeTracingLayer } from './builder/build-effect/tracing-layer.js'
 import { ingestRagDocuments } from './builder/build-effect/rag-ingestion.js'
 import { fetchAndMergePricing } from './builder/build-effect/pricing-fetch.js'
 import { setupParentContext } from './builder/build-effect/parent-context.js'
+import { buildToolMcpRegistrations } from './builder/build-effect/tool-mcp-registrations.js'
 import { wireRiHooks, type RiHooks } from './builder/ri-wiring.js'
 import {
     buildBaseRuntimeAndEngine,
@@ -2211,167 +2212,27 @@ export class ReactiveAgentBuilder {
             }
 
             // ── MCP servers, custom tools, agent tools: bake into the runtime layer ────
-            //
-            // Root cause of the scope bug: registrations done via `Effect.provide(runtime)`
-            // inside buildEffect() wrote into a ToolService from a throwaway scope. The
-            // ManagedRuntime used by run()/subscribe() creates a fresh scope on first use —
-            // so those registrations were invisible at execution time.
-            //
-            // Fix: Compose a Layer.effectDiscard into the runtime. The effectDiscard runs
-            // connectMCPServer() / register() during layer evaluation, INSIDE the
-            // ManagedRuntime scope. Because Layer.merge uses reference-identity memoization,
-            // the same ToolService instance (from baseRuntime) receives all registrations
-            // AND serves the engine — MCP tools are visible to the LLM.
-            let fullRuntime: Layer.Layer<unknown, unknown, unknown> =
-                runtimeWithCortex
-
-            if (
-                agentTools.length > 0 ||
-                allowDynamicSubAgents ||
-                mcpServers.length > 0 ||
-                (toolsOptions?.tools?.length ?? 0) > 0 ||
-                toolsOptions?.terminal !== undefined
-            ) {
-                const toolsMod = yield* Effect.promise(
-                    () => import('@reactive-agents/tools')
-                )
-
-                const {
-                    createAgentTool,
-                    createRemoteAgentTool,
-                    executeRemoteAgentTool,
-                } = toolsMod
-
-                // Collect (definition, handler) pairs — no registration yet.
-                type RegEntry = {
-                    def: ToolDefinition
-                    handler: (
-                        args: Record<string, unknown>
-                    ) => Effect.Effect<unknown, Error>
-                }
-                const registrations: RegEntry[] = []
-
-                for (const agentTool of agentTools) {
-                    if (agentTool.remoteUrl) {
-                        registrations.push(
-                            createRemoteAgentToolRegistration(
-                                {
-                                    name: agentTool.name,
-                                    remoteUrl: agentTool.remoteUrl,
-                                },
-                                {
-                                    createRemoteAgentTool,
-                                    executeRemoteAgentTool,
-                                }
-                            )
-                        )
-                    } else if (agentTool.agent) {
-                        registrations.push(
-                            createLocalAgentToolRegistration(agentTool, {
-                                toolsMod: {
-                                    createAgentTool,
-                                    createSubAgentExecutor:
-                                        toolsMod.createSubAgentExecutor,
-                                },
-                                agentId,
-                                getParentContext,
-                            })
-                        )
-                    }
-                }
-
-                // Mutable ref for the parent's ToolService — set during agentToolInitEffect,
-                // read by spawn handler at call time. This avoids duplicate MCP containers
-                // by letting sub-agents proxy tool calls through the parent's live connections.
-                let parentToolServiceRef: any = null
-
-                /** Per-task arguments for a single sub-agent dispatch. */
-                type SubAgentTaskArgs = {
-                    task: string
-                    name: string
-                    role?: string
-                    instructions?: string
-                    tone?: string
-                    tools?: string[]
-                }
-
-                // Register the built-in spawn-agent tool when dynamic sub-agents are enabled.
-                // The handler captures parentProvider/parentModel so spawned agents inherit
-                // the parent's LLM config without any extra wiring required.
-                if (allowDynamicSubAgents) {
-                    const defaultMaxIter =
-                        dynamicSubAgentOptions?.maxIterations ?? 4
-
-                    /**
-                     * Build and execute a single sub-agent task.
-                     * Shared by spawnHandler (singular) and spawnAgentsHandler (batch).
-                     *
-                     * Body lifted to ./builder/build-effect/sub-agent-executor.ts
-                     * (W25-T4). This wrapper captures local closure refs and
-                     * delegates — no behavior change.
-                     */
-                    const buildSingleSubAgentTask = (
-                        t: SubAgentTaskArgs
-                    ): Promise<
-                        import('@reactive-agents/tools').SubAgentResult
-                    > =>
-                        buildSubAgentTask(
-                            t as ExtractedSubAgentTaskArgs,
-                            {
-                                parentProvider,
-                                parentModel,
-                                defaultMaxIter,
-                                getParentToolService: () =>
-                                    parentToolServiceRef,
-                                mcpServers,
-                                parentReasoningOptions,
-                                parentEnableGuardrails,
-                                parentEnableObservability,
-                                parentObservabilityOptions,
-                                parentContextProfile,
-                                parentEnableCostTracking,
-                                getParentContext,
-                                toolsMod: {
-                                    createSubAgentExecutor:
-                                        toolsMod.createSubAgentExecutor,
-                                    ALWAYS_INCLUDE_TOOLS:
-                                        toolsMod.ALWAYS_INCLUDE_TOOLS,
-                                },
-                            }
-                        )
-
-                    for (const reg of createDynamicSpawnRegistrations({
-                        toolsMod: {
-                            createSpawnAgentTool: toolsMod.createSpawnAgentTool,
-                            createSpawnAgentsTool:
-                                toolsMod.createSpawnAgentsTool,
-                        },
-                        buildSubAgentTask: buildSingleSubAgentTask,
-                    })) {
-                        registrations.push(reg)
-                    }
-                }
-
-                // agentToolInitEffect body extracted to ./builder/build-effect/tool-init-layer.ts (W25-B step 3c)
-                const toolInitLayer = buildToolInitLayer(
+            // Extracted to ./builder/build-effect/tool-mcp-registrations.ts (W26-B step 3).
+            const { fullRuntime: fullRuntimeAfterTools } =
+                yield* buildToolMcpRegistrations({
                     runtimeWithCortex,
-                    {
-                        toolsMod: {
-                            ToolService: toolsMod.ToolService,
-                        },
-                        mcpServers,
-                        toolsOptions,
-                        registrations,
-                        shellExecuteTool,
-                        shellExecuteHandler,
-                        onToolServiceResolved: (ts) => {
-                            parentToolServiceRef = ts
-                        },
-                    }
-                )
-
-                fullRuntime = Layer.merge(runtimeWithCortex, toolInitLayer)
-            }
+                    mcpServers,
+                    toolsOptions,
+                    agentTools,
+                    allowDynamicSubAgents,
+                    dynamicSubAgentOptions,
+                    agentId,
+                    getParentContext,
+                    parentProvider,
+                    parentModel,
+                    parentReasoningOptions,
+                    parentEnableGuardrails,
+                    parentEnableObservability,
+                    parentObservabilityOptions,
+                    parentContextProfile,
+                    parentEnableCostTracking,
+                })
+            let fullRuntime: Layer.Layer<unknown, unknown, unknown> = fullRuntimeAfterTools
 
             // RAG ingestion + meta-tool back-fill — extracted to ./builder/build-effect/rag-ingestion.ts (W25-B step 4)
             const ragStore = yield* ingestRagDocuments({

--- a/packages/runtime/src/builder/build-effect/agent-instantiation.ts
+++ b/packages/runtime/src/builder/build-effect/agent-instantiation.ts
@@ -1,0 +1,117 @@
+/**
+ * ReactiveAgent instantiation block for buildEffect (W26-B step 4).
+ *
+ * Wraps the fully-composed runtime layer in a ManagedRuntime so all facade
+ * calls share the same scope + service instances, then constructs the public
+ * ReactiveAgent with the 17-arg constructor.
+ *
+ * Extracted from builder.ts:2258-2317.
+ */
+import { Layer, ManagedRuntime, type Effect, type Stream as EStream } from "effect";
+import { ReactiveAgent } from "../../reactive-agent.js";
+import type { ExecutionContext } from "../../types.js";
+import type { StreamDensity, AgentStreamEvent } from "../../stream-types.js";
+import type { ChannelsConfig } from "@reactive-agents/channels";
+import type { RuntimeErrors } from "../../errors.js";
+import type {
+  Task,
+  TaskResult,
+  TaskError,
+  RunControllerLike,
+} from "@reactive-agents/core";
+import type { GatewayOptions } from "../types.js";
+import type { ParentExecutionContextSnapshot } from "./parent-context.js";
+
+type EngineLike = {
+  execute: (task: Task) => Effect.Effect<TaskResult, RuntimeErrors | TaskError>;
+  executeStream: (
+    task: Task,
+    options?: { density?: StreamDensity; runController?: RunControllerLike },
+  ) => Effect.Effect<EStream.Stream<AgentStreamEvent, Error>>;
+  cancel: (taskId: string) => Effect.Effect<void, RuntimeErrors>;
+  getContext: (taskId: string) => Effect.Effect<ExecutionContext | null, never>;
+};
+
+export interface AgentInstantiationDeps {
+  readonly engine: EngineLike;
+  readonly fullRuntime: Layer.Layer<unknown, unknown, unknown>;
+  readonly agentId: string;
+  readonly mcpServerNames: readonly string[];
+  readonly gatewayOptions?: GatewayOptions;
+  readonly streamDensity?: StreamDensity;
+  readonly hasParentCallbacks: boolean;
+  readonly parentCtxRef: { current: ParentExecutionContextSnapshot | null };
+  readonly errorHandler?: (
+    error: RuntimeErrors | Error,
+    context: {
+      taskId: string;
+      phase: string;
+      iteration: number;
+      lastStep?: string;
+    },
+  ) => void;
+  readonly sessionPersist: boolean;
+  readonly sessionMaxAgeDays?: number;
+  readonly ragStore?: import("@reactive-agents/tools").RagMemoryStore;
+  readonly channelsConfig?: ChannelsConfig;
+  readonly capabilities: {
+    minIterations?: number;
+    taskContext?: Record<string, string>;
+    progressCheckpoint?: { every: number; autoResume?: boolean };
+    verificationStep?: { mode: "reflect" | "loop"; prompt?: string };
+    outputValidator?: (output: string) => { valid: boolean; feedback?: string };
+    outputValidatorOptions?: { maxRetries?: number };
+    customTermination?: (state: { output: string }) => boolean;
+  };
+}
+
+/**
+ * Construct the ManagedRuntime + ReactiveAgent.
+ *
+ * The `Layer<any, never, never>` cast collapses three boundary facts the
+ * `unknown` triple hides:
+ *   • RIn = never — every dynamically-merged sub-layer in createRuntime has
+ *     had its requirements satisfied internally (see runtime.ts), so the
+ *     composed layer has no unprovided deps.
+ *   • E   = never — layer construction is total at this point; init failures
+ *     throw, not flow through E.
+ *   • ROut = any — the materialised service union is opaque (15+ conditional
+ *     optional services). ReactiveAgent stores it as `ManagedRuntime<any, never>`
+ *     and resolves services on-demand at the `runPromise` boundary.
+ * This single cast replaces the 6× `Layer<any, any>` casts that previously
+ * papered over the same boundary mismatch.
+ */
+export const instantiateAgent = (deps: AgentInstantiationDeps): ReactiveAgent => {
+  const managedRuntime = ManagedRuntime.make(
+    deps.fullRuntime as unknown as Layer.Layer<any, never, never>,
+  );
+
+  const taskDescriptionSetter = deps.hasParentCallbacks
+    ? (desc: string) => {
+        if (deps.parentCtxRef.current) {
+          deps.parentCtxRef.current.taskDescription = desc;
+        } else {
+          deps.parentCtxRef.current = { toolResults: [], taskDescription: desc };
+        }
+      }
+    : undefined;
+
+  return new ReactiveAgent(
+    deps.engine,
+    deps.agentId,
+    managedRuntime,
+    deps.mcpServerNames,
+    !!deps.gatewayOptions,
+    deps.gatewayOptions?.heartbeat?.intervalMs,
+    !!deps.gatewayOptions?.heartbeat?.instruction,
+    deps.gatewayOptions?.persistMemoryAcrossRuns === true,
+    deps.streamDensity,
+    taskDescriptionSetter,
+    deps.errorHandler,
+    deps.sessionPersist,
+    deps.sessionMaxAgeDays,
+    deps.ragStore,
+    deps.channelsConfig,
+    deps.capabilities,
+  );
+};

--- a/packages/runtime/src/builder/build-effect/parent-context.ts
+++ b/packages/runtime/src/builder/build-effect/parent-context.ts
@@ -1,0 +1,93 @@
+/**
+ * Parent-context wiring for sub-agent registrations (W26-B step 2).
+ *
+ * Sub-agents need read access to (1) the parent's accumulated ACT-phase tool
+ * results and (2) the original task description set by run() before execution
+ * starts. This module owns the mutable ref-holder, a typed getter, and the
+ * after-ACT lifecycle hook that keeps the ref fresh.
+ *
+ * Extracted from builder.ts:2187-2241.
+ */
+import { Effect } from "effect";
+import type { ParentContext } from "@reactive-agents/tools";
+import type { ExecutionContext } from "../../types.js";
+
+export interface ParentExecutionContextSnapshot {
+  toolResults: Array<{ toolName: string; result: string }>;
+  taskDescription?: string;
+}
+
+export interface ParentContextWiring {
+  /**
+   * Mutable holder for the parent's execution context. Set by the engine's
+   * after-ACT hook (when registered) and by run() before execution starts.
+   * `null` until either firing fills it.
+   */
+  readonly ref: { current: ParentExecutionContextSnapshot | null };
+
+  /**
+   * Returns the parent context shape consumed by sub-agent handlers. Returns
+   * `undefined` when no tool results AND no task description are available.
+   */
+  readonly getParentContext: () => ParentContext | undefined;
+
+  /**
+   * Registers the after-ACT lifecycle hook that updates `ref.current.toolResults`
+   * after each tool batch. Caller chooses when to invoke (only when sub-agents
+   * are wired). Preserves `taskDescription` across updates.
+   */
+  readonly registerCaptureHook: (engine: {
+    registerHook: (hook: {
+      phase: "act";
+      timing: "after";
+      handler: (
+        ctx: ExecutionContext,
+      ) => Effect.Effect<ExecutionContext, never>;
+    }) => Effect.Effect<unknown, never>;
+  }) => Effect.Effect<void, never>;
+}
+
+export const setupParentContext = (): ParentContextWiring => {
+  const ref: { current: ParentExecutionContextSnapshot | null } = {
+    current: null,
+  };
+
+  const getParentContext = (): ParentContext | undefined => {
+    if (!ref.current) return undefined;
+    const ctx = ref.current;
+    const items = ctx.toolResults ?? [];
+    if (items.length === 0 && !ctx.taskDescription) return undefined;
+    return {
+      toolResults: items.map((tr) => ({
+        toolName: tr.toolName,
+        result: tr.result,
+      })),
+      taskDescription: ctx.taskDescription,
+    };
+  };
+
+  const registerCaptureHook: ParentContextWiring["registerCaptureHook"] = (
+    engine,
+  ) =>
+    Effect.gen(function* () {
+      yield* engine.registerHook({
+        phase: "act" as const,
+        timing: "after" as const,
+        handler: (ctx) =>
+          Effect.sync(() => {
+            const toolResults = (ctx.toolResults ?? []).map((tr: any) => ({
+              toolName: String(tr.toolName ?? tr.name ?? "unknown"),
+              result: String(tr.result ?? tr.output ?? "").slice(0, 200),
+            }));
+            // Preserve task description set by runEffect(), update tool results
+            ref.current = {
+              toolResults,
+              taskDescription: ref.current?.taskDescription,
+            };
+            return ctx;
+          }),
+      }) as Effect.Effect<unknown, never>;
+    });
+
+  return { ref, getParentContext, registerCaptureHook };
+};

--- a/packages/runtime/src/builder/build-effect/pricing-fetch.ts
+++ b/packages/runtime/src/builder/build-effect/pricing-fetch.ts
@@ -1,0 +1,51 @@
+/**
+ * Pricing fetch extraction for buildEffect (W26-B step 1).
+ *
+ * Fetches remote pricing through the configured PricingProvider and merges
+ * into the static registry. In strict mode, fetch failures propagate as Effect
+ * errors; otherwise they log a console warning and the original registry is
+ * returned unchanged.
+ */
+import { Effect } from "effect";
+import type { PricingProvider } from "@reactive-agents/llm-provider";
+
+export interface PricingFetchInput {
+  readonly pricingProvider?: PricingProvider;
+  readonly pricingRegistry: Record<
+    string,
+    { readonly input: number; readonly output: number }
+  >;
+  readonly strict: boolean;
+}
+
+export interface PricingFetchOutput {
+  readonly registry: Record<
+    string,
+    { readonly input: number; readonly output: number }
+  >;
+}
+
+export const fetchAndMergePricing = ({
+  pricingProvider,
+  pricingRegistry,
+  strict,
+}: PricingFetchInput): Effect.Effect<PricingFetchOutput, Error> =>
+  Effect.gen(function* () {
+    if (!pricingProvider) {
+      return { registry: pricingRegistry };
+    }
+    try {
+      const remotePricing = yield* pricingProvider.fetchPricing();
+      return {
+        registry: { ...pricingRegistry, ...remotePricing },
+      };
+    } catch (e) {
+      if (strict) {
+        return yield* Effect.fail(e as Error);
+      }
+      console.warn(
+        `[Pricing] Failed to fetch dynamic pricing — falling back to static map. ${e}`,
+      );
+      return { registry: pricingRegistry };
+    }
+  });

--- a/packages/runtime/src/builder/build-effect/tool-mcp-registrations.ts
+++ b/packages/runtime/src/builder/build-effect/tool-mcp-registrations.ts
@@ -1,0 +1,192 @@
+/**
+ * Tool / MCP / agent-tool registration block for buildEffect (W26-B step 3).
+ *
+ * Bakes registrations into the runtime layer via Layer.effectDiscard so they
+ * run inside the ManagedRuntime scope (not a throwaway scope). Conditional on
+ * any of: agentTools / allowDynamicSubAgents / mcpServers / toolsOptions.tools
+ * / toolsOptions.terminal.
+ *
+ * Extracted verbatim from builder.ts:2213-2374.
+ */
+import { Effect, Layer } from "effect";
+import { shellExecuteTool, shellExecuteHandler } from "@reactive-agents/tools";
+import type {
+  ToolDefinition,
+  ParentContext,
+} from "@reactive-agents/tools";
+import type { ContextProfile } from "@reactive-agents/reasoning";
+import type { MCPServerConfig } from "../../runtime.js";
+import type { ReasoningOptions } from "../../types.js";
+import type {
+  AgentToolOptions,
+  ToolsOptions,
+  ObservabilityOptions,
+} from "../types.js";
+import type {
+  SubAgentTaskArgs as ExtractedSubAgentTaskArgs,
+} from "./sub-agent-executor.js";
+import { buildSubAgentTask } from "./sub-agent-executor.js";
+import { createRemoteAgentToolRegistration } from "./remote-agent-tools.js";
+import {
+  createLocalAgentToolRegistration,
+  createDynamicSpawnRegistrations,
+} from "./local-agent-tools.js";
+import { buildToolInitLayer } from "./tool-init-layer.js";
+
+type ProviderName = string;
+
+export interface ToolMcpRegistrationsDeps {
+  readonly runtimeWithCortex: Layer.Layer<unknown, unknown, unknown>;
+  readonly mcpServers: readonly MCPServerConfig[];
+  readonly toolsOptions?: ToolsOptions;
+  readonly agentTools: readonly AgentToolOptions[];
+  readonly allowDynamicSubAgents: boolean;
+  readonly dynamicSubAgentOptions?: { maxIterations?: number };
+  readonly agentId: string;
+  readonly getParentContext: () => ParentContext | undefined;
+  readonly parentProvider: ProviderName;
+  readonly parentModel?: string;
+  readonly parentReasoningOptions?: ReasoningOptions;
+  readonly parentEnableGuardrails: boolean;
+  readonly parentEnableObservability: boolean;
+  readonly parentObservabilityOptions: ObservabilityOptions;
+  readonly parentContextProfile?: Partial<ContextProfile>;
+  readonly parentEnableCostTracking: boolean;
+}
+
+export interface ToolMcpRegistrationsOutput {
+  /** The runtime layer after Layer.merge with the tool-init layer (or unchanged when no registrations). */
+  readonly fullRuntime: Layer.Layer<unknown, unknown, unknown>;
+}
+
+export const buildToolMcpRegistrations = (
+  deps: ToolMcpRegistrationsDeps,
+): Effect.Effect<ToolMcpRegistrationsOutput, never> =>
+  Effect.gen(function* () {
+    let fullRuntime: Layer.Layer<unknown, unknown, unknown> = deps.runtimeWithCortex;
+
+    if (
+      deps.agentTools.length > 0 ||
+      deps.allowDynamicSubAgents ||
+      deps.mcpServers.length > 0 ||
+      (deps.toolsOptions?.tools?.length ?? 0) > 0 ||
+      deps.toolsOptions?.terminal !== undefined
+    ) {
+      const toolsMod = yield* Effect.promise(
+        () => import("@reactive-agents/tools"),
+      );
+
+      const {
+        createAgentTool,
+        createRemoteAgentTool,
+        executeRemoteAgentTool,
+      } = toolsMod;
+
+      // Collect (definition, handler) pairs — no registration yet.
+      type RegEntry = {
+        def: ToolDefinition;
+        handler: (
+          args: Record<string, unknown>,
+        ) => Effect.Effect<unknown, Error>;
+      };
+      const registrations: RegEntry[] = [];
+
+      for (const agentTool of deps.agentTools) {
+        if (agentTool.remoteUrl) {
+          registrations.push(
+            createRemoteAgentToolRegistration(
+              {
+                name: agentTool.name,
+                remoteUrl: agentTool.remoteUrl,
+              },
+              {
+                createRemoteAgentTool,
+                executeRemoteAgentTool,
+              },
+            ),
+          );
+        } else if (agentTool.agent) {
+          registrations.push(
+            createLocalAgentToolRegistration(agentTool, {
+              toolsMod: {
+                createAgentTool,
+                createSubAgentExecutor: toolsMod.createSubAgentExecutor,
+              },
+              agentId: deps.agentId,
+              getParentContext: deps.getParentContext,
+            }),
+          );
+        }
+      }
+
+      // Mutable ref for the parent's ToolService — set during agentToolInitEffect,
+      // read by spawn handler at call time. This avoids duplicate MCP containers
+      // by letting sub-agents proxy tool calls through the parent's live connections.
+      let parentToolServiceRef: any = null;
+
+      /** Per-task arguments for a single sub-agent dispatch. */
+      type SubAgentTaskArgs = {
+        task: string;
+        name: string;
+        role?: string;
+        instructions?: string;
+        tone?: string;
+        tools?: string[];
+      };
+
+      // Register the built-in spawn-agent tool when dynamic sub-agents are enabled.
+      if (deps.allowDynamicSubAgents) {
+        const defaultMaxIter = deps.dynamicSubAgentOptions?.maxIterations ?? 4;
+
+        const buildSingleSubAgentTask = (
+          t: SubAgentTaskArgs,
+        ): Promise<import("@reactive-agents/tools").SubAgentResult> =>
+          buildSubAgentTask(t as ExtractedSubAgentTaskArgs, {
+            parentProvider: deps.parentProvider,
+            parentModel: deps.parentModel,
+            defaultMaxIter,
+            getParentToolService: () => parentToolServiceRef,
+            mcpServers: deps.mcpServers as MCPServerConfig[],
+            parentReasoningOptions: deps.parentReasoningOptions,
+            parentEnableGuardrails: deps.parentEnableGuardrails,
+            parentEnableObservability: deps.parentEnableObservability,
+            parentObservabilityOptions: deps.parentObservabilityOptions,
+            parentContextProfile: deps.parentContextProfile,
+            parentEnableCostTracking: deps.parentEnableCostTracking,
+            getParentContext: deps.getParentContext,
+            toolsMod: {
+              createSubAgentExecutor: toolsMod.createSubAgentExecutor,
+              ALWAYS_INCLUDE_TOOLS: toolsMod.ALWAYS_INCLUDE_TOOLS,
+            },
+          });
+
+        for (const reg of createDynamicSpawnRegistrations({
+          toolsMod: {
+            createSpawnAgentTool: toolsMod.createSpawnAgentTool,
+            createSpawnAgentsTool: toolsMod.createSpawnAgentsTool,
+          },
+          buildSubAgentTask: buildSingleSubAgentTask,
+        })) {
+          registrations.push(reg);
+        }
+      }
+
+      const toolInitLayer = buildToolInitLayer(deps.runtimeWithCortex, {
+        toolsMod: {
+          ToolService: toolsMod.ToolService,
+        },
+        mcpServers: deps.mcpServers as MCPServerConfig[],
+        toolsOptions: deps.toolsOptions,
+        registrations,
+        shellExecuteTool,
+        shellExecuteHandler,
+        onToolServiceResolved: (ts) => {
+          parentToolServiceRef = ts;
+        },
+      });
+
+      fullRuntime = Layer.merge(deps.runtimeWithCortex, toolInitLayer);
+    }
+
+    return { fullRuntime };
+  });

--- a/wiki/Planning/Implementation-Plans/2026-05-24-w26b-builder-decomposition.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-24-w26b-builder-decomposition.md
@@ -1,0 +1,591 @@
+# W26-B: builder.ts Decomposition — buildEffect wave
+
+**Goal:** Reduce `packages/runtime/src/builder.ts` from 2512 LOC by extracting 4 cohesive blocks out of `buildEffect()` (lines 2103-2512) into `builder/build-effect/*` submodules. Target ≤2200 LOC. Closes the buildEffect portion of issue #76; wither-method extraction deferred to a follow-up W26-B-2.
+
+**Architecture:** Continue the W25 pattern (`builder/build-effect/` already holds `runtime-construction.ts`, `tool-init-layer.ts`, `rag-ingestion.ts`, `health-layer.ts`, `tracing-layer.ts`, `sub-agent-executor.ts`). W26-B adds 4 more cousins: pricing fetch, parent-context wiring, tool/MCP/agent registrations, and ReactiveAgent instantiation. Each extraction is behavior-preserving and gated by the existing test suite + replay-determinism net.
+
+**Baseline (captured at branch creation):**
+- builder.ts: **2512 LOC**
+- runtime tests: 811 pass / 0 fail / 1 skip
+- replay tests: 24 pass / 0 fail (re-verify per task)
+- build: 38/38 successful (re-verify per task)
+
+## File Structure
+
+**New modules under `packages/runtime/src/builder/build-effect/`:**
+- `pricing-fetch.ts` — fetchAndMergePricing factory (Task 1)
+- `parent-context.ts` — setupParentContext closure factory (Task 2)
+- `tool-mcp-registrations.ts` — buildToolMcpRegistrations Effect (Task 3)
+- `agent-instantiation.ts` — instantiateAgent pure constructor (Task 4)
+
+**Modified:** `packages/runtime/src/builder.ts` (buildEffect body shrinks ~300 LOC).
+
+## Task 1: Extract pricing fetch
+
+**Files:**
+- Create: `packages/runtime/src/builder/build-effect/pricing-fetch.ts`
+- Modify: `packages/runtime/src/builder.ts:2125-2143` (replace inline with helper call)
+
+- [ ] **Step 1: Create module**
+
+```typescript
+// packages/runtime/src/builder/build-effect/pricing-fetch.ts
+import { Effect } from "effect"
+import type { PricingProvider } from "@reactive-agents/llm-provider"
+
+export interface PricingFetchInput {
+  readonly pricingProvider?: PricingProvider
+  readonly pricingRegistry: Record<string, { readonly input: number; readonly output: number }>
+  readonly strict: boolean
+}
+
+export interface PricingFetchOutput {
+  readonly registry: Record<string, { readonly input: number; readonly output: number }>
+}
+
+/**
+ * Fetch remote pricing (when a provider was configured) and merge into the
+ * static pricing registry. In strict mode, fetch failures propagate as Effect
+ * errors; otherwise they log a console warning and the original registry is
+ * returned unchanged.
+ *
+ * Extracted from builder.ts:2125 (W26-B step 1).
+ */
+export const fetchAndMergePricing = ({
+  pricingProvider,
+  pricingRegistry,
+  strict,
+}: PricingFetchInput): Effect.Effect<PricingFetchOutput, Error> =>
+  Effect.gen(function* () {
+    if (!pricingProvider) {
+      return { registry: pricingRegistry }
+    }
+    try {
+      const remotePricing = yield* pricingProvider.fetchPricing()
+      return {
+        registry: { ...pricingRegistry, ...remotePricing },
+      }
+    } catch (e) {
+      if (strict) {
+        return yield* Effect.fail(e as Error)
+      }
+      console.warn(
+        `[Pricing] Failed to fetch dynamic pricing — falling back to static map. ${e}`,
+      )
+      return { registry: pricingRegistry }
+    }
+  })
+```
+
+- [ ] **Step 2: Replace inline block in builder.ts**
+
+In `packages/runtime/src/builder.ts`, replace lines 2125-2143:
+
+```typescript
+// before (inline)
+if (self._pricingProvider) {
+    try {
+        const remotePricing = yield* self._pricingProvider.fetchPricing()
+        self._pricingRegistry = { ...self._pricingRegistry, ...remotePricing }
+    } catch (e) {
+        if (self._strictValidation) {
+            return yield* Effect.fail(e as Error)
+        }
+        console.warn(`[Pricing] Failed to fetch dynamic pricing — falling back to static map. ${e}`)
+    }
+}
+
+// after (extracted)
+{
+    const { registry } = yield* fetchAndMergePricing({
+        pricingProvider: self._pricingProvider,
+        pricingRegistry: self._pricingRegistry,
+        strict: self._strictValidation,
+    })
+    self._pricingRegistry = registry
+}
+```
+
+Add import (alphabetized in the imports block at top):
+```typescript
+import { fetchAndMergePricing } from "./builder/build-effect/pricing-fetch.js"
+```
+
+- [ ] **Step 3: Verify + commit**
+
+```bash
+rtk bun test packages/runtime/
+rtk bun test packages/replay/
+rtk bun run build 2>&1 | tail -3
+rtk wc -l packages/runtime/src/builder.ts
+```
+Expected: 811/0/1 + 24/0 + 38/38; builder.ts ~2500 LOC (-12).
+
+```bash
+rtk git add packages/runtime/src/builder/build-effect/pricing-fetch.ts \
+            packages/runtime/src/builder.ts
+rtk git commit -m "refactor(runtime): extract pricing fetch from buildEffect (W26-B step 1)
+
+Behavior-preserving move of the pricing-provider fetch + strict-mode error
+handling into builder/build-effect/pricing-fetch.ts. Tests + replay green.
+
+Partial: #76"
+```
+
+## Task 2: Extract parent-context wiring
+
+**Files:**
+- Create: `packages/runtime/src/builder/build-effect/parent-context.ts`
+- Modify: `packages/runtime/src/builder.ts:2194-2248` (replace 54-LOC block)
+
+The parent-context block creates a mutable ref, a `getParentContext` reader, and conditionally registers an `after-act` lifecycle hook that updates the ref. All three pieces co-vary — extract as one factory that returns `{ parentExecutionContextRef, getParentContext, registerCaptureHook }`.
+
+- [ ] **Step 1: Create module**
+
+```typescript
+// packages/runtime/src/builder/build-effect/parent-context.ts
+import { Effect } from "effect"
+import type { ParentContext } from "@reactive-agents/tools"
+import type { ExecutionContext } from "../../types.js"
+
+export interface ParentExecutionContextRef {
+  toolResults: Array<{ toolName: string; result: string }>
+  taskDescription?: string
+}
+
+export interface ParentContextWiring {
+  /** Mutable holder updated by the engine's act-hook (when wired) and by run() for task description. */
+  readonly ref: { current: ParentExecutionContextRef | null }
+  /** Reader that returns the tool-results + taskDescription as a ParentContext (or undefined when empty). */
+  readonly getParentContext: () => ParentContext | undefined
+  /**
+   * Register a lifecycle hook on the engine that captures tool results from
+   * each ACT phase into the ref. Should be called only when sub-agents are wired
+   * (agentTools present or allowDynamicSubAgents = true).
+   */
+  readonly registerCaptureHook: (engine: {
+    registerHook: (hook: {
+      phase: "act"
+      timing: "after"
+      handler: (ctx: ExecutionContext) => Effect.Effect<ExecutionContext, never>
+    }) => Effect.Effect<unknown, never>
+  }) => Effect.Effect<void, never>
+}
+
+/**
+ * Build the parent-context plumbing used by sub-agent registrations. Returns
+ * a ref-holder + getter + hook-registrar. Sub-agents read tool results and
+ * task description through the getter; the engine writes results via the
+ * registered after-act hook.
+ *
+ * Extracted from builder.ts:2194 (W26-B step 2).
+ */
+export const setupParentContext = (): ParentContextWiring => {
+  const ref: { current: ParentExecutionContextRef | null } = { current: null }
+
+  const getParentContext = (): ParentContext | undefined => {
+    if (!ref.current) return undefined
+    const ctx = ref.current
+    const items = ctx.toolResults ?? []
+    if (items.length === 0 && !ctx.taskDescription) return undefined
+    return {
+      toolResults: items.map((tr) => ({
+        toolName: tr.toolName,
+        result: tr.result,
+      })),
+      taskDescription: ctx.taskDescription,
+    }
+  }
+
+  const registerCaptureHook: ParentContextWiring["registerCaptureHook"] = (engine) =>
+    Effect.gen(function* () {
+      yield* engine.registerHook({
+        phase: "act" as const,
+        timing: "after" as const,
+        handler: (ctx) =>
+          Effect.sync(() => {
+            const toolResults = (ctx.toolResults ?? []).map((tr: any) => ({
+              toolName: String(tr.toolName ?? tr.name ?? "unknown"),
+              result: String(tr.result ?? tr.output ?? "").slice(0, 200),
+            }))
+            ref.current = {
+              toolResults,
+              taskDescription: ref.current?.taskDescription,
+            }
+            return ctx
+          }),
+      }) as Effect.Effect<unknown, never>
+    })
+
+  return { ref, getParentContext, registerCaptureHook }
+}
+```
+
+- [ ] **Step 2: Replace inline block in builder.ts**
+
+Replace `packages/runtime/src/builder.ts:2194-2248`:
+
+```typescript
+// after
+const parentCtx = setupParentContext()
+const getParentContext = parentCtx.getParentContext
+
+if (agentTools.length > 0 || allowDynamicSubAgents) {
+    yield* parentCtx.registerCaptureHook(engine)
+}
+```
+
+Note: the rest of `buildEffect` (lines 2483-2493) reads `parentExecutionContextRef` mutably (sets `taskDescription` via the run() callback). Replace those reads/writes to use `parentCtx.ref.current` instead. Grep for `parentExecutionContextRef` to find all sites:
+
+```bash
+rtk grep -n "parentExecutionContextRef" packages/runtime/src/builder.ts
+```
+
+Rewrite each site to read/write via `parentCtx.ref.current`:
+
+```typescript
+// before
+if (parentExecutionContextRef) {
+    parentExecutionContextRef.taskDescription = desc
+} else {
+    parentExecutionContextRef = { toolResults: [], taskDescription: desc }
+}
+
+// after
+if (parentCtx.ref.current) {
+    parentCtx.ref.current.taskDescription = desc
+} else {
+    parentCtx.ref.current = { toolResults: [], taskDescription: desc }
+}
+```
+
+Add import:
+```typescript
+import { setupParentContext } from "./builder/build-effect/parent-context.js"
+```
+
+- [ ] **Step 3: Verify + commit**
+
+```bash
+rtk bun test packages/runtime/
+rtk bun test packages/replay/
+rtk bun run build 2>&1 | tail -3
+rtk wc -l packages/runtime/src/builder.ts
+```
+Expected: 811/0/1 + 24/0 + 38/38; builder.ts ~2450 LOC (-50).
+
+```bash
+rtk git add packages/runtime/src/builder/build-effect/parent-context.ts \
+            packages/runtime/src/builder.ts
+rtk git commit -m "refactor(runtime): extract parent-context wiring from buildEffect (W26-B step 2)
+
+Moves the parentExecutionContextRef + getParentContext + capture-hook
+registration trio into builder/build-effect/parent-context.ts as a
+setupParentContext() factory. Sub-agent tool results + task description
+flow through the same ref-shaped contract; no behavior change.
+
+Partial: #76"
+```
+
+## Task 3: Extract tool/MCP/agent registration loop
+
+**Files:**
+- Create: `packages/runtime/src/builder/build-effect/tool-mcp-registrations.ts`
+- Modify: `packages/runtime/src/builder.ts:2266-2427` (replace ~160 LOC block)
+
+This is the biggest extraction. The block conditionally runs when any of `agentTools` / `allowDynamicSubAgents` / `mcpServers.length` / `toolsOptions.tools.length` / `toolsOptions.terminal` is truthy. It builds `registrations[]`, wires the dynamic-spawn agent tools, calls `buildToolInitLayer`, and updates `fullRuntime` via `Layer.merge`.
+
+Extract as `buildToolMcpRegistrations(deps): Effect<{ fullRuntime, parentToolServiceRef }, never>`.
+
+- [ ] **Step 1: Read the full block + audit closure deps**
+
+```bash
+rtk awk 'NR>=2266 && NR<=2427' packages/runtime/src/builder.ts
+```
+
+Closure deps to thread through (audit list):
+- `runtimeWithCortex: Layer.Layer<...>`
+- `mcpServers: MCPServerConfig[]`
+- `toolsOptions?: ToolsOptions`
+- `agentTools: AgentToolOptions[]`
+- `allowDynamicSubAgents: boolean`
+- `dynamicSubAgentOptions?: { maxIterations?: number }`
+- `agentId: string`
+- `getParentContext: () => ParentContext | undefined`
+- `parentProvider: ProviderName`
+- `parentModel?: string`
+- `parentReasoningOptions?: ReasoningOptions`
+- `parentEnableGuardrails: boolean`
+- `parentEnableObservability: boolean`
+- `parentObservabilityOptions: ObservabilityOptions`
+- `parentContextProfile?: Partial<ContextProfile>`
+- `parentEnableCostTracking: boolean`
+- `shellExecuteTool, shellExecuteHandler` (computed near top of buildEffect — verify in scope)
+
+- [ ] **Step 2: Create module**
+
+Create `packages/runtime/src/builder/build-effect/tool-mcp-registrations.ts`. The body is a verbatim move; declare `ToolMcpRegistrationsDeps` listing every closed-over identifier; replace bare references with `deps.<name>`.
+
+(Body copied verbatim from `builder.ts:2266-2427`. Public surface of the module:)
+
+```typescript
+export interface ToolMcpRegistrationsDeps {
+  // ... all deps listed above ...
+}
+
+export interface ToolMcpRegistrationsOutput {
+  readonly fullRuntime: Layer.Layer<unknown, unknown, unknown>
+  /** Set by the toolInitLayer's onToolServiceResolved callback. */
+  readonly parentToolServiceRef: { current: unknown }
+}
+
+export const buildToolMcpRegistrations = (
+  deps: ToolMcpRegistrationsDeps,
+): Effect.Effect<ToolMcpRegistrationsOutput, never> => Effect.gen(function* () {
+  const parentToolServiceRef: { current: unknown } = { current: null }
+  // ... rest of the body, deps.* throughout, return { fullRuntime, parentToolServiceRef }
+})
+```
+
+- [ ] **Step 3: Replace inline block in builder.ts**
+
+```typescript
+// before: 160 LOC of inline if-block
+// after:
+const toolMcpResult = yield* buildToolMcpRegistrations({
+    runtimeWithCortex,
+    mcpServers,
+    toolsOptions,
+    agentTools,
+    allowDynamicSubAgents,
+    dynamicSubAgentOptions,
+    agentId,
+    getParentContext,
+    parentProvider,
+    parentModel,
+    parentReasoningOptions,
+    parentEnableGuardrails,
+    parentEnableObservability,
+    parentObservabilityOptions,
+    parentContextProfile,
+    parentEnableCostTracking,
+    shellExecuteTool,
+    shellExecuteHandler,
+})
+let fullRuntime = toolMcpResult.fullRuntime
+const parentToolServiceRef = toolMcpResult.parentToolServiceRef
+```
+
+Add import.
+
+- [ ] **Step 4: Verify + commit**
+
+```bash
+rtk bun test packages/runtime/
+rtk bun test packages/replay/
+rtk bun run build 2>&1 | tail -3
+rtk wc -l packages/runtime/src/builder.ts
+```
+Expected: 811/0/1 + 24/0 + 38/38; builder.ts ~2295 LOC (-155). This is the high-risk extraction — if the block re-orders any registration or skips the if-condition, sub-agent / MCP tests fail. Run the sub-agent integration tests specifically:
+
+```bash
+rtk bun test packages/runtime/tests/sub-agent
+```
+
+```bash
+rtk git add packages/runtime/src/builder/build-effect/tool-mcp-registrations.ts \
+            packages/runtime/src/builder.ts
+rtk git commit -m "refactor(runtime): extract tool/MCP/agent registrations from buildEffect (W26-B step 3)
+
+Moves the conditional tool/MCP/sub-agent registration loop (~160 LOC) into
+builder/build-effect/tool-mcp-registrations.ts as buildToolMcpRegistrations.
+The output { fullRuntime, parentToolServiceRef } is consumed by the remaining
+buildEffect body unchanged. Replay determinism + sub-agent integration tests
+green.
+
+Partial: #76"
+```
+
+## Task 4: Extract ReactiveAgent instantiation
+
+**Files:**
+- Create: `packages/runtime/src/builder/build-effect/agent-instantiation.ts`
+- Modify: `packages/runtime/src/builder.ts:2450-2510` (replace ~60 LOC block)
+
+The tail of `buildEffect` constructs the `ManagedRuntime` and `new ReactiveAgent(...)`. 17-arg constructor + a `desc` callback closure. Extract as `instantiateAgent(deps)`.
+
+- [ ] **Step 1: Create module**
+
+```typescript
+// packages/runtime/src/builder/build-effect/agent-instantiation.ts
+import { Layer, ManagedRuntime } from "effect"
+import { ReactiveAgent } from "../../reactive-agent.js"
+import type { ExecutionEngine } from "../../execution-engine.js"
+// ... import other types as needed
+
+export interface AgentInstantiationDeps {
+  readonly engine: typeof ExecutionEngine extends ... ? ... : unknown // tighten on extraction
+  readonly fullRuntime: Layer.Layer<unknown, unknown, unknown>
+  readonly agentId: string
+  readonly mcpServerNames: readonly string[]
+  readonly gatewayOptions?: any
+  readonly streamDensity?: any
+  readonly hasParentCallbacks: boolean
+  readonly parentCtxRef: { current: { taskDescription?: string; toolResults: any[] } | null }
+  readonly errorHandler?: any
+  readonly sessionPersist: boolean
+  readonly sessionMaxAgeDays?: number
+  readonly ragStore: unknown
+  readonly channelsConfig?: any
+  readonly capabilities: {
+    minIterations?: number
+    taskContext?: Record<string, string>
+    progressCheckpoint?: { every: number; autoResume?: boolean }
+    verificationStep?: { mode: "reflect" | "loop"; prompt?: string }
+    outputValidator?: (output: string) => { valid: boolean; feedback?: string }
+    outputValidatorOptions?: { maxRetries?: number }
+    customTermination?: (state: { output: string }) => boolean
+  }
+}
+
+export const instantiateAgent = (deps: AgentInstantiationDeps): ReactiveAgent => {
+  const managedRuntime = ManagedRuntime.make(
+    deps.fullRuntime as unknown as Layer.Layer<any, never, never>,
+  )
+
+  return new ReactiveAgent(
+    deps.engine,
+    deps.agentId,
+    managedRuntime,
+    deps.mcpServerNames,
+    !!deps.gatewayOptions,
+    deps.gatewayOptions?.heartbeat?.intervalMs,
+    !!deps.gatewayOptions?.heartbeat?.instruction,
+    deps.gatewayOptions?.persistMemoryAcrossRuns === true,
+    deps.streamDensity,
+    deps.hasParentCallbacks
+      ? (desc: string) => {
+          if (deps.parentCtxRef.current) {
+            deps.parentCtxRef.current.taskDescription = desc
+          } else {
+            deps.parentCtxRef.current = { toolResults: [], taskDescription: desc }
+          }
+        }
+      : undefined,
+    deps.errorHandler,
+    deps.sessionPersist,
+    deps.sessionMaxAgeDays,
+    deps.ragStore,
+    deps.channelsConfig,
+    deps.capabilities,
+  )
+}
+```
+
+- [ ] **Step 2: Replace inline block in builder.ts**
+
+Replace `builder.ts:2450-2509` with:
+
+```typescript
+return instantiateAgent({
+    engine,
+    fullRuntime,
+    agentId,
+    mcpServerNames: mcpServers.map((s) => s.name),
+    gatewayOptions,
+    streamDensity,
+    hasParentCallbacks: agentTools.length > 0 || allowDynamicSubAgents,
+    parentCtxRef: parentCtx.ref,
+    errorHandler,
+    sessionPersist,
+    sessionMaxAgeDays,
+    ragStore,
+    channelsConfig: self._channelsConfig,
+    capabilities: {
+        minIterations: self._minIterations,
+        taskContext: self._taskContext,
+        progressCheckpoint: self._progressCheckpoint,
+        verificationStep: self._verificationStep,
+        outputValidator: self._outputValidator,
+        outputValidatorOptions: self._outputValidatorOptions,
+        customTermination: self._customTermination,
+    },
+})
+```
+
+- [ ] **Step 3: Verify + commit**
+
+```bash
+rtk bun test packages/runtime/
+rtk bun test packages/replay/
+rtk bun run build 2>&1 | tail -3
+rtk wc -l packages/runtime/src/builder.ts
+```
+Expected: 811/0/1 + 24/0 + 38/38; builder.ts ~2240 LOC (-55).
+
+```bash
+rtk git add packages/runtime/src/builder/build-effect/agent-instantiation.ts \
+            packages/runtime/src/builder.ts
+rtk git commit -m "refactor(runtime): extract ReactiveAgent instantiation from buildEffect (W26-B step 4)
+
+Final W26-B extraction — moves the ManagedRuntime construction + 17-arg
+new ReactiveAgent(...) call into builder/build-effect/agent-instantiation.ts
+as instantiateAgent(deps). Behavior preserved by the dep-struct boundary.
+
+Partial: #76"
+```
+
+## Task 5: Bundle-wide verify
+
+- [ ] **Step 1: LOC progress**
+
+```bash
+rtk wc -l packages/runtime/src/builder.ts
+```
+Expected: ≤2250 LOC. If LOC > 2250, identify one more extraction candidate or accept the partial as a stepping stone.
+
+- [ ] **Step 2: Full sweep**
+
+```bash
+rtk bun test packages/runtime/   # baseline parity
+rtk bun test packages/replay/     # determinism gate
+rtk bun test                       # workspace
+rtk bun run build 2>&1 | tail -3   # all packages
+```
+Expected: runtime + replay at baseline; build 38/38; workspace flakes in untouched packages don't block (per skill v7).
+
+- [ ] **Step 3: Dead-import sweep**
+
+```bash
+# grep candidates that may have been removed from active use after the 4 extractions
+for sym in "PricingProvider" "ManagedRuntime" "createRemoteAgentTool" "executeRemoteAgentTool"; do
+  printf "%-25s " "$sym"
+  rtk grep -c "$sym" packages/runtime/src/builder.ts
+done
+```
+If any returns 0 (and exists in the import block), drop it. Commit as `chore: drop dead imports left over from W26-B extractions`.
+
+## Task 6: PR + retro
+
+- [ ] **Step 1: Push + open PR**
+
+```bash
+rtk git push -u origin bundle/w26b-builder-decomp
+rtk gh pr create --base main --head bundle/w26b-builder-decomp \
+  --title "refactor(runtime): W26-B builder.ts buildEffect decomposition" \
+  --body "<see W26-A PR template; substitute numbers + extracted modules>"
+```
+
+- [ ] **Step 2: Retro**
+
+Write `wiki/Research/Debriefs/2026-05-24-w26b-builder-debrief.md` (template from W26-A retro). Update master plan status. Comment on #76 with W26-B landing summary; flag whether wither-method extraction (W26-B-2) is needed to hit ≤1500 LOC.
+
+## Self-Review
+
+**1. Spec coverage:** Each of the 4 buildEffect blocks identified at planning time has a task. ✅
+
+**2. Placeholder scan:** Task 3 body is described as "verbatim copy" rather than reproduced inline — the block is too long to duplicate in the plan and the closure-dep audit (Step 1) is the actual implementation work. Acceptable given size; engineer reads the source file directly. Tasks 1, 2, 4 have full code blocks. ✅
+
+**3. Type consistency:** `ParentContextWiring` (Task 2) used in Task 3 as `parentCtx.ref` and Task 4 as `parentCtxRef`. Names align (the latter is a parameter rename for cleanliness). `getParentContext` consistent across Tasks 2/3. ✅
+
+**4. Behavior-preserving guarantee:** Every task ends with the replay determinism gate. ✅


### PR DESCRIPTION
## Bundle: W26-B — builder.ts buildEffect decomposition

Partial: #76 (full closure pending W26-C / W26-D; W26-B-2 may follow for wither-method extraction if needed to hit ≤1500 LOC threshold).

## Summary

Four cohesive extractions out of `ReactiveAgentBuilder.buildEffect()` (builder.ts 2512 → 2271 LOC, -241 / -9.6%):

1. **`builder/build-effect/pricing-fetch.ts`** — `fetchAndMergePricing()` factors out the remote-pricing fetch + strict-mode error handling. -7 LOC.
2. **`builder/build-effect/parent-context.ts`** — `setupParentContext()` returns a `{ ref, getParentContext, registerCaptureHook }` trio. All 3 read/write sites (capture hook, getter, run-time `taskDescription` setter) now route through the same ref-holder. -46 LOC.
3. **`builder/build-effect/tool-mcp-registrations.ts`** — `buildToolMcpRegistrations()` lifts the ~162 LOC conditional tool / MCP / sub-agent registration block (verbatim move + typed dep-struct boundary). -139 LOC.
4. **`builder/build-effect/agent-instantiation.ts`** — `instantiateAgent()` owns the `ManagedRuntime.make` + 17-arg `new ReactiveAgent(...)` call, including the load-bearing `Layer<any, never, never>` cast + commentary. -33 LOC.

Plus a follow-up commit dropping dead imports left behind by the extractions (`ManagedRuntime`, `ToolDefinition`, `shellExecuteTool/Handler`, 5 sub-agent/tool-init helpers). -16 LOC.

Behavior-preserving by design; existing test suites are the safety net.

## Verification

- `bun test packages/runtime/`: **811 pass / 0 fail / 1 skip / 1480 expect()** (matches baseline exactly)
- `bun test packages/runtime/tests/subagent-*.test.ts`: **9 pass / 0 fail** (Task 3 high-risk gate)
- `bun test packages/replay/`: **24 pass / 0 fail** (determinism gate)
- `bun run build`: **38/38 successful** (DTS clean)
- `wc -l packages/runtime/src/builder.ts`: **2512 → 2271** (-241 LOC)

Per-commit verified; no commit pushed the suite into a red state.

## Plan + Retro

- Master: `wiki/Planning/Implementation-Plans/2026-05-24-w26-decomposition-master.md`
- Plan: `wiki/Planning/Implementation-Plans/2026-05-24-w26b-builder-decomposition.md`
- Retro: filed after merge at `wiki/Research/Debriefs/2026-05-24-w26b-builder-debrief.md`

## Out of scope / follow-ups

- builder.ts is **still 2271 LOC** — above the ≤1500 LOC threshold from #76. Hitting that needs **W26-B-2: wither-method extraction** (~40 `withX(opts)` methods, bundling option-application bodies into helper modules). Filing as follow-up.
- W26-C (runtime.ts 2083 LOC) and W26-D (reactive-agent.ts 1578 LOC) pending — own PRs each per master plan.