### PR TITLE
feat(llm-provider): Anthropic prompt caching (Lever 1) — 90% input discount on multi-turn

### DIFF
--- a/packages/core/src/services/event-bus.ts
+++ b/packages/core/src/services/event-bus.ts
@@ -1136,6 +1136,10 @@ export type AgentEvent =
         readonly stopReason?: string;
         readonly tokensIn?: number;
         readonly tokensOut?: number;
+        /** Anthropic prompt-caching: tokens that wrote new cache entries (Lever 1). */
+        readonly cacheCreationTokensIn?: number;
+        /** Anthropic prompt-caching: tokens served from cache hits. */
+        readonly cacheReadTokensIn?: number;
         readonly costUsd?: number;
         readonly durationMs?: number;
       };

--- a/packages/llm-provider/src/providers/anthropic.ts
+++ b/packages/llm-provider/src/providers/anthropic.ts
@@ -38,31 +38,53 @@ type AnthropicMessage = {
 
 const toAnthropicMessages = (
   messages: readonly LLMMessage[],
-): AnthropicMessage[] =>
-  messages
-    .filter((m) => m.role !== "system")
-    .map((m) => {
-      if (m.role === "tool") {
-        // Convert tool result to Anthropic's tool_result content block format
-        return {
-          role: "user" as AnthropicRole,
-          content: [{
-            type: "tool_result" as const,
-            tool_use_id: m.toolCallId,
-            content: m.content,
-          }] as unknown as AnthropicContentBlock[],
-        };
+): AnthropicMessage[] => {
+  const filtered = messages.filter((m) => m.role !== "system");
+
+  // Lever 1 prompt-caching — locate the last tool_result message and mark its
+  // tool_result block with cache_control. On multi-iteration runs the provider
+  // hits the cache on every message up to and including this breakpoint, so
+  // subsequent iterations re-process only the NEW tail (new assistant turn +
+  // user continuation). Combined with the system + tools breakpoints this
+  // uses 3 of Anthropic's 4 cache-breakpoint budget per request.
+  //
+  // The cache_control marker is a no-op on cold caches and when the cached
+  // prefix is below the per-model minimum (Sonnet: 1024 tok; Haiku: 2048 tok),
+  // so adding it unconditionally is safe.
+  let lastToolResultIdx = -1;
+  for (let i = filtered.length - 1; i >= 0; i--) {
+    if (filtered[i]?.role === "tool") {
+      lastToolResultIdx = i;
+      break;
+    }
+  }
+
+  return filtered.map((m, idx) => {
+    if (m.role === "tool") {
+      const block: Record<string, unknown> = {
+        type: "tool_result" as const,
+        tool_use_id: m.toolCallId,
+        content: m.content,
+      };
+      if (idx === lastToolResultIdx) {
+        block.cache_control = { type: "ephemeral" as const };
       }
       return {
-        role: m.role as AnthropicRole,
-        content:
-          typeof m.content === "string"
-            ? m.content
-            : (m.content as readonly ContentBlock[]).map(
-                (b) => b as unknown as AnthropicContentBlock,
-              ),
+        role: "user" as AnthropicRole,
+        content: [block] as unknown as AnthropicContentBlock[],
       };
-    });
+    }
+    return {
+      role: m.role as AnthropicRole,
+      content:
+        typeof m.content === "string"
+          ? m.content
+          : (m.content as readonly ContentBlock[]).map(
+              (b) => b as unknown as AnthropicContentBlock,
+            ),
+    };
+  });
+};
 
 const toAnthropicTool = (tool: {
   name: string;
@@ -96,23 +118,35 @@ const toEffectError = (error: unknown, provider: "anthropic"): LLMErrors => {
 };
 
 // ── System prompt caching ────────────────────────────────────────────────────
-// Anthropic's prompt caching uses cache_control on content blocks.
-// System prompts >= ~1024 tokens benefit from ephemeral caching; the 5-min
-// cache window avoids re-processing the same system prompt across turns.
-
-const MIN_SYSTEM_CACHE_CHARS = 4096; // ~1024 tokens at ~4 chars/token
+// Anthropic prompt caching: marking content with cache_control: { type:
+// "ephemeral" } tells the provider "everything from the request start up to
+// (and including) this block can be cached for 5 minutes". Subsequent calls
+// with the same prefix get a 90% input-token discount on the cached portion.
+//
+// Per-model minimum cacheable block: Sonnet 1024 tok, Haiku 2048 tok. Marking
+// a block below the threshold is a no-op (provider ignores the marker). So
+// marking unconditionally is safe — the provider self-gates.
+//
+// Lever 1 spike (this PR): wrap the system parameter as a content block with
+// cache_control on every call. Pairs with tool-list cache_control (already
+// present, on last tool entry) and message-thread cache_control (added in
+// `toAnthropicMessages` above, on last tool_result). Three breakpoints total,
+// well under Anthropic's 4-breakpoint per-request limit.
 
 type SystemParam =
   | string
   | Array<{ type: "text"; text: string; cache_control?: { type: "ephemeral" } }>;
 
 /**
- * Build the Anthropic `system` parameter. For long system prompts, wrap in
- * a content block with `cache_control: { type: "ephemeral" }`.
+ * Build the Anthropic `system` parameter. Wraps in a cache-able content block
+ * unconditionally — the provider auto-skips cache_control on blocks below the
+ * per-model minimum cacheable size (Sonnet: 1024 tok, Haiku: 2048 tok), so
+ * always marking is safe and lets longer scaffolds (real-world RA agents with
+ * multiple built-in tools + full ContextManager output) get cache benefit on
+ * iteration 1+ without any per-call decision logic.
  */
 const buildSystemParam = (systemPrompt: string | undefined): SystemParam | undefined => {
   if (!systemPrompt) return undefined;
-  if (systemPrompt.length < MIN_SYSTEM_CACHE_CHARS) return systemPrompt;
   return [{
     type: "text",
     text: systemPrompt,
@@ -309,6 +343,13 @@ export const AnthropicProviderLive = Layer.effect(
                     },
                     config.pricingRegistry,
                   ),
+                  // Lever 1 prompt-caching observability — mirrors complete() path.
+                  ...(typeof msg.usage.cache_creation_input_tokens === "number"
+                    ? { cacheCreationInputTokens: msg.usage.cache_creation_input_tokens }
+                    : {}),
+                  ...(typeof msg.usage.cache_read_input_tokens === "number"
+                    ? { cacheReadInputTokens: msg.usage.cache_read_input_tokens }
+                    : {}),
                 },
               });
               emit.end();
@@ -602,6 +643,15 @@ const mapAnthropicResponse = (
         },
         registry,
       ),
+      // Lever 1 prompt-caching observability — surface cache hit/creation
+      // counts up the stack so bench reports and runtime metrics can show
+      // "X input tok (Y cached)" instead of just total input.
+      ...(typeof response.usage.cache_creation_input_tokens === "number"
+        ? { cacheCreationInputTokens: response.usage.cache_creation_input_tokens }
+        : {}),
+      ...(typeof response.usage.cache_read_input_tokens === "number"
+        ? { cacheReadInputTokens: response.usage.cache_read_input_tokens }
+        : {}),
     },
     model: response.model ?? model,
     toolCalls: toolCalls.length > 0 ? toolCalls : undefined,

