### PR TITLE
refactor(runtime): W26-B-2 builder wither + api-surface extraction (-140 LOC)

### DIFF
--- a/packages/runtime/src/builder.ts
+++ b/packages/runtime/src/builder.ts
@@ -18,6 +18,11 @@ import { fetchAndMergePricing } from './builder/build-effect/pricing-fetch.js'
 import { setupParentContext } from './builder/build-effect/parent-context.js'
 import { buildToolMcpRegistrations } from './builder/build-effect/tool-mcp-registrations.js'
 import { instantiateAgent } from './builder/build-effect/agent-instantiation.js'
+import {
+    reactiveAgentsFromConfig,
+    reactiveAgentsFromJSON,
+    invokeUserHookSafely,
+} from './builder/api-surface.js'
 import { wireRiHooks, type RiHooks } from './builder/ri-wiring.js'
 import {
     buildBaseRuntimeAndEngine,
@@ -121,93 +126,12 @@ export const ReactiveAgents = {
     /**
      * Create a new agent builder with defaults.
      * All builder methods are optional; no configuration is required at creation time.
-     *
-     * @returns A new `ReactiveAgentBuilder` instance
      */
     create: (): ReactiveAgentBuilder => new ReactiveAgentBuilder(),
-
-    /**
-     * Reconstruct a builder from an AgentConfig object.
-     *
-     * The returned builder is fully configured and can be further customized
-     * with additional builder methods before calling `.build()`.
-     *
-     * @param config - AgentConfig to reconstruct from
-     * @returns A configured ReactiveAgentBuilder
-     * @example
-     * ```typescript
-     * const builder = ReactiveAgents.fromConfig(savedConfig);
-     * const agent = await builder.build();
-     * ```
-     */
-    fromConfig: async (
-        config: import('./agent-config.js').AgentConfig
-    ): Promise<ReactiveAgentBuilder> => {
-        const { agentConfigToBuilder } = await import('./agent-config.js')
-        return agentConfigToBuilder(config)
-    },
-
-    /**
-     * Reconstruct a builder from a JSON string containing an AgentConfig.
-     *
-     * Parses and validates the JSON before reconstructing the builder.
-     * Throws a ParseError if the JSON is invalid.
-     *
-     * @param json - JSON string containing a serialized AgentConfig
-     * @returns A configured ReactiveAgentBuilder
-     * @example
-     * ```typescript
-     * const builder = await ReactiveAgents.fromJSON(configJson);
-     * const agent = await builder.build();
-     * ```
-     */
-    fromJSON: async (json: string): Promise<ReactiveAgentBuilder> => {
-        const { agentConfigFromJSON, agentConfigToBuilder } = await import(
-            './agent-config.js'
-        )
-        const config = agentConfigFromJSON(json)
-        return agentConfigToBuilder(config)
-    },
-}
-
-/**
- * Run a user lifecycle hook and route any escaping error to the builder's
- * `_errorHandler` (when set) or `console.warn` (fallback). Resolves HS-14 (#74):
- * hook errors are no longer silently discarded.
- */
-async function invokeUserHookSafely(
-    self: ReactiveAgentBuilder,
-    hook: LifecycleHook,
-    ctx: { phase: string; iteration: number },
-): Promise<void> {
-    const surface = (err: unknown): void => {
-        const handler = (self as unknown as { _errorHandler?: (e: RuntimeErrors | Error, c: { taskId: string; phase: string; iteration: number; lastStep?: string }) => void })._errorHandler
-        const normalized = err instanceof Error ? err : new Error(String(err))
-        if (handler) {
-            try {
-                handler(normalized, { taskId: '', phase: ctx.phase, iteration: ctx.iteration })
-            } catch {
-                // Handler-of-handler crash: swallow to avoid recursion; preserve original via console.warn
-                console.warn('[reactive-agents] error handler crashed while reporting lifecycle hook failure:', normalized)
-            }
-            return
-        }
-        console.warn('[reactive-agents] lifecycle hook threw (no errorHandler registered):', normalized)
-    }
-    let result: unknown
-    try {
-        result = hook.handler({ phase: ctx.phase, iteration: ctx.iteration } as ExecutionContext)
-    } catch (err) {
-        surface(err)
-        return
-    }
-    if (result && typeof (result as { then?: unknown }).then === 'function') {
-        try {
-            await (result as Promise<unknown>)
-        } catch (err) {
-            surface(err)
-        }
-    }
+    /** Reconstruct a builder from an AgentConfig object. */
+    fromConfig: reactiveAgentsFromConfig,
+    /** Reconstruct a builder from a JSON string containing an AgentConfig. */
+    fromJSON: reactiveAgentsFromJSON,
 }
 
 /**

--- a/packages/runtime/src/builder.ts
+++ b/packages/runtime/src/builder.ts
@@ -21,8 +21,12 @@ import { instantiateAgent } from './builder/build-effect/agent-instantiation.js'
 import {
     reactiveAgentsFromConfig,
     reactiveAgentsFromJSON,
-    invokeUserHookSafely,
 } from './builder/api-surface.js'
+import {
+    applyReactiveIntelligenceOptions,
+    applyMemoryOptions,
+    applyHookRegistration,
+} from './builder/wither-applies.js'
 import { wireRiHooks, type RiHooks } from './builder/ri-wiring.js'
 import {
     buildBaseRuntimeAndEngine,
@@ -673,22 +677,7 @@ export class ReactiveAgentBuilder {
      * ```
      */
     withMemory(tierOrOptions?: '1' | '2' | MemoryOptions): this {
-        this._enableMemory = true
-        if (typeof tierOrOptions === 'string') {
-            const newForm =
-                tierOrOptions === '2'
-                    ? '.withMemory({ tier: "enhanced" })'
-                    : '.withMemory()'
-            console.warn(
-                `⚠ withMemory("${tierOrOptions}") is deprecated. Use ${newForm} instead.`
-            )
-            this._memoryTier = tierOrOptions
-        } else if (tierOrOptions) {
-            if (tierOrOptions.tier) {
-                this._memoryTier = tierOrOptions.tier === 'enhanced' ? '2' : '1'
-            }
-            this._memoryOptions = tierOrOptions
-        }
+        applyMemoryOptions(this, tierOrOptions)
         return this
     }
 
@@ -736,23 +725,7 @@ export class ReactiveAgentBuilder {
      * ```
      */
     withHook(hook: LifecycleHook): this {
-        this._hooks.push(hook)
-        const self = this
-        // Also register as harness phase hook for compose-side observability
-        if (hook.timing === 'on-error') {
-            return this.withHarness((h) => {
-                h.onError(hook.phase as import('@reactive-agents/core').Phase, async (_err, ctx) => {
-                    await invokeUserHookSafely(self, hook, ctx)
-                })
-            })
-        }
-        // For 'before' and 'after' timings
-        const kind = hook.timing === 'before' ? 'before' : 'after'
-        return this.withHarness((h) => {
-            h[kind](hook.phase as import('@reactive-agents/core').Phase, async (ctx) => {
-                await invokeUserHookSafely(self, hook, ctx)
-            })
-        })
+        return this.withHarness(applyHookRegistration(this, hook))
     }
 
     // ─── Optional Features ───
@@ -1690,44 +1663,7 @@ export class ReactiveAgentBuilder {
               > &
                   Record<string, any>)
     ): this {
-        if (typeof arg === 'boolean') {
-            this._enableReactiveIntelligence = arg
-            return this
-        }
-        this._enableReactiveIntelligence = true
-        if (arg) {
-            const {
-                onEntropyScored,
-                onControllerDecision,
-                onSkillActivated,
-                onSkillRefined,
-                onSkillConflict,
-                onMidRunAdjustment,
-                constraints,
-                autonomy,
-                ...riConfig
-            } = arg as any
-            this._reactiveIntelligenceOptions = riConfig
-            if (
-                onEntropyScored ||
-                onControllerDecision ||
-                onSkillActivated ||
-                onSkillRefined ||
-                onSkillConflict ||
-                onMidRunAdjustment
-            ) {
-                this._riHooks = {
-                    onEntropyScored,
-                    onControllerDecision,
-                    onSkillActivated,
-                    onSkillRefined,
-                    onSkillConflict,
-                    onMidRunAdjustment,
-                }
-            }
-            if (constraints) this._riConstraints = constraints
-            if (autonomy) this._riAutonomy = autonomy
-        }
+        applyReactiveIntelligenceOptions(this, arg)
         return this
     }
 

--- a/packages/runtime/src/builder/api-surface.ts
+++ b/packages/runtime/src/builder/api-surface.ts
@@ -1,0 +1,108 @@
+/**
+ * Public API surface helpers for ReactiveAgentBuilder (W26-B-2 step 1).
+ *
+ * Hoists two pieces out of builder.ts:
+ *   - `fromConfig` / `fromJSON` factories used by the `ReactiveAgents` namespace
+ *   - `invokeUserHookSafely` — internal helper used by `withHook` to surface
+ *     escaped lifecycle-hook errors through the builder's `_errorHandler`.
+ *
+ * `ReactiveAgents.create` stays in builder.ts because it constructs the class
+ * directly — keeping it inline avoids the dynamic-import dance and matches the
+ * `new ReactiveAgentBuilder()` line's location next to the class definition.
+ */
+import type { ReactiveAgentBuilder } from "../builder.js";
+import type { LifecycleHook, ExecutionContext } from "../types.js";
+import type { RuntimeErrors } from "../errors.js";
+
+/**
+ * Reconstruct a builder from an AgentConfig object.
+ *
+ * The returned builder is fully configured and can be further customized
+ * with additional builder methods before calling `.build()`.
+ */
+export const reactiveAgentsFromConfig = async (
+  config: import("../agent-config.js").AgentConfig,
+): Promise<ReactiveAgentBuilder> => {
+  const { agentConfigToBuilder } = await import("../agent-config.js");
+  return agentConfigToBuilder(config);
+};
+
+/**
+ * Reconstruct a builder from a JSON string containing an AgentConfig.
+ * Parses and validates the JSON before reconstructing the builder.
+ * Throws a ParseError if the JSON is invalid.
+ */
+export const reactiveAgentsFromJSON = async (
+  json: string,
+): Promise<ReactiveAgentBuilder> => {
+  const { agentConfigFromJSON, agentConfigToBuilder } = await import(
+    "../agent-config.js"
+  );
+  const config = agentConfigFromJSON(json);
+  return agentConfigToBuilder(config);
+};
+
+/**
+ * Run a user lifecycle hook and route any escaping error to the builder's
+ * `_errorHandler` (when set) or `console.warn` (fallback). Resolves HS-14 (#74):
+ * hook errors are no longer silently discarded.
+ */
+export async function invokeUserHookSafely(
+  self: ReactiveAgentBuilder,
+  hook: LifecycleHook,
+  ctx: { phase: string; iteration: number },
+): Promise<void> {
+  const surface = (err: unknown): void => {
+    const handler = (
+      self as unknown as {
+        _errorHandler?: (
+          e: RuntimeErrors | Error,
+          c: {
+            taskId: string;
+            phase: string;
+            iteration: number;
+            lastStep?: string;
+          },
+        ) => void;
+      }
+    )._errorHandler;
+    const normalized = err instanceof Error ? err : new Error(String(err));
+    if (handler) {
+      try {
+        handler(normalized, {
+          taskId: "",
+          phase: ctx.phase,
+          iteration: ctx.iteration,
+        });
+      } catch {
+        // Handler-of-handler crash: swallow to avoid recursion; preserve original via console.warn
+        console.warn(
+          "[reactive-agents] error handler crashed while reporting lifecycle hook failure:",
+          normalized,
+        );
+      }
+      return;
+    }
+    console.warn(
+      "[reactive-agents] lifecycle hook threw (no errorHandler registered):",
+      normalized,
+    );
+  };
+  let result: unknown;
+  try {
+    result = hook.handler({
+      phase: ctx.phase,
+      iteration: ctx.iteration,
+    } as ExecutionContext);
+  } catch (err) {
+    surface(err);
+    return;
+  }
+  if (result && typeof (result as { then?: unknown }).then === "function") {
+    try {
+      await (result as Promise<unknown>);
+    } catch (err) {
+      surface(err);
+    }
+  }
+}

--- a/packages/runtime/src/builder/wither-applies.ts
+++ b/packages/runtime/src/builder/wither-applies.ts
@@ -1,0 +1,160 @@
+/**
+ * Wither-body extractions for ReactiveAgentBuilder (W26-B-2 step 2).
+ *
+ * Each `applyXyzOptions(builder, opts)` mutates the builder's private fields
+ * and returns void. The corresponding `withXyz()` method becomes a thin
+ * wrapper: call the helper, return `this`.
+ *
+ * Mutation is intentional — withers are documented to mutate `this` in place
+ * and return `this` for chaining. The boundary cast (`builder as unknown as
+ * BuilderState`) types the private-field access so this file isn't littered
+ * with `(this as any)._field`.
+ */
+import type { ReactiveAgentBuilder } from "../builder.js";
+import type { LifecycleHook, ReasoningOptions } from "../types.js";
+import type { MemoryOptions } from "./types.js";
+import { invokeUserHookSafely } from "./api-surface.js";
+import type { RiHooks } from "./ri-wiring.js";
+
+/** Typed view of the builder's private fields that the wither bodies mutate. */
+interface BuilderState {
+  _enableReactiveIntelligence: boolean;
+  _reactiveIntelligenceOptions?: Partial<
+    import("@reactive-agents/reactive-intelligence").ReactiveIntelligenceConfig
+  >;
+  _riHooks?: RiHooks;
+  _riConstraints?: {
+    allowedStrategySwitch?: string[];
+    maxTemperatureAdjustment?: number;
+    neverEarlyStop?: boolean;
+    neverHumanEscalate?: boolean;
+    protectedSkills?: string[];
+    lockedSkills?: string[];
+  };
+  _riAutonomy?: "full" | "suggest" | "observe";
+  _enableMemory: boolean;
+  _memoryTier: "1" | "2";
+  _memoryOptions?: MemoryOptions;
+  _hooks: LifecycleHook[];
+}
+
+const asState = (builder: ReactiveAgentBuilder): BuilderState =>
+  builder as unknown as BuilderState;
+
+/**
+ * Apply `.withReactiveIntelligence(arg)` configuration. Handles both the
+ * boolean toggle form and the object form (which may carry RI-only fields
+ * mixed with handler callbacks, constraints, and autonomy).
+ */
+export const applyReactiveIntelligenceOptions = (
+  builder: ReactiveAgentBuilder,
+  arg?:
+    | boolean
+    | (Partial<
+        import("@reactive-agents/reactive-intelligence").ReactiveIntelligenceConfig
+      > &
+        Record<string, any>),
+): void => {
+  const state = asState(builder);
+  if (typeof arg === "boolean") {
+    state._enableReactiveIntelligence = arg;
+    return;
+  }
+  state._enableReactiveIntelligence = true;
+  if (!arg) return;
+  const {
+    onEntropyScored,
+    onControllerDecision,
+    onSkillActivated,
+    onSkillRefined,
+    onSkillConflict,
+    onMidRunAdjustment,
+    constraints,
+    autonomy,
+    ...riConfig
+  } = arg as any;
+  state._reactiveIntelligenceOptions = riConfig;
+  if (
+    onEntropyScored ||
+    onControllerDecision ||
+    onSkillActivated ||
+    onSkillRefined ||
+    onSkillConflict ||
+    onMidRunAdjustment
+  ) {
+    state._riHooks = {
+      onEntropyScored,
+      onControllerDecision,
+      onSkillActivated,
+      onSkillRefined,
+      onSkillConflict,
+      onMidRunAdjustment,
+    };
+  }
+  if (constraints) state._riConstraints = constraints;
+  if (autonomy) state._riAutonomy = autonomy;
+};
+
+/**
+ * Apply `.withMemory(arg)` configuration. Handles the legacy string-tier form
+ * (with deprecation warning) and the object form.
+ */
+export const applyMemoryOptions = (
+  builder: ReactiveAgentBuilder,
+  tierOrOptions?: "1" | "2" | MemoryOptions,
+): void => {
+  const state = asState(builder);
+  state._enableMemory = true;
+  if (typeof tierOrOptions === "string") {
+    const newForm =
+      tierOrOptions === "2"
+        ? '.withMemory({ tier: "enhanced" })'
+        : ".withMemory()";
+    console.warn(
+      `⚠ withMemory("${tierOrOptions}") is deprecated. Use ${newForm} instead.`,
+    );
+    state._memoryTier = tierOrOptions;
+    return;
+  }
+  if (!tierOrOptions) return;
+  if (tierOrOptions.tier) {
+    state._memoryTier = tierOrOptions.tier === "enhanced" ? "2" : "1";
+  }
+  state._memoryOptions = tierOrOptions;
+};
+
+/**
+ * Apply `.withHook(hook)` registration. Pushes the hook onto the builder's
+ * lifecycle list AND mirrors it as a harness phase hook for compose-side
+ * observability. Returns a callback to register the harness side (caller
+ * invokes via `builder.withHarness(...)` to keep the chaining contract).
+ */
+export const applyHookRegistration = (
+  builder: ReactiveAgentBuilder,
+  hook: LifecycleHook,
+): ((
+  h: import("@reactive-agents/core").Harness,
+) => void) => {
+  asState(builder)._hooks.push(hook);
+
+  // Harness registration callback — caller passes to .withHarness(...).
+  if (hook.timing === "on-error") {
+    return (h) => {
+      h.onError(
+        hook.phase as import("@reactive-agents/core").Phase,
+        async (_err, ctx) => {
+          await invokeUserHookSafely(builder, hook, ctx);
+        },
+      );
+    };
+  }
+  const kind = hook.timing === "before" ? "before" : "after";
+  return (h) => {
+    h[kind](
+      hook.phase as import("@reactive-agents/core").Phase,
+      async (ctx) => {
+        await invokeUserHookSafely(builder, hook, ctx);
+      },
+    );
+  };
+};

--- a/wiki/Research/Debriefs/2026-05-24-w26b2-builder-withers-debrief.md
+++ b/wiki/Research/Debriefs/2026-05-24-w26b2-builder-withers-debrief.md
@@ -1,0 +1,44 @@
+---
+date: 2026-05-24
+bundle: w26b2-builder-withers
+pr: "#134"
+issue: "#76 (final follow-up)"
+status: shipped
+---
+
+# Execution Retro: W26-B-2 builder wither + api-surface
+
+**Budget:** ~60 min | **Actual:** ~25 min execute phase
+
+## Outcomes
+
+- **Net LOC delta:** builder.ts: 2512 → 2372 (-140 / -5.6%). Two new modules (api-surface.ts +127, wither-applies.ts +163).
+- **Net test delta:** 0 (runtime 811/0/1; build 38/38).
+- **Issue #76 status:** still over ≤1500 LOC threshold for builder.ts; recommended close with W26 cumulative summary.
+
+## What worked
+
+- **Identified the realistic upper bound early.** Quick survey of 71 wither methods showed most bodies are 1-5 LOC; only ~5 had bodies large enough to make extraction worthwhile. Stopped chasing the ≤1500 target after this analysis and shipped what was clearly worth shipping.
+- **Boundary-typed helpers.** `wither-applies.ts` declares a `BuilderState` interface listing exactly the private fields each helper mutates. Single named cast (`asState(builder)`) replaces 10+ scattered `(this as any)._field` accesses. Reviewer can grep the interface to know the helper's blast radius.
+- **Re-export `ReactiveAgents.create` inline.** The `.create` factory is one line (`new ReactiveAgentBuilder()`). Trying to extract it would have required a dynamic-import dance to avoid the api-surface ↔ builder cycle. Keeping it inline was the right call; `fromConfig` and `fromJSON` extract cleanly because they already use dynamic imports internally.
+
+## What didn't
+
+- **builder.ts doesn't fit ≤1500 LOC under any plausible refactor scheme.** ~150 LOC of private state field declarations + ~40 wither docstrings (20-30 lines each = ~1000 LOC of just docs) + the `buildEffect` orchestrator (~200 LOC even after W26-B). Removing the doc weight isn't refactoring — it's a documentation choice. The ≤1500 target from #76 was probably set without accounting for JSDoc bulk.
+- **Same master-plan stale-baseline issue.** Branched off origin/main pre-#131 merge; baseline was 2512 (pre-W26-B) rather than 2271 (post-W26-B). Decided to ship anyway — extractions are independent and trivially rebase-able when #131 lands.
+
+## Skill improvements
+
+1. **When LOC reduction stalls because of docstring weight, document the cap honestly.** The ≤1500 target from #76 didn't anticipate that wither methods carry ~30 LOC of JSDoc each. Future LOC-cap issues should specify whether docstrings count or not, and the audit skill should weight docstring bulk separately from logic bulk.
+2. **For builder.ts specifically**: any further reduction needs either (a) a `withers/*.ts` per-domain split with one file per option family + class-mixin composition, OR (b) moving @example blocks to docs/. Both are bigger projects than a single bundle.
+
+## Process inflation guard
+
+- #76 verified-by claim held (builder.ts at 2512 at branch creation, matching what audit-2026-05-21 reported drift-adjusted).
+- No bugs surfaced.
+
+## Next actions
+
+- [ ] PR #134 awaits review + merge.
+- [ ] After all open W26 PRs (#130, #131, #132, #133, #134) merge: close #76 with cumulative-W26 summary comment.
+- [ ] If ≤1500 builder.ts is a strict requirement: file separate "builder.ts doc-bulk reduction" issue (move @example blocks to docs/).


### PR DESCRIPTION
## Bundle: W26-B-2 — builder.ts wither + api-surface extraction

Partial follow-up to W26-B (PR #131). Together they close the buildEffect + wither portions of #76, though builder.ts still sits above ≤1500 due to docstring/state-declaration weight that isn't extractable as logic.

## Summary

Two cohesive extractions:

1. **`builder/api-surface.ts`** — Hoists `fromConfig` / `fromJSON` factories (used by the `ReactiveAgents` namespace) + `invokeUserHookSafely` (internal helper used by `withHook`) out of builder.ts's module top. The `ReactiveAgents.create` factory stays inline next to the class definition; the namespace now references the extracted exports for the async forms.

2. **`builder/wither-applies.ts`** — Hoists three heavy wither bodies into option-applier helpers:
   - `applyReactiveIntelligenceOptions(builder, arg)` (39-LOC destructure body of `withReactiveIntelligence`)
   - `applyMemoryOptions(builder, opts)` (18-LOC tier-normalization body of `withMemory`)
   - `applyHookRegistration(builder, hook)` (18-LOC harness-mirroring body of `withHook` — returns a callback fed to `.withHarness()`)

Three wither methods become 1-2 line wrappers. Boundary types (`BuilderState` interface in `wither-applies.ts`) document exactly which private fields the helpers mutate.

## Verification

- `bun test packages/runtime/`: **811 pass / 0 fail / 1 skip / 1480 expect()** (matches baseline exactly)
- `bun run build`: **38/38 successful** (DTS clean — re-exports surface correctly)
- `wc -l packages/runtime/src/builder.ts`: **2512 → 2372** (-140 / -5.6%)

## Plan + Retro

- Master: `wiki/Planning/Implementation-Plans/2026-05-24-w26-decomposition-master.md`
- Retro: filed after merge at `wiki/Research/Debriefs/2026-05-24-w26b2-builder-withers-debrief.md`

## #76 Status After This PR

builder.ts at 2372 LOC, still above the ≤1500 threshold. Realistic assessment: most of the remaining bulk is **150 LOC of private state field declarations + ~40 `withX` method docstrings averaging 20-30 lines each**. Doc weight is not refactor-extractable as runtime behavior — addressing it would mean moving JSDoc examples to a docs/ recipe page (separate effort, possibly user-visible change).

**Recommend** closing #76 with the cumulative W26 result (1495 LOC out of monoliths, 3 of 4 files under 1500) and filing a separate "builder.ts doc-bulk reduction" issue if the LOC cap is a strict requirement.