### PR TITLE
fix(examples): wire JudgeLLMService Tag in eval-framework example

### DIFF
--- a/apps/examples/src/advanced/16-eval-framework.ts
+++ b/apps/examples/src/advanced/16-eval-framework.ts
@@ -16,8 +16,9 @@ import { ReactiveAgents } from "reactive-agents";
 import {
   EvalService,
   EvalServiceLive,
+  JudgeLLMService,
 } from "@reactive-agents/eval";
-import { TestLLMServiceLayer } from "@reactive-agents/llm-provider";
+import { LLMService, TestLLMServiceLayer } from "@reactive-agents/llm-provider";
 
 export interface ExampleResult {
   passed: boolean;
@@ -81,14 +82,22 @@ export async function run(opts?: { provider?: string; model?: string }): Promise
     return result;
   });
 
-  // EvalServiceLive requires LLMService for LLM-as-judge scoring
-  // In test mode, provide TestLLMServiceLayer which returns deterministic responses
+  // EvalServiceLive requires JudgeLLMService (Rule 4 — frozen judge, separate
+  // code path from the SUT's LLMService). In test mode we build a deterministic
+  // JudgeLLMService by reusing TestLLMService's complete() through a thin adapter.
   const testLLMLayer = TestLLMServiceLayer([
     { match: "accuracy", text: "SCORE: 0.9\nRATIONALE: The output correctly identifies Paris as the capital of France." },
     { match: "relevance", text: "SCORE: 1.0\nRATIONALE: The answer is directly relevant to the question asked." },
     { text: "SCORE: 0.85\nRATIONALE: Good response." },
   ]);
-  const evalLayer = EvalServiceLive.pipe(Layer.provide(testLLMLayer));
+  const judgeLayer = Layer.effect(
+    JudgeLLMService,
+    Effect.gen(function* () {
+      const llm = yield* LLMService;
+      return { complete: llm.complete };
+    }),
+  ).pipe(Layer.provide(testLLMLayer));
+  const evalLayer = EvalServiceLive.pipe(Layer.provide(judgeLayer));
 
   const evalResult = await Effect.runPromise(
     evalProgram.pipe(Effect.provide(evalLayer)),


### PR DESCRIPTION
## Problem

Example #16 (`apps/examples/src/advanced/16-eval-framework.ts`) fails with:

```
Service not found: JudgeLLMService
  at packages/eval/src/services/judge-llm-service.ts:29
```

## Root cause

`EvalService.runCase()` resolves the `JudgeLLMService` Tag (W9 FIX-21 / Rule 4 frozen-judge isolation, see `00-RESEARCH-DISCIPLINE.md`). The example was providing `TestLLMServiceLayer` (which fulfills the `LLMService` Tag, not `JudgeLLMService`).

## Fix

Build a thin adapter Layer that yields `LLMService` from `TestLLMServiceLayer` and re-exposes its `.complete` as `JudgeLLMService`. Deterministic judge responses unchanged.

```typescript
const judgeLayer = Layer.effect(
  JudgeLLMService,
  Effect.gen(function* () {
    const llm = yield* LLMService;
    return { complete: llm.complete };
  }),
).pipe(Layer.provide(testLLMLayer));
const evalLayer = EvalServiceLive.pipe(Layer.provide(judgeLayer));
```

## Verification

`bun run apps/examples/index.ts` against ollama (qwen3:14b): **26/26 pass** (was 25/26 with #16 failing).

Surface unchanged for live runs — wiring fix only.