--- a/packages/llm-provider/src/types.ts
+++ b/packages/llm-provider/src/types.ts
@@ -575,6 +575,20 @@ export const TokenUsageSchema = Schema.Struct({
   totalTokens: Schema.Number,
   /** Estimated cost in USD based on provider pricing */
   estimatedCost: Schema.Number,
+  /**
+   * Tokens that wrote NEW entries to the provider's prompt cache on this turn.
+   * Charged at a premium (e.g. Anthropic: 1.25x base input). Subsequent calls
+   * within the cache TTL window read these for the discounted cache_read price.
+   * Optional — providers without prompt caching omit this field.
+   */
+  cacheCreationInputTokens: Schema.optional(Schema.Number),
+  /**
+   * Tokens served from the provider's prompt cache (cache hit). Charged at a
+   * deep discount (e.g. Anthropic: 0.1x base input — 90% off). Indicates the
+   * caching infrastructure (Lever 1, GH #143-followup) is firing on multi-turn
+   * conversations. Optional — providers without prompt caching omit this field.
+   */
+  cacheReadInputTokens: Schema.optional(Schema.Number),
 });
 
 /**

--- a/packages/llm-provider/tests/anthropic-prompt-caching.test.ts
+++ b/packages/llm-provider/tests/anthropic-prompt-caching.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, mock, beforeAll } from "bun:test";
+import { Effect, Layer } from "effect";
+
+// ─── Mock @anthropic-ai/sdk BEFORE the provider module is imported ───
+// Pattern mirrors gemini-provider.test.ts. Lever 1 prompt-caching spike —
+// validates cache_control markers fire on system + last tool + last
+// tool_result so multi-iter Anthropic calls hit the 5-min ephemeral cache.
+
+let capturedCreateOpts: Record<string, unknown> | null = null;
+
+const mockCreate = mock(async (opts: unknown) => {
+  capturedCreateOpts = opts as Record<string, unknown>;
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    content: [{ type: "text", text: "ok" }],
+    model: "claude-sonnet-4-6",
+    stop_reason: "end_turn",
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_creation_input_tokens: 100,
+      cache_read_input_tokens: 500,
+    },
+  };
+});
+
+mock.module("@anthropic-ai/sdk", () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: mockCreate,
+      stream: () => ({ on: () => {} }),
+    };
+  },
+}));
+
+import type { LLMService as LLMServiceType } from "../src/index.js";
+import type { Layer as EffectLayer } from "effect";
+
+let AnthropicProviderLive: EffectLayer.Layer<LLMServiceType>;
+let LLMService: typeof import("../src/index.js")["LLMService"];
+let LLMConfig: typeof import("../src/index.js")["LLMConfig"];
+
+beforeAll(async () => {
+  const mod = await import("../src/index.js");
+  AnthropicProviderLive = mod.AnthropicProviderLive;
+  LLMService = mod.LLMService;
+  LLMConfig = mod.LLMConfig;
+});
+
+function makeLayer() {
+  const configLayer = Layer.succeed(LLMConfig, {
+    provider: "anthropic" as const,
+    apiKey: "test-key",
+    defaultModel: "claude-sonnet-4-6",
+    defaultMaxTokens: 1024,
+    defaultTemperature: 0.5,
+    pricingRegistry: undefined,
+  });
+  return Layer.provide(AnthropicProviderLive, configLayer);
+}
+
+describe("Anthropic prompt caching (Lever 1)", () => {
+  it("marks system prompt with cache_control on every call", async () => {
+    capturedCreateOpts = null;
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LLMService;
+        yield* llm.complete({
+          messages: [{ role: "user", content: "hi" }],
+          systemPrompt: "You are an agent.",
+        });
+      }).pipe(Effect.provide(makeLayer())),
+    );
+
+    expect(capturedCreateOpts).not.toBeNull();
+    const system = capturedCreateOpts!.system;
+    expect(Array.isArray(system)).toBe(true);
+    const arr = system as Array<{ type: string; cache_control?: { type: string } }>;
+    expect(arr).toHaveLength(1);
+    expect(arr[0]!.cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("marks the LAST tool with cache_control (existing behavior preserved)", async () => {
+    capturedCreateOpts = null;
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LLMService;
+        yield* llm.complete({
+          messages: [{ role: "user", content: "use a tool" }],
+          systemPrompt: "agent",
+          tools: [
+            { name: "first", description: "first tool", inputSchema: {} },
+            { name: "second", description: "second tool", inputSchema: {} },
+            { name: "third", description: "third tool", inputSchema: {} },
+          ],
+        });
+      }).pipe(Effect.provide(makeLayer())),
+    );
+
+    const tools = capturedCreateOpts!.tools as Array<{ name: string; cache_control?: { type: string } }>;
+    expect(tools).toHaveLength(3);
+    expect(tools[0]!.cache_control).toBeUndefined();
+    expect(tools[1]!.cache_control).toBeUndefined();
+    expect(tools[2]!.cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("marks the LAST tool_result message with cache_control on multi-turn input", async () => {
+    capturedCreateOpts = null;
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LLMService;
+        yield* llm.complete({
+          messages: [
+            { role: "user", content: "what is X?" },
+            { role: "assistant", content: "let me check" },
+            { role: "tool", toolCallId: "call_1", content: "X = 42" },
+            { role: "assistant", content: "answer is" },
+            { role: "tool", toolCallId: "call_2", content: "and here is more" },
+            { role: "user", content: "continue" },
+          ],
+        });
+      }).pipe(Effect.provide(makeLayer())),
+    );
+
+    const messages = capturedCreateOpts!.messages as Array<{
+      role: string;
+      content: string | Array<{ type: string; cache_control?: { type: string } }>;
+    }>;
+
+    // Find the two tool_result messages — only the LAST one should carry cache_control.
+    const toolResultMessages = messages.filter(
+      (m) =>
+        Array.isArray(m.content) &&
+        m.content.some((b) => b.type === "tool_result"),
+    );
+    expect(toolResultMessages).toHaveLength(2);
+
+    const firstToolResultBlock = (toolResultMessages[0]!.content as Array<{
+      type: string;
+      cache_control?: { type: string };
+    }>)[0]!;
+    expect(firstToolResultBlock.cache_control).toBeUndefined();
+
+    const lastToolResultBlock = (toolResultMessages[1]!.content as Array<{
+      type: string;
+      cache_control?: { type: string };
+    }>)[0]!;
+    expect(lastToolResultBlock.cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("surfaces cacheCreationInputTokens + cacheReadInputTokens in usage", async () => {
+    capturedCreateOpts = null;
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LLMService;
+        return yield* llm.complete({
+          messages: [{ role: "user", content: "hi" }],
+          systemPrompt: "agent",
+        });
+      }).pipe(Effect.provide(makeLayer())),
+    );
+
+    expect(result.usage.cacheCreationInputTokens).toBe(100);
+    expect(result.usage.cacheReadInputTokens).toBe(500);
+  });
+
+  it("omits cache_control on tool_result when no tool_result in messages", async () => {
+    capturedCreateOpts = null;
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const llm = yield* LLMService;
+        yield* llm.complete({
+          messages: [
+            { role: "user", content: "no tools called" },
+            { role: "assistant", content: "ok done" },
+            { role: "user", content: "continue" },
+          ],
+        });
+      }).pipe(Effect.provide(makeLayer())),
+    );
+
+    const messages = capturedCreateOpts!.messages as Array<{
+      role: string;
+      content: string | Array<{ type: string; cache_control?: { type: string } }>;
+    }>;
+    // None of the messages are tool_result — none should have cache_control on content blocks.
+    for (const m of messages) {
+      if (Array.isArray(m.content)) {
+        for (const b of m.content) {
+          expect(b.cache_control).toBeUndefined();
+        }
+      }
+    }
+  });
+});

--- a/packages/reasoning/src/kernel/observable-llm.ts
+++ b/packages/reasoning/src/kernel/observable-llm.ts
@@ -91,6 +91,10 @@ type PartialCompletion = {
     readonly inputTokens?: number;
     readonly outputTokens?: number;
     readonly estimatedCost?: number;
+    /** Anthropic prompt-caching: tokens that wrote new cache entries (Lever 1). */
+    readonly cacheCreationInputTokens?: number;
+    /** Anthropic prompt-caching: tokens served from cache hits. */
+    readonly cacheReadInputTokens?: number;
   };
 };
 
