### PR TITLE
fix(docs): repair integration example links (.ts→.md)

### DIFF
--- a/apps/docs/src/content/docs/guides/examples.mdx
+++ b/apps/docs/src/content/docs/guides/examples.mdx
@@ -114,9 +114,9 @@ Drop-in adapters for popular Node/Bun servers.
 
 | # | Example | What it shows |
 |---|---------|---------------|
-| 25 | [nextjs-streaming](https://github.com/tylerjrbuell/reactive-agents-ts/blob/main/apps/examples/src/integrations/25-nextjs-streaming.ts) | Next.js Route Handler with `useAgentStream` |
-| 26 | [hono-agent-api](https://github.com/tylerjrbuell/reactive-agents-ts/blob/main/apps/examples/src/integrations/26-hono-agent-api.ts) | Hono on Bun with SSE streaming |
-| 27 | [express-middleware](https://github.com/tylerjrbuell/reactive-agents-ts/blob/main/apps/examples/src/integrations/27-express-middleware.ts) | Express middleware pattern |
+| 25 | [nextjs-streaming](https://github.com/tylerjrbuell/reactive-agents-ts/blob/main/apps/examples/src/integrations/25-nextjs-streaming.md) | Next.js Route Handler with `useAgentStream` |
+| 26 | [hono-agent-api](https://github.com/tylerjrbuell/reactive-agents-ts/blob/main/apps/examples/src/integrations/26-hono-agent-api.md) | Hono on Bun with SSE streaming |
+| 27 | [express-middleware](https://github.com/tylerjrbuell/reactive-agents-ts/blob/main/apps/examples/src/integrations/27-express-middleware.md) | Express middleware pattern |
 
 ## Gateway
 


### PR DESCRIPTION
Cherry-pick of 7375fa05 from overhaul/foundation-2026-05-26.

Closes lychee link-check regression introduced by PR #140 (HS-30) which
converted 3 integration examples from .ts source files to .md snippets
but missed the docs site link table:

  apps/examples/src/integrations/25-nextjs-streaming.ts → .md
  apps/examples/src/integrations/26-hono-agent-api.ts   → .md
  apps/examples/src/integrations/27-express-middleware.ts → .md

Without this fix, every open PR fails Docs Link Check on the 3× 404s
against deleted paths, blocking the merge train (#141, #142, #144, #145,
#148).

## Test plan

- [x] Local build green (was already verified on overhaul branch)
- [x] Cherry-pick clean (no conflicts)