### PR TITLE
feat(runtime): relax trivial gates to short-output tool tasks (Lever 7)

### DIFF
--- a/packages/runtime/src/engine/finalize/debrief-synthesis.ts
+++ b/packages/runtime/src/engine/finalize/debrief-synthesis.ts
@@ -162,18 +162,29 @@ export const synthesizeAndStoreDebrief = (
       rationale: rationaleLog,
     };
 
-    // GH #143 trivial-task gate — skip the LLM debrief call when the task is
-    // trivial enough that the fallback synthesizer can reconstruct an equivalent
-    // record from captured signals. On local tier (qwen3.5:latest) the LLM
-    // debrief failed 52% of the time anyway (hit max_tokens, returned empty
-    // content), and bench evidence showed it burned ~825 tok/task uncounted.
-    // The gate covers: short final output (no synthesis nuance to extract),
-    // zero tool calls (nothing to summarize beyond the answer itself), and no
-    // errors (no error-narrative for the LLM to attempt). Any one of those
-    // conditions failing falls through to the LLM path.
+    // GH #143 / Lever 7 trivial-task gate — skip the LLM debrief call when
+    // the captured signals are simple enough that the fallback synthesizer
+    // can reconstruct an equivalent record. On local tier (qwen3.5:latest)
+    // the LLM debrief failed 52% of the time anyway (hit max_tokens, returned
+    // empty content), and bench evidence showed it burned ~825 tok and ~6 s
+    // per task uncounted.
+    //
+    // Lever 7 (2026-05-26) — relaxed the gate to also fire on tool-using
+    // tasks with short outputs. The original gate required zero tool calls,
+    // which left tasks like t1-calculator-add ("Use bench_calculator → 391")
+    // paying the full debrief LLM cost even though the output is 3 chars and
+    // the fallback could trivially summarize it. Profile evidence: t1 local
+    // burned 6.3 s on the debrief LLM call alone (37% of total runtime).
+    //
+    // Conditions:
+    //  - outputForSuccess.length < 100  — short answer, fallback handles it
+    //  - errorsFromLoop.length === 0    — no error narrative for the LLM
+    //
+    // Tool-call presence is no longer a gating signal — the fallback already
+    // records `toolsUsed` from `toolCallHistory`, which the LLM debrief
+    // adds no information on top of for trivial answers.
     const isTrivialForDebrief =
       outputForSuccess.length < 100 &&
-      toolCallLog.length === 0 &&
       errorsFromLoop.length === 0;
 
     // Synthesize debrief (best-effort, only on the reasoning path with memory enabled).

--- a/packages/runtime/src/engine/phases/memory-flush.ts
+++ b/packages/runtime/src/engine/phases/memory-flush.ts
@@ -113,11 +113,21 @@ export const memoryFlush: Phase = {
         Effect.catchAll(() => Effect.succeed(0)),
       );
 
-      // Auto-extract semantic memories — only when there's meaningful content
+      // Auto-extract semantic memories — only when there's meaningful content.
+      //
+      // Lever 7 (2026-05-26) — tightened the gate. Previously fired on
+      // `hadToolCalls || substantialResponse`, which meant any tool-using
+      // task with a short answer (e.g. t1-calculator-add → "391") paid the
+      // ~4 s LLM extraction cost despite having nothing extractable. Profile
+      // evidence: t1 local burned 4.2 s on memory extraction alone for a
+      // 3-char answer. Now requires `substantialResponse` (output > 200 chars)
+      // OR multiple tool calls (≥2 — single tool calls are isolated facts
+      // already captured in the agent's task store, not memory-worthy).
       const lastResponse = String(ctx.metadata["lastResponse"] ?? "");
       const substantialResponse = lastResponse.length > 200;
+      const multiToolUse = ctx.toolResults.length >= 2;
 