@@ -121,6 +125,14 @@ function emitForRequest(
       stopReason: fullResponse?.stopReason,
       tokensIn: fullResponse?.usage?.inputTokens,
       tokensOut: fullResponse?.usage?.outputTokens,
+      // Lever 1 observability — surface Anthropic prompt-cache stats into the
+      // trace so multi-iter cache hit rates are inspectable via `rax:diagnose`.
+      ...(typeof fullResponse?.usage?.cacheCreationInputTokens === "number"
+        ? { cacheCreationTokensIn: fullResponse.usage.cacheCreationInputTokens }
+        : {}),
+      ...(typeof fullResponse?.usage?.cacheReadInputTokens === "number"
+        ? { cacheReadTokensIn: fullResponse.usage.cacheReadInputTokens }
+        : {}),
       costUsd: fullResponse?.usage?.estimatedCost,
       durationMs,
     },

--- a/packages/reasoning/src/kernel/utils/diagnostics.ts
+++ b/packages/reasoning/src/kernel/utils/diagnostics.ts
@@ -320,6 +320,10 @@ export function emitLLMExchange(args: {
     readonly stopReason?: string;
     readonly tokensIn?: number;
     readonly tokensOut?: number;
+    /** Anthropic prompt-caching: tokens that wrote new cache entries (Lever 1). */
+    readonly cacheCreationTokensIn?: number;
+    /** Anthropic prompt-caching: tokens served from cache hits. */
+    readonly cacheReadTokensIn?: number;
     readonly costUsd?: number;
     readonly durationMs?: number;
   };
@@ -356,6 +360,12 @@ export function emitLLMExchange(args: {
           stopReason: args.response.stopReason,
           tokensIn: args.response.tokensIn,
           tokensOut: args.response.tokensOut,
+          ...(typeof args.response.cacheCreationTokensIn === "number"
+            ? { cacheCreationTokensIn: args.response.cacheCreationTokensIn }
+            : {}),
+          ...(typeof args.response.cacheReadTokensIn === "number"
+            ? { cacheReadTokensIn: args.response.cacheReadTokensIn }
+            : {}),
           costUsd: args.response.costUsd,
           durationMs: args.response.durationMs,
         },

--- a/packages/trace/src/events.ts
+++ b/packages/trace/src/events.ts
@@ -256,6 +256,10 @@ export interface LLMExchangeEvent extends TraceEventBase {
     readonly stopReason?: string
     readonly tokensIn?: number
     readonly tokensOut?: number
+    /** Anthropic prompt-caching: tokens that wrote new cache entries (Lever 1 evidence). */
+    readonly cacheCreationTokensIn?: number
+    /** Anthropic prompt-caching: tokens served from cache hits (90% input discount). */
+    readonly cacheReadTokensIn?: number
     readonly costUsd?: number
     readonly durationMs?: number
   }


### PR DESCRIPTION
First of 5 levers from the [Mastra-vs-RA dynamic-optimization plan](https://github.com/tylerjrbuell/reactive-agents-ts/pull/142). Wires Anthropic's ephemeral prompt-cache markers on the three reusable prefix segments of every Claude request.

## Empirical evidence (real Anthropic API, ~1231-tok padded system prompt)

| Call | Input tok (NEW) | Cache READ tok | Effective billable |
|------|-----------------|----------------|--------------------|
| 1 (cold) | 3 | 1149 | ~128 (~89% discount) |
| 2 (warm) | 3 | 1149 | ~128 (~89% discount) |

Without caching: ~1162 billable input tok/call. **Per-call cost on Sonnet drops from $0.0035 → $0.0004.**

Real RA agent projection (~2000-tok scaffold × 6 iter = 12000 input tok): **~82% input cost reduction** to ~2200 billable.

## Cache breakpoints (3 of Anthropic's 4-breakpoint budget)

1. **System prompt** — always marked (Anthropic auto-skips below per-model min)
2. **Last tool entry** — already in place pre-PR
3. **Last tool_result message** — NEW. Multi-iter runs cache the full message-thread prefix

## Files changed

- `packages/llm-provider/src/providers/anthropic.ts` — mark cache_control + surface cache stats in usage
- `packages/llm-provider/src/types.ts` — `cacheCreationInputTokens` / `cacheReadInputTokens` on `TokenUsageSchema`
- `packages/reasoning/src/kernel/observable-llm.ts` + `utils/diagnostics.ts` — forward to trace
- `packages/trace/src/events.ts` + `packages/core/src/services/event-bus.ts` — trace event schema
- `packages/llm-provider/tests/anthropic-prompt-caching.test.ts` (NEW) — 5 unit tests pin marker positions

## Why this matters vs Mastra

Mastra has zero caching infrastructure — minimal-prompt philosophy means no reusable prefix to cache. RA's larger scaffold (driven by verifier + grounding mechanisms that give the +3 pass-rate lead on tool-extract tasks) now pays for itself across iterations via cache hits. Scaffold tax that hurt single-call cost → amortized across multi-turn at 90% discount.

## Test plan

- [x] `bun test` packages/llm-provider: 268 pass / 0 fail (was 263 + 5 new caching tests)
- [x] `bun test` packages/reasoning: 1373 pass / 0 fail
- [x] `bun test` packages/runtime: 831 pass / 0 fail (1 skip pre-existing)
- [x] Real-API demo with padded prompt: 1149 cache_read tokens confirmed on call 2

## Followup

- **Lever 2** (iter-delta prompts) — only ship guidance section on iter 1+, drop full scaffold rebuild. Stacks multiplicatively.
- **OpenAI prompt caching** — different shape, automatic via `cache=true` on request
- **Bench cache reporting** — surface hit rate in CSV once #142 token plumbing lands