### PR TITLE
fix(reasoning): final-answer-via-tool bypasses controller-signal veto (Lever 8)

### DIFF
--- a/packages/reasoning/src/kernel/capabilities/decide/arbitrator.ts
+++ b/packages/reasoning/src/kernel/capabilities/decide/arbitrator.ts
@@ -900,13 +900,31 @@ export function arbitrate(intent: TerminationIntent, ctx: ArbitrationContext): V
     case "agent-final-answer": {
       // Agent self-claimed success. Apply Verdict-Override: if controller
       // signals contradict, mark as failure.
-      const veto = shouldVetoSuccess(ctx);
-      if (veto.veto) {
-        return {
-          action: "exit-failure",
-          error: veto.reason,
-          terminatedBy: "controller_signal_veto",
-        };
+      //
+      // Lever 8 (2026-05-26) — when the agent exits via the final-answer
+      // TOOL (`intent.via === "tool"`), skip the veto. The final-answer
+      // tool is a deliberate, structured exit channel: invoking it is the
+      // model's strongest possible "I considered the situation and this
+      // is my answer" signal. Vetoing a deliberate tool-mediated exit
+      // breaks graceful-failure tasks like the f1 bench scenario
+      // ("…stop trying and state that you cannot fetch the live price")
+      // where the model correctly acknowledges tool failure via
+      // final-answer and the controller-signal veto then incorrectly
+      // converts the success into max_iterations failure.
+      //
+      // Veto still applies on `via === "regex"` (FINAL ANSWER: prefix
+      // match — weaker signal, may be incidental in a thought) and on
+      // `via === undefined` (raw end_turn — the original veto target,
+      // silent drops mid-loop).
+      if (intent.via !== "tool") {
+        const veto = shouldVetoSuccess(ctx);
+        if (veto.veto) {
+          return {
+            action: "exit-failure",
+            error: veto.reason,
+            terminatedBy: "controller_signal_veto",
+          };
+        }
       }
 
       // Sprint 3.4 Scaffold 3 — synthesis-grounding gate. If the answer

--- a/packages/reasoning/tests/kernel/capabilities/decide/arbitrator.test.ts
+++ b/packages/reasoning/tests/kernel/capabilities/decide/arbitrator.test.ts
@@ -186,11 +186,17 @@ describe("arbitrate — agent-final-answer (Verdict-Override pattern)", () => {
     }
   });
 
-  it("VETOES agent's success claim when ≥2 stall-detect with no escalation", () => {
+  // Lever 8 (2026-05-26) — these tests previously used `via: "tool"` which is
+  // now veto-exempt (deliberate tool-mediated exits trust the model). Updated
+  // to `via: undefined` (raw end_turn — the original veto target, silent
+  // mid-loop drops). Veto still applies to `via: "regex"` (FINAL ANSWER:
+  // prefix match) and `via: undefined`.
+  it("VETOES agent's success claim when ≥2 stall-detect with no escalation (end_turn path)", () => {
     const v = arbitrate(
-      { kind: "agent-final-answer", via: "tool", output: "best effort" },
+      { kind: "agent-final-answer", via: undefined, output: "best effort" },
       {
         ...baseCtx,
+        steps: [failedToolStep], // tool-failure evidence needed for veto
         controllerDecisionLog: [
           "stall-detect: low entropy delta",
           "stall-detect: still stuck",
@@ -204,11 +210,12 @@ describe("arbitrate — agent-final-answer (Verdict-Override pattern)", () => {
     }
   });
 
-  it("VETOES on ≥3 tool-inject without escalation", () => {
+  it("VETOES on ≥3 tool-inject without escalation (end_turn path)", () => {
     const v = arbitrate(
-      { kind: "agent-final-answer", via: "tool", output: "" },
+      { kind: "agent-final-answer", via: undefined, output: "" },
       {
         ...baseCtx,
+        steps: [failedToolStep],
         controllerDecisionLog: [
           "tool-inject: more",
           "tool-inject: more",
@@ -222,16 +229,40 @@ describe("arbitrate — agent-final-answer (Verdict-Override pattern)", () => {
     }
   });
 
-  it("VETOES on stall + high entropy combination", () => {
+  it("VETOES on stall + high entropy combination (end_turn path)", () => {
     const v = arbitrate(
-      { kind: "agent-final-answer", via: "tool", output: "" },
+      { kind: "agent-final-answer", via: undefined, output: "" },
       {
         ...baseCtx,
+        steps: [failedToolStep],
         controllerDecisionLog: ["stall-detect: stuck"],
         entropyComposite: 0.7,
       },
     );
     expect(v.action).toBe("exit-failure");
+  });
+
+  // Lever 8 (2026-05-26) — new invariant: deliberate exit via the
+  // final-answer TOOL is the model's strongest possible "I am done"
+  // signal and bypasses the controller-signal veto. Tests f1-style
+  // graceful-failure tasks ("…stop trying and state that you cannot…").
+  it("does NOT veto when agent exits via final-answer TOOL (Lever 8 — deliberate exit)", () => {
+    const v = arbitrate(
+      { kind: "agent-final-answer", via: "tool", output: "I cannot fetch the live price after multiple tool failures." },
+      {
+        ...baseCtx,
+        steps: [failedToolStep],
+        controllerDecisionLog: [
+          "tool-inject: retry",
+          "tool-inject: retry",
+          "tool-inject: retry",
+        ],
+      },
+    );
+    expect(v.action).toBe("exit-success");
+    if (v.action === "exit-success") {
+      expect(v.terminatedBy).toBe("final_answer_tool");
+    }
   });
 
   it("does NOT veto when switch-strategy already fired (controller escalated)", () => {
@@ -277,9 +308,12 @@ describe("arbitrate — agent-final-answer (Verdict-Override pattern)", () => {
     expect(v.action).toBe("exit-success");
   });
 
-  it("DOES veto when stall-detect AND failed tool observations both present (failure pattern)", () => {
+  // Lever 8 (2026-05-26) — switched to via:undefined; via:"tool" now bypasses
+  // the veto unconditionally. The veto still fires when stall+tool-failure
+  // evidence is present AND exit path is end_turn (silent drop).
+  it("DOES veto when stall-detect AND failed tool observations both present, via end_turn (failure pattern)", () => {
     const v = arbitrate(
-      { kind: "agent-final-answer", via: "tool", output: "best effort" },
+      { kind: "agent-final-answer", via: undefined, output: "best effort" },
       {
         ...baseCtx,
         steps: [failedToolStep], // has tool failure evidence
@@ -474,18 +508,39 @@ describe("arbitrateAndApply", () => {
     expect(out.output).toBe("the answer");
   });
 
-  it("vetoed final-answer flows through to status:failed end-to-end", () => {
+  // Lever 8 (2026-05-26) — via:"tool" path is now veto-exempt; this test
+  // covers the end_turn path which still vetoes when stall + tool-failure
+  // evidence is present.
+  it("vetoed final-answer flows through to status:failed end-to-end (end_turn path)", () => {
     const out = arbitrateAndApply(
       baseState,
-      { kind: "agent-final-answer", via: "tool", output: "fake answer" },
+      { kind: "agent-final-answer", via: undefined, output: "fake answer" },
       {
         ...baseCtx,
+        steps: [failedToolStep],
         controllerDecisionLog: ["stall-detect: x", "stall-detect: x"],
       },
     );
     expect(out.status).toBe("failed");
     expect(out.error).toContain("controller_signal_veto");
     expect(out.meta.terminatedBy).toBe("controller_signal_veto");
+  });
+
+  // Lever 8 (2026-05-26) — verify tool-mediated final-answer survives end-to-end
+  // even when controller signals would otherwise veto.
+  it("final-answer via TOOL bypasses veto end-to-end (Lever 8 invariant)", () => {
+    const out = arbitrateAndApply(
+      baseState,
+      { kind: "agent-final-answer", via: "tool", output: "I cannot fetch the live price." },
+      {
+        ...baseCtx,
+        steps: [failedToolStep],
+        controllerDecisionLog: ["tool-inject: a", "tool-inject: b", "tool-inject: c"],
+      },
+    );
+    expect(out.status).toBe("done");
+    expect(out.output).toBe("I cannot fetch the live price.");
+    expect(out.meta.terminatedBy).toBe("final_answer_tool");
   });
 });
 

--- a/packages/testing/src/gate/scenarios/cf-24-all-termination-flows-through-arbitrator.ts
+++ b/packages/testing/src/gate/scenarios/cf-24-all-termination-flows-through-arbitrator.ts
@@ -92,8 +92,12 @@ export const scenario: ScenarioModule = {
 
     // 1b: corpus failure pattern (≥2 stall-detect + tool-failure evidence,
     // no escalation) → veto fires (Sprint 3.3 refinement: requires tool failure)
+    // Lever 8 (2026-05-26) — switched to via:undefined. Tool-mediated
+    // final answers are deliberate and bypass the veto; the corpus pattern
+    // is preserved on the end_turn path where silent mid-loop drops are
+    // the original veto target.
     const fa2 = arbitrate(
-      { kind: "agent-final-answer", via: "tool", output: "fake answer" },
+      { kind: "agent-final-answer", via: undefined, output: "fake answer" },
       {
         ...ctxWithFailure,
         controllerDecisionLog: [

--- a/wiki/Research/Harness-Reports/integration-control-flow-scenario-health.json
+++ b/wiki/Research/Harness-Reports/integration-control-flow-scenario-health.json
@@ -2,8 +2,8 @@
   "schemaVersion": 1,
   "scenarios": {
     "cf-04-goal-achieved-from-end-turn": {
-      "executions": 111,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 115,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -11,8 +11,8 @@
       "targetedWeakness": "W11/IC-17"
     },
     "cf-10-error-swallowed-event-emitted": {
-      "executions": 108,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 112,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -20,8 +20,8 @@
       "targetedWeakness": "S0.2"
     },
     "cf-11-redactor-strips-secrets": {
-      "executions": 108,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 112,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -29,8 +29,8 @@
       "targetedWeakness": "S0.3"
     },
     "cf-13-no-advisory-only-dispatches": {
-      "executions": 111,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 115,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -38,8 +38,8 @@
       "targetedWeakness": "Principle-11"
     },
     "cf-14-w4-maxiterations-honored": {
-      "executions": 97,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 101,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -47,8 +47,8 @@
       "targetedWeakness": "W4"
     },
     "cf-15-num-ctx-from-capability": {
-      "executions": 97,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 101,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -56,8 +56,8 @@
       "targetedWeakness": "G-1"
     },
     "cf-16-capability-cache-roundtrip": {
-      "executions": 97,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 101,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -65,8 +65,8 @@
       "targetedWeakness": "G-1"
     },
     "cf-17-tier-derived-from-capability": {
-      "executions": 93,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 97,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -74,8 +74,8 @@
       "targetedWeakness": "G-2"
     },
     "cf-18-meta-tools-trusted": {
-      "executions": 91,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 95,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -83,8 +83,8 @@
       "targetedWeakness": "Q5/S2.3"
     },
     "cf-19-untrusted-observation-rendered": {
-      "executions": 89,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 93,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -92,8 +92,8 @@
       "targetedWeakness": "Phase1-§4/S2.5"
     },
     "cf-20-curator-renders-untrusted-section": {
-      "executions": 83,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 87,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -101,8 +101,8 @@
       "targetedWeakness": "Phase1-§4/S2.5-Slice-B"
     },
     "cf-21-failure-detected-from-controller-signal": {
-      "executions": 78,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 82,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -110,8 +110,8 @@
       "targetedWeakness": "corpus-false-positive/CHANGE-A"
     },
     "cf-22-kernel-internal-structure": {
-      "executions": 65,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 69,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 0,
       "lastRegressionAt": null,
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -119,8 +119,8 @@
       "targetedWeakness": "G-5/Sprint-3.1"
     },
     "cf-23-verifier-runs-after-effector": {
-      "executions": 63,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
+      "executions": 67,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
       "regressionsCaught": 2,
       "lastRegressionAt": "2026-04-30T18:36:35.035Z",
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
@@ -128,10 +128,10 @@
       "targetedWeakness": "Verify-capability/Sprint-3.2"
     },
     "cf-24-all-termination-flows-through-arbitrator": {
-      "executions": 54,
-      "lastExecutedAt": "2026-05-25T04:34:50.558Z",
-      "regressionsCaught": 0,
-      "lastRegressionAt": null,
+      "executions": 58,
+      "lastExecutedAt": "2026-05-26T14:06:46.624Z",
+      "regressionsCaught": 2,
+      "lastRegressionAt": "2026-05-26T14:04:22.982Z",
       "baselineUpdatedAt": "2026-04-30T18:42:04.001Z",
       "baselineUpdateCount": 3,
       "targetedWeakness": "G-5/Sprint-3.3"


### PR DESCRIPTION
## Summary

- Closes the f1-web-search-error quality regression in the Mastra-vs-RA local bench by exempting deliberate tool-mediated exits from the controller-signal veto.
- Veto was firing on `agent-final-answer` intents regardless of `intent.via`, including the strongest possible deliberate-exit channel (the final-answer TOOL), breaking graceful-failure tasks where the model correctly acknowledges tool failure and stops.

## Background

f1 task: *"Use bench_web_search... If you receive an error after 2 attempts, stop trying and state that you cannot fetch the live price."*

Trace `01KSJ8NNCC82QKX1CC39SAZ632` (qwen3.5:latest, local tier):
- iter 0-2: bench_web_search fails 3× with "Rate limit exceeded"
- iter 3: model called discover-tools (exploring alternatives — correct)
- iter 4: bench_web_search fails again
- iter 5: model invoked `final-answer` tool with "I cannot fetch the live price after multiple failed attempts" — exactly what the task asked for
- **Result:** `status=failed`, `terminatedBy=controller_signal_veto`, `outLen=0`

Root cause: `controllerSignalVeto` evaluator + the `agent-final-answer` branch in `arbitrate()` applied the veto uniformly across all `intent.via` values. The veto was designed for silent `end_turn` drops (agent stops mid-loop without producing an answer). The final-answer TOOL is a structured, deliberate exit channel — the model invoked a specific tool whose entire purpose is "I have an answer."

## Structural fix

`packages/reasoning/src/kernel/capabilities/decide/arbitrator.ts`:

```ts
case "agent-final-answer": {
  if (intent.via !== "tool") {
    const veto = shouldVetoSuccess(ctx);
    if (veto.veto) {
      return { action: "exit-failure", error: veto.reason, terminatedBy: "controller_signal_veto" };
    }
  }
  // ... existing synthesis-grounding + success path
}
```

Veto still applies on:
- `via: "regex"` (FINAL ANSWER: prefix match — weaker signal, may be incidental in a thought)
- `via: undefined` (raw `end_turn` — the original veto target, silent mid-loop drops)

## Tests

- `packages/reasoning/tests/kernel/capabilities/decide/arbitrator.test.ts` — 3 tests pinning the old veto-on-tool behavior switched to `via: undefined`; 2 new tests cover the Lever 8 invariant (tool-mediated exit bypasses veto end-to-end).
- `packages/testing/src/gate/scenarios/cf-24-all-termination-flows-through-arbitrator.ts` — fa2 case switched to `via: undefined` to preserve corpus-pattern coverage on the end_turn path.

## Verification

| Check | Result |
|---|---|
| Reasoning suite | 1375/1375 pass |
| Repo-wide tests | 5652/5652 pass, 23 skip |
| North Star gate (cf-24) | green |
| Build (turbo) | 38/38 successful |
| f1 trace re-run (Lever 8 case) | passes with "I cannot fetch..." output |

## What this does NOT fix

f1 has a complementary non-deterministic failure mode where the qwen3.5 model never invokes final-answer at all — it just keeps hammering the failing tool through 5 iterations until veto fires from a different path (max-iter or low-delta-guard). That requires a separate fix (loop-detector tightening on same-tool-same-error pattern, or output salvage on veto). Out of scope here — single-purpose PR per the multi-bundle protocol.

## Vision alignment

This is the first quality regression closed in the active Mastra-vs-RA local sweep. Aligns with the "speed + accuracy + quality on local models" direction — RA's correctness loss on f1 was the only ✗ in the 11-task corpus, and the fix preserves RA's pass-rate lead over Mastra (which fails on m2/t3 single-tool tasks where RA succeeds).