-      if (hadToolCalls || substantialResponse) {
+      if (substantialResponse || multiToolUse) {
         yield* Effect.succeed(memoryExtractorOpt).pipe(
           Effect.flatMap((extractorOpt) => {
             if (extractorOpt._tag !== "Some") return Effect.void;

--- a/packages/runtime/tests/semantic-extraction.test.ts
+++ b/packages/runtime/tests/semantic-extraction.test.ts
@@ -155,7 +155,11 @@ function makeMockMemoryService() {
 // ─── TESTS ─────────────────────────────────────────────────────────────────
 
 describe("Semantic memory extraction during memory-flush", () => {
-  it("extracts semantic memories when tool calls were made", async () => {
+  it("extracts semantic memories when multiple tool calls were made (Lever 7 gate)", async () => {
+    // Lever 7 (2026-05-26) — single-tool + short-answer tasks now SKIP
+    // extraction (no memory-worthy content to summarize). Multi-tool tasks
+    // STILL trigger extraction because the cross-tool synthesis IS the
+    // memory-worthy artifact.
     const extractedEntries = [
       { id: "mem-1", agentId: "test-agent", content: "The web search returned useful info about addition.", summary: "addition info", importance: 0.6, verified: false, tags: ["math"] },
     ];
@@ -163,10 +167,14 @@ describe("Semantic memory extraction during memory-flush", () => {
     const memService = makeMockMemoryService();
     const { engineLayer } = makeEngine();
 
-    // LLM makes a tool call on first request, then returns final answer
+    // LLM makes TWO tool calls on first request, then returns final answer.
+    // Multi-tool use triggers the extraction path under Lever 7.
     const llmLayer = makeMockLLM({
       content: "FINAL ANSWER: The answer is 4.",
-      toolCalls: [{ id: "tc-1", name: "web_search", input: { query: "2+2" } }],
+      toolCalls: [
+        { id: "tc-1", name: "web_search", input: { query: "2+2" } },
+        { id: "tc-2", name: "web_search", input: { query: "2 plus 2" } },
+      ],
     });
 
     const testLayer = Layer.mergeAll(
@@ -333,9 +341,14 @@ describe("Semantic memory extraction during memory-flush", () => {
     const extractor = makeMockExtractor(extractedEntries);
     const { engineLayer } = makeEngine();
 
+    // Multi-tool use triggers the extraction path under Lever 7 (single tool
+    // + short answer would skip the LLM call entirely).
     const llmLayer = makeMockLLM({
       content: "FINAL ANSWER: The answer is 4.",
-      toolCalls: [{ id: "tc-1", name: "web_search", input: { query: "2+2" } }],
+      toolCalls: [
+        { id: "tc-1", name: "web_search", input: { query: "2+2" } },
+        { id: "tc-2", name: "web_search", input: { query: "addition" } },
+      ],
     });
 
     const testLayer = Layer.mergeAll(


### PR DESCRIPTION
Stacks on `combined/all-improvements` (which has #142+#144+#145+#146).

Profile evidence: t1-calculator-add on local burned 6.3s on debrief LLM + 4.2s on memory extract for a 3-char answer ("391"). PR #144's debrief gate and the existing memory-flush gate required `toolCallLog === 0` to fire, which left ALL tool tasks paying full LLM cost.

## Empirical wins (local sweep, qwen3.5:latest)

| Task | Combined ms | Lever 7 ms | Δ | vs Mastra |
|---|---|---|---|---|
| **k1** | 4084 | **1299** | **-68%** | **RA FASTER (Mastra 2336)** ✅ |
| **t3** | 20062 | **8353** | **-58%** | 2.9× (was 6.8×) |
| k2 | 16858 | 13813 | -18% | |
| t1 | 43030 | 40379 | -6% | |
| t2 | 45082 | 40652 | -10% | |

Pass: 11/11 preserved.
Sweep tokens: 51947 → 49772 (-4%).

## Changes

- `debrief-synthesis.ts` — `isTrivialForDebrief` drops `toolCallLog === 0` requirement
- `memory-flush.ts` — extraction gate changed from `hadToolCalls || substantialResponse` to `substantialResponse || multiToolUse (≥2)`
- `tests/semantic-extraction.test.ts` — 2 tests updated to use 2+ tool calls (multi-tool path) matching new gate contract

## Test plan

- [x] `bun test` packages/runtime: 831 pass / 0 fail
- [x] Local bench full sweep: 11/11 pass, k1 NOW FASTER than Mastra
- [x] Profile t1 standalone: 17.6s → 15.2s (-14%, debrief gate fires)

## Followup

- Kernel iter loop is now the dominant remaining latency cost on multi-iter tasks (f1, m2). Next levers should target iter-count reduction via smarter termination signals.