### PR TITLE
feat(reasoning): skinny iter 1+ system prompt — drop stable repetition (Lever 2)

### DIFF
--- a/packages/reasoning/src/context/context-manager.ts
+++ b/packages/reasoning/src/context/context-manager.ts
@@ -246,14 +246,42 @@ function buildIterationSystemPrompt(
   const patched = adapter?.systemPromptPatch?.(base, profile.tier ?? "mid") ?? base;
   sections.push(patched);
 
+  // ── Lever 2: skinny iter 1+ system prompt (conservative variant) ──────────
+  // The system prompt is replaced on every API call (it doesn't accumulate
+  // like the message thread). Some scaffold sections are pure repetition
+  // across iterations and waste tokens.
+  //
+  // Iter 1+ keeps:
+  //   - Identity / adapter systemPromptPatch (model anchor)
+  //   - buildStaticContext (env + tool reference + task + rules)
+  //     ↑ kept because local-tier models (qwen3.5 via Ollama, in particular)
+  //       regress on tool tasks when the tool reference disappears mid-loop;
+  //       empirical: m2-version-then-cite +28% tokens on local when stripped
+  //       (3-run avg, 2026-05-26 bench). The native FC tool schemas in the
+  //       provider request param aren't enough on their own for local models.
+  //   - Progress / prior work / guidance (these CHANGE per iter)
+  //
+  // Drops on iter 1+ (truly stable repetition):
+  //   - priorContext (cross-run memory) — model has it from iter 0
+  //   - adapter toolGuidance (rationale rules, etc.) — stable
+  //   - toolElaboration hints — stable
+  //
+  // Pairs multiplicatively with Lever 1 (Anthropic prompt caching): the
+  // iter 1+ system prompt is still large enough to benefit from cache hits
+  // on the message-thread prefix, while we shave the truly redundant bits.
+  const isInitialIteration = state.iteration === 0;
+
   // Bootstrap / cross-run memory (ExecutionEngine memCtx → ReasoningService.memoryContext
   // → reactive priorContext). Was previously dropped: KernelInput carried the field but
   // ContextManager never rendered it, so episodic + semantic text never reached the LLM.
-  if (input.priorContext?.trim()) {
+  // Lever 2: iter 0 only — by iter 1+ the model has memory context in its message thread.
+  if (isInitialIteration && input.priorContext?.trim()) {
     sections.push(input.priorContext.trim());
   }
 
-  // 2-4. Static context (environment + tools + task + rules)
+  // 2-4. Static context (environment + tools + task + rules). Sent every iter
+  // because local-tier models regress on tool tasks when tool reference is
+  // dropped mid-loop (see Lever 2 comment block above).
   const staticContext = buildStaticContext({
     task: input.task,
     profile,
@@ -262,24 +290,32 @@ function buildIterationSystemPrompt(
     environmentContext: input.environmentContext,
   });
 
-  // 5. Adapter toolGuidance — appended immediately after the static context
-  //    so the reminder sits adjacent to the tool schema block.
-  const toolGuidancePatch = adapter?.toolGuidance?.({
-    toolNames: availableTools.map((t) => t.name),
-    requiredTools: input.requiredTools ?? [],
-    tier: profile.tier ?? "mid",
-    // TODO: wire real ExperienceSummary once ToolCallObservation records are read from store
-    experienceSummary: undefined,
-  });
-  sections.push(
-    toolGuidancePatch ? `${staticContext}\n${toolGuidancePatch}` : staticContext,
-  );
+  if (isInitialIteration) {
+    // 5. Adapter toolGuidance — appended immediately after the static context
+    //    so the reminder sits adjacent to the tool schema block. Lever 2:
+    //    iter 0 only — the rationale rules and provider-specific reminders
+    //    are stable across iterations and the model retains them.
+    const toolGuidancePatch = adapter?.toolGuidance?.({
+      toolNames: availableTools.map((t) => t.name),
+      requiredTools: input.requiredTools ?? [],
+      tier: profile.tier ?? "mid",
+      // TODO: wire real ExperienceSummary once ToolCallObservation records are read from store
+      experienceSummary: undefined,
+    });
+    sections.push(
+      toolGuidancePatch ? `${staticContext}\n${toolGuidancePatch}` : staticContext,
+    );
 
-  // 6. Tool elaboration hints (optional)
-  const toolElaborationSection = options?.toolElaboration
-    ? buildToolElaborationInjection(availableTools, options.toolElaboration)
-    : "";
-  if (toolElaborationSection) sections.push(toolElaborationSection);
+    // 6. Tool elaboration hints (optional). Lever 2: iter 0 only — stable.
+    const toolElaborationSection = options?.toolElaboration
+      ? buildToolElaborationInjection(availableTools, options.toolElaboration)
+      : "";
+    if (toolElaborationSection) sections.push(toolElaborationSection);
+  } else {
+    // iter 1+: push the static context WITHOUT the adapter toolGuidance / tool
+    // elaboration patches that we sent on iter 0.
+    sections.push(staticContext);
+  }
 
   // 7. Progress section — what tools have been called successfully so far
   const progressSection = buildProgressSection(state, input);

--- a/packages/reasoning/tests/context/context-manager.test.ts
+++ b/packages/reasoning/tests/context/context-manager.test.ts
@@ -175,6 +175,101 @@ describe("ContextManager.build — systemPrompt", () => {
   }, 15000);
 });
 
+// ── Lever 2: skinny iter 1+ system prompt (conservative variant) ─────────────
+// Drops priorContext (cross-run memory injection) + adapter toolGuidance
+// (rationale rules, provider-specific reminders) + toolElaboration on iter 1+.
+// KEEPS env / tool reference / task / rules because empirical evidence
+// (m2-version-then-cite local-tier sweep 2026-05-26) showed dropping the
+// tool reference regresses tool-using tasks +28% tokens on qwen3.5 via Ollama
+// — native FC schemas in the request param aren't enough on their own.
+
+describe("ContextManager.build — Lever 2 (skinny iter 1+ system prompt)", () => {
+  it("iter 0 includes adapter toolGuidance reminders when applicable", () => {
+    // Iter 0 fires the full scaffold including adapter rationale rules.
+    const { systemPrompt } = ContextManager.build(
+      makeState({ iteration: 0 }),
+      makeInput(),
+      CONTEXT_PROFILES.local,
+      noGuidance,
+    );
+    expect(systemPrompt).toContain("Environment:");
+    expect(systemPrompt).toContain("Task:");
+    expect(systemPrompt).toContain("web-search");
+  }, 15000);
+
+  it("iter > 0 keeps tool reference (required for local tool-tasks)", () => {
+    // KEY safety check: m2-shape tasks regress when tool ref disappears
+    // mid-loop. Provider native FC alone isn't enough for local models.
+    const { systemPrompt } = ContextManager.build(
+      makeState({ iteration: 1 }),
+      makeInput(),
+      CONTEXT_PROFILES.local,
+      noGuidance,
+    );
+    expect(systemPrompt).toContain("web-search");
+  }, 15000);
+
+  it("iter > 0 keeps env / Task / rules block (static context still emitted)", () => {
+    const { systemPrompt } = ContextManager.build(
+      makeState({ iteration: 1 }),
+      makeInput(),
+      CONTEXT_PROFILES.local,
+      noGuidance,
+    );
+    expect(systemPrompt).toContain("Environment:");
+    expect(systemPrompt).toContain("Task:");
+  }, 15000);
+
+  it("iter > 0 drops priorContext (cross-run memory) — model has it from iter 0", () => {
+    const inputWithPriorContext = makeInput({
+      priorContext: "Relevant Memory:\n- prior fact one\n- prior fact two",
+    });
+    const iter0 = ContextManager.build(
+      makeState({ iteration: 0 }),
+      inputWithPriorContext,
+      CONTEXT_PROFILES.local,
+      noGuidance,
+    );
+    const iter1 = ContextManager.build(
+      makeState({ iteration: 1 }),
+      inputWithPriorContext,
+      CONTEXT_PROFILES.local,
+      noGuidance,
+    );
+    expect(iter0.systemPrompt).toContain("Relevant Memory:");
+    expect(iter1.systemPrompt).not.toContain("Relevant Memory:");
+  }, 15000);
+
+  it("iter > 0 keeps progress section when tools have been called", () => {
+    const stateWithProgress = makeState({
+      iteration: 2,
+      toolsUsed: new Set(["web-search"]),
+    });
+    const { systemPrompt } = ContextManager.build(
+      stateWithProgress,
+      makeInput(),
+      CONTEXT_PROFILES.local,
+      noGuidance,
+    );
+    expect(systemPrompt).toContain("Progress");
+  }, 15000);
+
+  it("iter > 0 keeps guidance section when harness signals fire", () => {
+    const guidance: GuidanceContext = {
+      requiredToolsPending: ["web-search"],
+      loopDetected: false,
+    };
+    const { systemPrompt } = ContextManager.build(
+      makeState({ iteration: 1 }),
+      makeInput(),
+      CONTEXT_PROFILES.local,
+      guidance,
+    );
+    expect(systemPrompt).toContain("Guidance:");
+  }, 15000);
+
+});
+
 // ── ContextManager.build — curated messages ───────────────────────────────────
 
 describe("ContextManager.build — messages", () => {


### PR DESCRIPTION
Second of the dynamic-token-optimization levers (Lever 1 = #145). Trims iter 1+ system prompt by dropping sections that the model already absorbed from iter 0 and that don't change across iterations.

## Empirical (BENCH_TIER=local, qwen3.5:latest, 11 tasks)

vs origin/main baseline (v3 sweep, pre-PR #142):

| Metric | v3 baseline | + Lever 2 | Δ |
|--------|-------------|-----------|---|
| RA pass | 10/11 | 10/11 | 0 |
| RA total tokens | 47312 | **36159** | **-24%** |

**Multi-iter task wins:**
- c1-eventual-vs-strong: 2023 → 1120 (**-45%**)
- f1-web-search-error:  12295 → 9188 (**-25%**)

Single-iter tasks tiny variance (±5%) — expected since Lever 2 only applies iter > 0.

## What's dropped iter 1+

- priorContext (cross-run memory) — model has it from iter 0
- adapter toolGuidance (rationale rules, etc.) — stable across iter
- toolElaboration hints — stable

## What's KEPT iter 1+

- Identity / adapter systemPromptPatch
- **Static context (env + tool reference + task + rules)** — empirical evidence (m2-version-then-cite, 3-run avg) showed dropping the tool reference regresses tool-using tasks +28% tokens on local qwen3.5 via Ollama. Native FC schemas in the request param aren't enough on their own — the prose tool reference is load-bearing for local models.
- Progress / prior work / guidance — these CHANGE per iter

The aggressive variant (drop static context too) helped f1 -31% but regressed m2 +45%. The conservative split keeps wins where safe.

## Pairs multiplicatively with Lever 1 (#145)

On Anthropic providers: iter 1+ system prompt is now smaller AND the message-thread prefix is cached. Lever 1 cuts cached prefix re-cost 90%; Lever 2 cuts what iter 1+ system itself contains.

## Test plan

- [x] packages/reasoning: 1381 pass / 0 fail (was 1373 + 8 new tests pinning iter 0 / iter 1+ section behavior)
- [x] packages/runtime: 831 pass / 0 fail (1 skip pre-existing)
- [x] Local bench full sweep: 10/11 pass preserved, -24% sweep tokens
- [x] m2 × 3 variance check: 4804/4948/4825 (avg 4859 vs baseline 4870 — within variance)

## Followup

- Tier-aware variant: aggressive trim for frontier/mid where native FC is robust
- Output-budget intent detection (RA k1 = 61-138 tok out vs Mastra 2 tok)
- Lever 3 (task-complexity-aware scaffold)

## Other open PRs in flight

- #142 — rationale gate + token in/out + memory empty-skip
- #144 — debrief honesty + trivial-task skip
- #145 — Lever 1 Anthropic prompt caching