### PR TITLE
fix(reactive-intelligence): RI early-stop empty-run invariant — FM-A3 backstop

### DIFF
--- a/packages/reactive-intelligence/src/controller/early-stop.ts
+++ b/packages/reactive-intelligence/src/controller/early-stop.ts
@@ -4,12 +4,26 @@ import type { ControllerDecision, ControllerEvalParams } from "../types.js";
  * Evaluate whether the agent should early-stop based on entropy trajectory.
  * Fires when trajectory has been "converging" for convergenceCount consecutive
  * iterations and latest composite is at or below convergenceThreshold.
+ *
+ * Empty-run invariant (FM-A3 backstop, 2026-05-25):
+ * Suppresses early-stop on either branch when `hasUserOutput === false` AND
+ * the agent isn't at the last allowed iteration. Otherwise an empty
+ * `state.output` would terminate the run with a useless
+ * `status="failure", error="Reasoning failed"`. Last-iteration early-stop is
+ * still allowed because the agent is out of budget regardless.
  */
 export function evaluateEarlyStop(
   params: ControllerEvalParams,
 ): (ControllerDecision & { decision: "early-stop" }) | null {
-  const { entropyHistory, config, calibration, iteration, maxIterations } = params;
+  const { entropyHistory, config, calibration, iteration, maxIterations, hasUserOutput } = params;
   const convergenceCount = config.earlyStopConvergenceCount ?? 2;
+
+  // Empty-run invariant — applies to BOTH branches below.
+  // Permissive default: when caller omits the flag, treat as `true` so outer-loop
+  // synthetic evaluators (plan-execute, ToT) that don't plumb state.output keep
+  // their current behavior.
+  const atLastIteration = maxIterations > 0 && iteration >= maxIterations - 1;
+  const suppressForEmptyOutput = hasUserOutput === false && !atLastIteration;
 
   // Need enough history and must be past iteration 1 (too early to stop)
   if (entropyHistory.length < convergenceCount || iteration < 2) return null;
@@ -21,6 +35,7 @@ export function evaluateEarlyStop(
     // Check latest composite is at or below convergence threshold
     const latest = entropyHistory[entropyHistory.length - 1]!;
     if (latest.composite <= calibration.convergenceThreshold) {
+      if (suppressForEmptyOutput) return null;
       return {
         decision: "early-stop",
         reason: `Entropy converging for ${convergenceCount} iterations (composite: ${latest.composite.toFixed(3)}, threshold: ${calibration.convergenceThreshold})`,
@@ -33,6 +48,7 @@ export function evaluateEarlyStop(
   // Catches non-converging runaway loops as a safety net.
   const iterationsBeforeMax = config.earlyStopIterationsBeforeMax ?? 2;
   if (maxIterations > 0 && iteration >= maxIterations - iterationsBeforeMax) {
+    if (suppressForEmptyOutput) return null;
     return {
       decision: "early-stop",
       reason: `Approaching maxIterations (iter=${iteration}, max=${maxIterations})`,

--- a/packages/reactive-intelligence/src/types.ts
+++ b/packages/reactive-intelligence/src/types.ts
@@ -282,6 +282,21 @@ export type ControllerEvalParams = {
   readonly consecutiveToolFailures?: number;
   /** Name of the tool currently on a failure streak, if any. */
   readonly failingToolName?: string;
+  /**
+   * True when `state.output` is a non-empty user-facing string.
+   *
+   * Backstop for FM-A3 (Spurious Tool Engagement → empty-run termination):
+   * RI's `early-stop` MUST NOT terminate a run that has produced no user-facing
+   * output unless we're at the last allowed iteration (`iteration ≥ maxIterations - 1`).
+   * Otherwise the kernel exits `done` with `state.output=null`, which the runtime
+   * wraps as `status="failure", error="Reasoning failed"` — an unhelpful empty failure.
+   *
+   * Caller must compute from kernel state at call time. When omitted, the
+   * suppression defaults to a permissive `true` (preserves prior behavior for
+   * outer-loop synthetic evaluators in plan-execute / ToT that maintain their
+   * own output bookkeeping).
+   */
+  readonly hasUserOutput?: boolean;
 };
 
 export const defaultReactiveIntelligenceConfig: ReactiveIntelligenceConfig = {

--- a/packages/reactive-intelligence/tests/controller/early-stop.test.ts
+++ b/packages/reactive-intelligence/tests/controller/early-stop.test.ts
@@ -162,4 +162,80 @@ describe("evaluateEarlyStop", () => {
     // Convergence wins: reason should contain "Entropy converging", not "Approaching maxIterations"
     expect(result!.reason).toContain("Entropy converging");
   });
+
+  // ── FM-A3 backstop: empty-run invariant (2026-05-25) ──
+  // RI early-stop must not terminate a run with no user-facing output unless
+  // we're at the last allowed iteration. See trace 01KSGRBEJQ8APBNQ5HQ0BVN4Z9
+  // (success-typescript-paradigm, qwen3.5:latest, maxIter=4 → fired at iter=2
+  // with outputLen=0 → status=failure "Reasoning failed").
+  describe("empty-run invariant (hasUserOutput)", () => {
+    it("suppresses overflow early-stop when hasUserOutput=false AND not at last iter (maxIter=4, iter=2)", () => {
+      // Reproduces the qwen3.5:latest regression: short-budget task triggers
+      // overflow at 50% utilization with no output yet → must NOT fire.
+      const params = makeParams({
+        entropyHistory: [makeEntry(0.15, "flat"), makeEntry(0.15, "flat")],
+        iteration: 2,
+        maxIterations: 4,
+        hasUserOutput: false,
+      });
+      expect(evaluateEarlyStop(params)).toBeNull();
+    });
+
+    it("suppresses convergence early-stop when hasUserOutput=false AND not at last iter", () => {
+      // Converging entropy + below threshold but no output yet → must NOT fire.
+      const params = makeParams({
+        entropyHistory: [
+          makeEntry(0.4, "flat"),
+          makeEntry(0.25, "converging"),
+          makeEntry(0.15, "converging"),
+        ],
+        iteration: 3,
+        maxIterations: 10,
+        hasUserOutput: false,
+      });
+      expect(evaluateEarlyStop(params)).toBeNull();
+    });
+
+    it("allows overflow early-stop when hasUserOutput=false AND at last iter (iter === maxIter - 1)", () => {
+      // At iter 3 of maxIter 4 → last iteration; out of budget regardless,
+      // so empty-run termination is acceptable.
+      const params = makeParams({
+        entropyHistory: [makeEntry(0.6, "flat"), makeEntry(0.6, "flat")],
+        iteration: 3,
+        maxIterations: 4,
+        hasUserOutput: false,
+      });
+      const result = evaluateEarlyStop(params);
+      expect(result).not.toBeNull();
+      expect(result!.decision).toBe("early-stop");
+      expect(result!.reason).toContain("Approaching maxIterations");
+    });
+
+    it("allows overflow early-stop when hasUserOutput=true (output already present)", () => {
+      // Standard overflow case unaffected by the invariant when output exists.
+      const params = makeParams({
+        entropyHistory: [makeEntry(0.6, "flat"), makeEntry(0.6, "flat")],
+        iteration: 2,
+        maxIterations: 4,
+        hasUserOutput: true,
+      });
+      const result = evaluateEarlyStop(params);
+      expect(result).not.toBeNull();
+      expect(result!.decision).toBe("early-stop");
+    });
+
+    it("permissive default: when hasUserOutput omitted, behaves as if true (preserves outer-loop callers)", () => {
+      // plan-execute and ToT call evaluate() without hasUserOutput. The flag
+      // omission must NOT suppress — they manage their own output bookkeeping.
+      const params = makeParams({
+        entropyHistory: [makeEntry(0.6, "flat"), makeEntry(0.6, "flat")],
+        iteration: 2,
+        maxIterations: 4,
+        // hasUserOutput intentionally omitted
+      });
+      const result = evaluateEarlyStop(params);
+      expect(result).not.toBeNull();
+      expect(result!.decision).toBe("early-stop");
+    });
+  });
 });

--- a/packages/reasoning/src/kernel/capabilities/reflect/reactive-observer.ts
+++ b/packages/reasoning/src/kernel/capabilities/reflect/reactive-observer.ts
@@ -233,6 +233,8 @@ export function runReactiveObserver(
           priorDecisionsThisRun: priorDecisionsThisRun.length > 0 ? priorDecisionsThisRun : undefined,
           consecutiveToolFailures: consecutiveToolFailures > 0 ? consecutiveToolFailures : undefined,
           failingToolName,
+          // FM-A3 backstop — empty-output invariant for RI early-stop.
+          hasUserOutput: typeof s.output === "string" && s.output.trim().length > 0,
         });
 
         for (const decision of decisions) {

--- a/wiki/Research/Harness-Reports/improvement-2026-05-25.md
+++ b/wiki/Research/Harness-Reports/improvement-2026-05-25.md
@@ -1,0 +1,119 @@
+---
+tags: [harness-improvement-loop, fix, empirical, evidence]
+date: 2026-05-25
+model: qwen3.5:latest
+probe: failure-corpus.ts (8 scenarios)
+status: shipped — branch fix/ri-empty-run-invariant
+---
+
+# Harness Improvement Loop — 2026-05-25
+
+## Probe baseline (qwen3.5:latest)
+
+8-scenario failure-corpus run (4 labeled "success", 4 labeled "failure"):
+
+| Scenario | Label | Before | After |
+|---|---|---|---|
+| success-days-of-week | success | ✅ | ✅ |
+| success-capital-france | success | ✅ | ✅ |
+| success-rgb-colors | success | ✅ | ✅ |
+| **success-typescript-paradigm** | success | ❌ | ✅ **FIXED** |
+| failure-rate-limit-loop | failure | failure | failure |
+| failure-save-loop | failure | failure | failure |
+| failure-verify-loop | failure | failure | failure |
+| failure-contradictory-data | failure | failure | failure |
+
+Success-corpus completion: 3/4 → **4/4**. Failure-corpus detection: 4/4 → 4/4 (no regression).
+
+## Root cause — FM-A3 Spurious Tool Engagement + RI empty-run termination
+
+Trace `01KSGRBEJQ8APBNQ5HQ0BVN4Z9` (before fix):
+
+- Task: `success-typescript-paradigm` — pure knowledge recall, `tools: []`, maxIterations=4.
+- Agent invoked auto-injected `find` tool 2× (looking up "TypeScript programming paradigm features") despite `tools: []` in the scenario config.
+- RI dispatched `early-stop` at iter 2 (50% of budget) with reason `Approaching maxIterations (iter=2, max=4)`.
+- Kernel terminated `status=done` via `dispatcher_early_stop` with `outputLen=0`.
+- Runtime wrapped empty output as `status="failure", error="Reasoning failed"`.
+
+Two coupled bugs:
+
+1. **`find` is in `FRAMEWORK_TOOL_NAMES`** (`tools-registry.ts:30`) — auto-injected regardless of scenario `tools: []`. Agent reached for it on a knowledge task that didn't need any tool. **(Root cause — deferred to follow-up; this commit is the backstop only.)**
+2. **`evaluateEarlyStop` overflow guard** (`early-stop.ts:34`) fires at `iter >= maxIter - iterationsBeforeMax` (default 2). For `maxIter=4` this triggers at iter 2 — **50% utilization, not "approaching"**. Fires regardless of whether agent has produced any output.
+
+## Structural fix — `hasUserOutput` invariant
+
+Empty-run invariant added to `evaluateEarlyStop`: RI's `early-stop` MUST NOT fire when `hasUserOutput === false && iteration < maxIterations - 1`. Applies to **both** the convergence branch and the overflow guard. Last-iteration early-stop still allowed (agent out of budget regardless).
+
+Edits:
+1. `packages/reactive-intelligence/src/types.ts` — `ControllerEvalParams.hasUserOutput?: boolean`. Permissive default (omitted → suppression doesn't apply) preserves outer-loop callers in plan-execute / ToT that manage their own output bookkeeping.
+2. `packages/reactive-intelligence/src/controller/early-stop.ts` — derived `suppressForEmptyOutput`, applied to both early-return branches.
+3. `packages/reasoning/src/kernel/capabilities/reflect/reactive-observer.ts` — caller passes `hasUserOutput: typeof s.output === "string" && s.output.trim().length > 0`.
+
+## Verification — same model, same probe
+
+Trace diff `01KSGRBEJQ8APBNQ5HQ0BVN4Z9` → `01KSGS4YG317D4KJNJER83FYXS`:
+
+```
+final state
+  A: status=done outputLen=0   terminatedBy=controller_early_stop:dispatcher_early_stop
+  B: status=done outputLen=593 terminatedBy=controller_early_stop:dispatcher_early_stop
+
+verifier verdicts: 0 → 1/1 passed
+interventions suppressed: 1 → 2  (extra suppression = new invariant firing)
+iterations: 3 → 8
+tool calls: 2 → 1  (find called once instead of twice)
+```
+
+Content sample (after fix, first 150 chars of output):
+
+> TypeScript primarily supports **Object-Oriented Programming (OOP)**, though it is technically a multi-paradigm language that also supports functional programming. Two features that reflect this OOP focus: 1. **Classes and Inheritance**…
+
+Legitimate technical answer. Verifier `output-not-harness-parrot` + `synthesis-grounded` checks passed.
+
+## Tests
+
+- New: 5 cases in `early-stop.test.ts` covering both branches of the invariant (overflow + convergence, with-output + without-output, at-last-iter vs not, permissive default for omitted flag).
+- RI package: 476 → **481** pass / 0 fail.
+- Reasoning package: 1373 / 0 fail (no regression).
+- Workspace: 5645 → **5655** pass / 0 fail / 23 skip.
+- Build: 38/38 green.
+
+## Architectural framing — Affordance Leakage
+
+Today's fix is a **backstop**. The root cause is broader and codified as a new design principle:
+
+> **Affordance Leakage** — framework injects tools, RI decisions, strategy variants, and Compose tags by default. Agent must actively suppress what shouldn't be in scope rather than opt into what should.
+
+Convergent evidence (all symptoms share this root):
+
+| Symptom | Affordance leaked |
+|---|---|
+| FM-A3 (today) | `find` auto-injected on `tools: []` task → agent calls it → empty output |
+| RI early-stop at 50% budget | Decision fires without checking if output exists |
+| ToT 3-23× cost on trivial tasks | Strategy routes by task-shape, not cost-vs-benefit |
+| 8/13 RI decisions dead in failure corpus | Declared variants never fire — surface > usage |
+| 4/7 Compose tags dead | Same shape — emit site never written |
+| M2a/b/c pre-Phase-0 | Framework markup leaked because producer had no audience-scope tag |
+
+North Star §9 "Anti-Scaffold" caught the *declared-without-callers* half. Flip side is unfixed: *callers-without-scope-gates*. Both ship noise.
+
+Proposed structural directions (filed as follow-up issues):
+
+1. `ToolDefinition.relevancePredicate?: (task: TaskComprehension) => Confidence` — `find` returns LOW on knowledge tasks → not in registry presented to LLM
+2. `ControllerDecision.relevancePredicate` — formalizes today's empty-run invariant for all 13 decision variants
+3. `StrategyAdapter.costEstimate(task)` → adaptive router compares before picking ToT for trivial math
+4. `Compose.Tag.requireEmitSite: true` lint rule
+
+## Out-of-scope (filed follow-ups)
+
+- **`find` auto-injection root cause** — `tools: []` should yield no `find` tool. Backstop in this commit; root fix is separate (`FRAMEWORK_TOOL_NAMES` audit + tool-relevance gating).
+- **`failure-verify-loop` overran maxIter (13 actual vs 12 declared)** — off-by-one or "force-last-synthesis" path; file as separate issue.
+- **Convergence-threshold tuning for cogito:14b / qwen3.5:latest** — `convergenceThreshold=0.3` default is calibrated against historical models; today's qwen3.5 hits 0.15 on trivial tasks and could trigger convergence-branch early-stop at any iter ≥2. Currently masked by `hasUserOutput=false` suppression, but worth tier-specific recalibration.
+
+## Files touched
+
+- `packages/reactive-intelligence/src/controller/early-stop.ts`
+- `packages/reactive-intelligence/src/types.ts`
+- `packages/reactive-intelligence/tests/controller/early-stop.test.ts`
+- `packages/reasoning/src/kernel/capabilities/reflect/reactive-observer.ts`
+- `wiki/Research/Harness-Reports/improvement-2026-05-25.md` (this file)


### PR DESCRIPTION
## Summary

RI's `evaluateEarlyStop` was terminating runs at iter 2 of maxIter 4 (50% utilization, not "approaching") with `state.output=null` — runtime then wrapped the empty state as `status="failure", error="Reasoning failed"`. This commit adds an empty-run invariant: RI early-stop MUST NOT terminate a run with no user-facing output unless we're at the last allowed iteration.

## Empirical evidence

`failure-corpus.ts` × `qwen3.5:latest` × `success-typescript-paradigm`:

| | Before | After |
|---|---|---|
| outputLen | 0 | **593** |
| verifier verdicts | 0 | **1/1 passed** |
| Success-corpus | 3/4 | **4/4** |
| Failure-corpus | 4/4 | 4/4 (no regression) |
| RI tests | 476 / 0 | **481 / 0** |
| Workspace | 5645 / 0 | **5655 / 0** |
| Build | 38/38 | 38/38 |

Trace diff `01KSGRBEJQ8APBNQ5HQ0BVN4Z9` → `01KSGS4YG317D4KJNJER83FYXS` in full report.

## Architectural framing

This is a **backstop**, not the root cause. The root cause is broader:

> **Affordance Leakage** — framework injects tools (`find`), RI decisions, strategy variants, and Compose tags by default. Agent must actively suppress what shouldn't be in scope rather than opt into what should.

Full diagnosis + 4 proposed follow-up directions in `wiki/Research/Harness-Reports/improvement-2026-05-25.md`.

## Out-of-scope (filed as followups)

- `find` auto-injection on `tools: []` tasks (FM-A3 root cause)
- `failure-verify-loop` 13 iters at maxIter 12 (off-by-one)
- Convergence-threshold tier recalibration for qwen3.5:latest

## Files

- `packages/reactive-intelligence/src/types.ts` — `ControllerEvalParams.hasUserOutput?`
- `packages/reactive-intelligence/src/controller/early-stop.ts` — invariant applied to both branches
- `packages/reactive-intelligence/src/controller/reactive-observer.ts` — caller plumb (in reasoning)
- `packages/reactive-intelligence/tests/controller/early-stop.test.ts` — 5 new cases
- `wiki/Research/Harness-Reports/improvement-2026-05-25.md` — full report