### PR TITLE
fix(release): WS-1 residual fixes — typecheck stubs + judge-server lockstep + dry-run gate

### DIFF
--- a/.agents/MEMORY.md
+++ b/.agents/MEMORY.md
@@ -43,6 +43,72 @@ All P0 bugs closed (merged to `main`). Probe-verified cross-tier (cogito:14b + q
 - ✅ **#108 R10** — Ablation probe `.withReactiveIntelligence(riEnabled)` explicit toggle (commit 1d528861). RI-off cells: `interventionsDispatched=0` across all 4 scenarios. Counter is correctly RI-scoped.
 - ✅ **#109 R11** — Triple-surface skill persistence failure: console.warn + Effect.logWarning + ErrorSwallowed tagged `"SkillPersistenceFailed"` (commit af6a9e35). Canonical grep predicate: `e._tag === "ErrorSwallowed" && e.tag === "SkillPersistenceFailed"`.
 
+### Health Sweep — 2026-05-27 (60 findings, 8 new GH issues)
+
+**Method:** 4 parallel scan agents (codebase-health-sweep skill v3), `verified-by:` per audit-of-audit. Build GREEN (38/38 turbo). Full report `wiki/Research/Audit-Reports-2026-05-27/health-sweep.md`.
+
+**Filed:** #151 (HS-A-01 P1 Gateway `this as any`), #152 (HS-B-01/02/03 P1 honesty-pass bundle), #153 (HS-A-03 P2 dead trace exports), #154 (HS-A-18 P1 HITL example calls nonexistent `onApprovalRequest`), #155 (HS-D-01/02/17/19 P1 surface test gaps observe+vue+health+umbrella), #156 (HS-C-11/12 P2 provider `completeStructured` dup + JSON deep-clone), #157 (HS-B-04 P2 memory-service 4× swallows missing `emitErrorSwallowed`), #158 (HS-A-19 P2 playground reads private `_lastDebrief`).
+
+**Comments on existing:** #77 (5 of 7 HS-20 monoliths grew + 5 NEW monoliths post-W26 including runner.ts 1739→1934, reactive-agent.ts 1415, runtime.ts 1261, builder.ts 2027, execution-engine.ts 1414), #78 (4/5 HS-21 deprecated still active + 1 new HS-C-20), #87 (test `as unknown as` grew 55→85 = +55%, reasoning(12)+runtime(10)+RI(4) hotspots).
+
+**Two active debt vectors:**
+1. **File-size regression** — arbitrator.ts +161 LOC most aggressive grower; runner regrew post-decomp.
+2. **Mock drift mirrors source drift** — Fixing source-side seam types (#91 + #151) auto-reduces test cast surface.
+
+**Stale doc detected:** `CLAUDE.md` cites runner.ts at 1,739 LOC; actual 1934. Update during next docs sweep.
+
+**No P0 found in iter 1.** Strong honesty discipline (0 `@ts-ignore` in prod, 0 `.skip`/`.todo` in tests, 0 dist/ committed).
+
+### Iter 2 (2026-05-28) — apps/* + wiki/docs staleness — **1 P0 surfaced**
+
+**+27 findings** (E:12 apps, F:15 docs) → 6 GH issues #159-#164.
+
+**🚨 P0 #159 release-state drift:** root `VERSION=0.11.1`, npm has 0.11.1 published, BUT 34/35 `packages/*/package.json` at `0.10.6` + NO `v0.10.x`/`v0.11.x` git tags exist (local OR remote, both max at `v0.9.0`). Tag-driven release flow violated. Next `bun run release:dry 0.12.0` will fail the drift gate per `feedback_npm_version_drift`.
+
+**P1 #160 confidenceFloor doc lie:** killswitch unshipped 2026-05-19 per `project_killswitch_honesty_2026_05_19` but still in AGENTS.md L66/L99 + Hot.md L25. Re-add risk.
+
+**P1 #162 AgentResult.debrief missing public type:** supersedes #158, single 5-LOC fix closes 4 cast sites across CLI + cortex/server.
+
+**P1 #163 AgentEvent union not narrowing on `_tag`:** 13+ casts in cortex/ui (chat-store + RunChatTab).
+
+**P1 #164 create-reactive-agent template:** ships `(process.env.LLM_PROVIDER as any)` to every scaffolded user project.
+
+**Combined iter 1+2:** 87 findings, 14 GH issues, 3 comments. Build still GREEN.
+
+### Iter 3 (2026-05-28) — CI/release root cause + live test scan
+
+**+19 findings** (H:13 CI, I:6 tests) → 2 GH issues #165 #166 + correction comment on #159.
+
+**🔧 #159 root cause found (CORRECTION):** Tags DO exist (my iter 2 `git tag | tail -10` only showed 10, missed v0.10.x range). Real bug: `publish.yml:135-149` "Sync VERSION to main" commits ONLY the `VERSION` file. `release.ts:197-208` stamps `packages/*/package.json` in ephemeral CI runner; mutations die with runner. Same mechanism stales CHANGELOG.
+
+**Fix:** Move stamping OUT of CI into local `release.ts` — stamp+commit+push BEFORE tag/publish. CI just builds + publishes already-stamped commit. Drift becomes structurally impossible.
+
+**Live test verdict:** 3219/3219 GREEN across 6 most-changed packages. +761 since Hot.md May-23 baseline of 2458. Zero regressions.
+
+**Filed:** #165 (orphan v0.10.7 draft GH release), #166 (MetricsCollectorTag missing in test Layers — WARN noise + potential prod under-counting).
+
+**Combined iter 1+2+3:** 106 findings, 16 GH issues #151-#166, 4 comments on existing. Build GREEN. Tests GREEN.
+
+### Iter 4 (2026-05-28) — Effect-TS abstraction + arch drift (5 GH issues)
+
+**+20 findings** (J:12, K:8) → 5 GH issues #167-#171.
+
+**🏗️ #167 RuntimeAssembly bundle:** `runtime.ts:479-868` mutates `runtime` variable 38× via `Layer.merge(...) as ComposableLayer` (64 casts in 3 files); 17 inline `Context.GenericTag<{...}>` inside Effect.gen; 2 shadow `MemoryService` Tags alongside canonical class-Tag. Fix: RuntimeAssembly collector + terminal `Layer.mergeAll`; ~230 LOC saved + eliminates `ComposableLayer` alias + dual-tag identity hazard.
+
+**🛡️ #168 tagged-error algebra:** 105 `Effect<X, unknown>` sites in production = silent swallow at type level. Per-service `Data.TaggedError` union; converts swallows into compile-time obligations. Type-level analog of `project_killswitch_honesty_2026_05_19` anti-pattern.
+
+**🕸️ #169 capability mesh:** kernel/capabilities/** has 21 sibling cross-edges + 7 cycles (act↔decide, act↔reason, reason↔verify, attend↔verify, decide↔comprehend). Violates documented "capability is a leaf" principle. Extract to `_shared/` + ESLint `no-restricted-imports`.
+
+**💀 #170 dead surfaces:** `@reactive-agents/observe` package has zero internal `src/` callers (only docs reference); 5 M12 `LocalProviderAdapter` hooks (continuationHint/errorRecovery/synthesisPrompt/qualityCheck/systemPromptPatch) ship 270 LOC with zero callers. Memory's claim "M12 dead hook removal 2026-05-24" was incomplete (only 1 of 6 removed).
+
+**📝 #171 manifest/doc drift:** AGENTS.md package tree omits 7/35 packages (incl. reactive-intelligence w/ 39 inbound consumers); North Star §4.3 says LearningPipeline "currently missing" but file exists with passing test; 2 unused workspace deps (reasoning→prompts, interaction→reasoning).
+
+**Effect-TS verdict: mid-maturity** (0 SubscriptionRef despite 409 Ref ops, 1 acquireRelease, 105 unknown errors, 28 runPromise calls, 15 in runtime alone). Runtime uses Effect as service locator, not type-driven composition.
+
+**Architecture verdict: mild-to-serious drift.** Capability mesh systemic; doc-vs-source inversions; central reference docs write-once-then-drift.
+
+**Combined iter 1+2+3+4:** 126 findings, 21 GH issues #151-#171, 4 comments. Build + tests GREEN.
+
 ### Architectural reframes (evidence-grounded)
 
 - ❌ "Strategies bypass kernel" → ✅ 5 of 7 use `runKernel`; outer loops legitimately reimplement BFS/critique/plan-revision (capability mapping <30% mappable)

--- a/.agents/skills/harness-improvement-loop/scripts/mcp-comprehension-probe.ts
+++ b/.agents/skills/harness-improvement-loop/scripts/mcp-comprehension-probe.ts
@@ -1,0 +1,447 @@
+// mcp-comprehension-probe.ts — Real MCP tool use + structured-result comprehension probe.
+//
+// Targets failure modes the existing quality-gate can't surface:
+//   1. MCP structured-result comprehension (arrays of objects via Docker-bridged MCP)
+//   2. Multi-step MCP workflows (search → get-file → summarize)
+//   3. Error recovery on MCP tool calls (bad args, missing data)
+//   4. Large-content navigation (huge file_contents responses)
+//   5. Field extraction from nested objects (commit.author.name, commit.commit.message)
+//
+// Uses the public github MCP server (ghcr.io/github/github-mcp-server) the
+// spot-test does. Requires GITHUB_PERSONAL_ACCESS_TOKEN env. Docker must
+// be reachable. Probe shares one MCP container across tasks for speed.
+//
+// Run: bun .claude/skills/harness-improvement-loop/scripts/mcp-comprehension-probe.ts
+// Default model: cogito:14b. Override: MCP_PROBE_MODEL=qwen3:14b bun ...
+// Output: wiki/Research/Harness-Reports/mcp-comprehension-<model>-<timestamp>.json
+
+import { ReactiveAgents } from "reactive-agents";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const MODEL = process.env.MCP_PROBE_MODEL ?? "cogito:14b";
+const PROVIDER = process.env.MCP_PROBE_PROVIDER ?? "ollama";
+const REPO = process.env.MCP_PROBE_REPO ?? "tylerjrbuell/reactive-agents-ts";
+const TIMESTAMP = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+const REPORTS_DIR = resolve(process.cwd(), "wiki/Research/Harness-Reports");
+
+if (!process.env.GITHUB_PERSONAL_ACCESS_TOKEN) {
+  console.error("GITHUB_PERSONAL_ACCESS_TOKEN required for MCP probe");
+  process.exit(1);
+}
+
+// ── Quality scoring ─────────────────────────────────────────────────────────
+
+interface QualityScore {
+  readonly toolSuccess: boolean;     // tools executed without unrecoverable error
+  readonly correctness: number;      // 0..1 — output matches ground truth
+  readonly faithfulness: number;     // 0..1 — cited values present in tool obs
+  readonly completeness: number;     // 0..1 — answers full question
+  readonly noFabrication: number;    // 0..1 — no hallucinated fields/values
+  readonly mcpComprehension: number; // 0..1 — correctly extracted nested fields
+  readonly composite: number;
+  readonly notes: readonly string[];
+}
+
+function composite(s: Omit<QualityScore, "composite" | "notes">): number {
+  return (
+    s.correctness * 0.30 +
+    s.faithfulness * 0.20 +
+    s.noFabrication * 0.20 +
+    s.mcpComprehension * 0.20 +
+    s.completeness * 0.10
+  );
+}
+
+function buildQuality(args: Omit<QualityScore, "composite">): QualityScore {
+  return { ...args, composite: composite(args) };
+}
+
+interface TaskResult {
+  readonly taskId: string;
+  readonly success: boolean;
+  readonly output: string;
+  readonly tokensUsed: number;
+  readonly iterations: number;
+  readonly wallMs: number;
+  readonly quality: QualityScore;
+  readonly errors?: readonly string[];
+}
+
+// ── Shared MCP config ───────────────────────────────────────────────────────
+
+const githubMcp = {
+  name: "github" as const,
+  transport: "stdio" as const,
+  command: "docker",
+  args: [
+    "run",
+    "-i",
+    "--rm",
+    "-e",
+    "GITHUB_PERSONAL_ACCESS_TOKEN",
+    "ghcr.io/github/github-mcp-server",
+  ],
+  env: {
+    GITHUB_PERSONAL_ACCESS_TOKEN: process.env.GITHUB_PERSONAL_ACCESS_TOKEN ?? "",
+  },
+};
+
+// ── Tasks ───────────────────────────────────────────────────────────────────
+
+interface TaskDef {
+  readonly id: string;
+  readonly description: string;
+  readonly allowedTools: readonly string[];
+  readonly task: string;
+  readonly groundTruth: () => Promise<Record<string, unknown>>;
+  readonly score: (output: string, truth: Record<string, unknown>) => QualityScore;
+}
+
+// Ground-truth fetches via plain HTTP, bypassing the framework, so the
+// scoring function knows what the right answer actually is.
+
+async function fetchRepoMetadata(): Promise<Record<string, unknown>> {
+  const r = await fetch(`https://api.github.com/repos/${REPO}`, {
+    headers: process.env.GITHUB_PERSONAL_ACCESS_TOKEN
+      ? { Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}` }
+      : {},
+  });
+  return (await r.json()) as Record<string, unknown>;
+}
+
+async function fetchCommits(): Promise<Array<Record<string, unknown>>> {
+  const r = await fetch(
+    `https://api.github.com/repos/${REPO}/commits?per_page=10`,
+    {
+      headers: process.env.GITHUB_PERSONAL_ACCESS_TOKEN
+        ? { Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}` }
+        : {},
+    },
+  );
+  return (await r.json()) as Array<Record<string, unknown>>;
+}
+
+const TASKS: TaskDef[] = [
+  // M1 — Single-record field extraction
+  {
+    id: "M1-single-record-field",
+    description:
+      "Use MCP github/search_repositories to find ${REPO}; output its star count as a single integer.",
+    allowedTools: ["github/search_repositories"],
+    task: `Use the github tools to find the repository ${REPO}. Output just the integer star count. No commentary, no formatting — just the number.`,
+    groundTruth: async () => {
+      const meta = await fetchRepoMetadata();
+      return { stars: meta.stargazers_count };
+    },
+    score: (output, truth) => {
+      const stars = String(truth.stars ?? "");
+      const numMatches = output.match(/\b\d+\b/g) ?? [];
+      const exactMatch = numMatches.includes(stars);
+      const containsTrue = output.includes(stars);
+      const isCompact = output.trim().length <= 200;
+      return buildQuality({
+        toolSuccess: true,
+        correctness: exactMatch ? 1 : containsTrue ? 0.7 : 0,
+        faithfulness: containsTrue ? 1 : 0,
+        completeness: containsTrue ? 1 : 0,
+        noFabrication: numMatches.length > 0 && !containsTrue ? 0 : 1,
+        mcpComprehension: containsTrue ? 1 : 0,
+        notes: [
+          containsTrue ? `★ star count ${stars} cited` : `✗ ${stars} not in output`,
+          isCompact ? "compact answer ✓" : `verbose (${output.length} chars)`,
+        ],
+      });
+    },
+  },
+
+  // M2 — Array listing (the spot-test scenario at smaller scale)
+  {
+    id: "M2-array-listing",
+    description:
+      "List the last 10 commits with title + author. Tests structured-result comprehension under compression.",
+    allowedTools: ["github/list_commits"],
+    task: `Use the github tools to fetch the last 10 commits to ${REPO}. Then output a numbered list: '1. TITLE — AUTHOR'. Use the actual commit messages and authors from the tool result. No invented entries.`,
+    groundTruth: async () => {
+      const commits = await fetchCommits();
+      const summaries = commits.slice(0, 10).map((c) => {
+        const commit = c.commit as Record<string, unknown>;
+        const author = commit.author as Record<string, unknown>;
+        const msg = String(commit.message ?? "").split("\n")[0];
+        return { title: msg, author: String(author.name ?? "") };
+      });
+      return { commits: summaries };
+    },
+    score: (output, truth) => {
+      const truthCommits = truth.commits as Array<{ title: string; author: string }>;
+      const titlePrefixes = truthCommits.map((c) => c.title.slice(0, 35));
+      const found = titlePrefixes.filter((p) => output.includes(p)).length;
+      const isNumberedList = /^\s*\d+\.\s/m.test(output);
+      const lineCount = output.split("\n").filter((l) => /^\s*\d+\./.test(l)).length;
+      // Detect fabricated commits — count numbered lines that don't match any
+      // real title prefix.
+      const lines = output.split("\n").filter((l) => /^\s*\d+\./.test(l));
+      const fabricatedCount = lines.filter(
+        (l) => !titlePrefixes.some((p) => l.includes(p.slice(0, 25))),
+      ).length;
+      return buildQuality({
+        toolSuccess: true,
+        correctness: found / 10,
+        faithfulness: found / Math.max(lineCount, 1),
+        completeness: lineCount >= 10 ? 1 : lineCount / 10,
+        noFabrication: 1 - Math.min(1, fabricatedCount / 10),
+        mcpComprehension: found >= 7 ? 1 : found / 7,
+        notes: [
+          `${found}/10 real titles cited`,
+          isNumberedList ? "numbered list ✓" : "no numbered list ✗",
+          `${lineCount} lines, ${fabricatedCount} fabricated`,
+        ],
+      });
+    },
+  },
+
+  // M3 — Selective filter (find by criterion)
+  {
+    id: "M3-selective-filter",
+    description:
+      "Find the SHA of the most recent commit whose subject mentions 'fix'. Tests filtering + nested field extraction.",
+    allowedTools: ["github/list_commits"],
+    task: `Use the github tools to fetch the last 10 commits to ${REPO}. Find the most recent commit whose commit message subject (first line) contains the word "fix" (case-insensitive). Output just the 7-character short SHA of that commit. No explanation, just the SHA.`,
+    groundTruth: async () => {
+      const commits = await fetchCommits();
+      const match = commits.find((c) => {
+        const subject = String((c.commit as Record<string, unknown>).message ?? "")
+          .split("\n")[0]
+          .toLowerCase();
+        return /\bfix/.test(subject);
+      });
+      const sha = match ? String(match.sha ?? "").slice(0, 7) : null;
+      return { sha };
+    },
+    score: (output, truth) => {
+      const sha = truth.sha as string | null;
+      if (!sha) {
+        return buildQuality({
+          toolSuccess: true,
+          correctness: 1,
+          faithfulness: 1,
+          completeness: 1,
+          noFabrication: 1,
+          mcpComprehension: 1,
+          notes: ["no 'fix' commit in last 10 — task is vacuous"],
+        });
+      }
+      const found = output.includes(sha);
+      const shaPattern = /\b[0-9a-f]{7,40}\b/.exec(output);
+      const fabricatedSha = shaPattern && !found;
+      return buildQuality({
+        toolSuccess: true,
+        correctness: found ? 1 : 0,
+        faithfulness: found ? 1 : 0,
+        completeness: found ? 1 : 0,
+        noFabrication: fabricatedSha ? 0 : 1,
+        mcpComprehension: found ? 1 : 0,
+        notes: [
+          found ? `★ correct SHA ${sha}` : `✗ expected ${sha}, got ${shaPattern?.[0] ?? "no SHA"}`,
+        ],
+      });
+    },
+  },
+
+  // M4 — Multi-tool MCP workflow
+  {
+    id: "M4-multi-tool-workflow",
+    description:
+      "Search repo + read README to compose answer. Tests cross-tool synthesis.",
+    allowedTools: ["github/search_repositories", "github/get_file_contents"],
+    task: `Use the github tools to find the repository ${REPO} and read its README.md. Then in one sentence, summarize the main purpose of the project using language drawn from the README. Do not invent features that aren't mentioned in the file.`,
+    groundTruth: async () => {
+      const r = await fetch(
+        `https://api.github.com/repos/${REPO}/contents/README.md`,
+        {
+          headers: process.env.GITHUB_PERSONAL_ACCESS_TOKEN
+            ? { Authorization: `Bearer ${process.env.GITHUB_PERSONAL_ACCESS_TOKEN}` }
+            : {},
+        },
+      );
+      const data = (await r.json()) as { content?: string };
+      const readme = data.content ? Buffer.from(data.content, "base64").toString("utf8") : "";
+      // Anchor words drawn from the actual README headers + tagline.
+      const anchors = ["agent", "reactive", "typescript", "framework", "react"];
+      return { readme, anchors };
+    },
+    score: (output, truth) => {
+      const anchors = truth.anchors as string[];
+      const lower = output.toLowerCase();
+      const hits = anchors.filter((a) => lower.includes(a)).length;
+      const isOneSentence = output.split(/[.!?]+/).filter((s) => s.trim().length > 5).length <= 2;
+      // Fabrication detection: words like "blockchain", "rust", "AI training" that
+      // shouldn't appear in the framework's README.
+      const fabricationMarkers = ["blockchain", "rust", "training", "neural network", "fine-tune"];
+      const fabricated = fabricationMarkers.filter((m) => lower.includes(m)).length;
+      return buildQuality({
+        toolSuccess: true,
+        correctness: hits >= 3 ? 1 : hits / 3,
+        faithfulness: hits / anchors.length,
+        completeness: output.length > 30 ? 1 : 0.3,
+        noFabrication: 1 - Math.min(1, fabricated / 2),
+        mcpComprehension: hits >= 2 ? 1 : hits / 2,
+        notes: [
+          `${hits}/${anchors.length} anchor words present`,
+          isOneSentence ? "one sentence ✓" : "multi-sentence ✗",
+          fabricated > 0 ? `★ ${fabricated} fabrication marker(s)` : "no fabrication markers",
+        ],
+      });
+    },
+  },
+
+  // M5 — Error recovery
+  {
+    id: "M5-error-recovery",
+    description:
+      "Call MCP tool with bad args (nonexistent file), recover by trying valid args. Tests error-loop resilience.",
+    allowedTools: ["github/get_file_contents"],
+    task: `Use the github tools to read the file 'DOES_NOT_EXIST_xyz123.md' from ${REPO}. If that file doesn't exist, recover by reading 'README.md' instead. Output: which file you successfully read (just the filename, e.g. "README.md"), and one fact from it.`,
+    groundTruth: async () => ({ expected: "README.md" }),
+    score: (output, truth) => {
+      const expected = truth.expected as string;
+      const containsExpected = output.toLowerCase().includes(expected.toLowerCase());
+      const hasFactual = output.length > 30;
+      const mentionsRecovery = /(?:doesn't exist|not found|recovered|instead|fallback)/i.test(output);
+      const isCompact = output.length <= 500;
+      return buildQuality({
+        toolSuccess: containsExpected,
+        correctness: containsExpected ? 1 : 0,
+        faithfulness: containsExpected ? 1 : 0,
+        completeness: containsExpected && hasFactual ? 1 : containsExpected ? 0.5 : 0,
+        noFabrication: 1,
+        mcpComprehension: containsExpected ? 1 : 0,
+        notes: [
+          containsExpected ? "★ recovered to README.md" : "✗ recovery failed",
+          mentionsRecovery ? "acknowledges fallback ✓" : "silent on recovery",
+          isCompact ? "compact ✓" : `verbose (${output.length} chars)`,
+        ],
+      });
+    },
+  },
+];
+
+// ── Runner ─────────────────────────────────────────────────────────────────
+
+async function runTask(def: TaskDef): Promise<TaskResult> {
+  console.log(`\n${"=".repeat(80)}`);
+  console.log(`[${def.id}] ${def.description}`);
+  console.log(`${"=".repeat(80)}`);
+
+  const truth = await def.groundTruth();
+  const truthStr = JSON.stringify(truth).slice(0, 200);
+  console.log(`Ground truth: ${truthStr}`);
+
+  const start = Date.now();
+  const errors: string[] = [];
+  let output = "";
+  let tokensUsed = 0;
+  let iterations = 0;
+  let success = false;
+
+  try {
+    const agent = await ReactiveAgents.create()
+      .withPersona({
+        role: "GitHub Agent",
+        background: "Expert in GitHub task execution",
+        instructions: "Use github tools to solve the task. Be concise.",
+        tone: "concise",
+      })
+      .withProvider(PROVIDER)
+      .withModel(MODEL)
+      .withReasoning({ defaultStrategy: "adaptive", enableStrategySwitching: false })
+      .withTools({ allowedTools: [...def.allowedTools] })
+      .withMCP(githubMcp)
+      .build();
+
+    const result = await agent.run(def.task);
+    output = result.output ?? "";
+    tokensUsed = (result as { tokensUsed?: number }).tokensUsed ?? 0;
+    iterations = (result as { iterations?: number }).iterations ?? 0;
+    success = result.success ?? false;
+    await agent.dispose();
+  } catch (e) {
+    errors.push(e instanceof Error ? e.message : String(e));
+  }
+
+  const wallMs = Date.now() - start;
+  const quality = def.score(output, truth);
+
+  console.log(`Output (${output.length} chars):`);
+  console.log(output.slice(0, 400));
+  if (output.length > 400) console.log("...(truncated)");
+
+  console.log(`\nQuality:`);
+  console.log(`  composite:      ${(quality.composite * 100).toFixed(0)}%`);
+  console.log(`  correctness:    ${(quality.correctness * 100).toFixed(0)}%`);
+  console.log(`  faithfulness:   ${(quality.faithfulness * 100).toFixed(0)}%`);
+  console.log(`  completeness:   ${(quality.completeness * 100).toFixed(0)}%`);
+  console.log(`  no-fabrication: ${(quality.noFabrication * 100).toFixed(0)}%`);
+  console.log(`  mcp-compre:     ${(quality.mcpComprehension * 100).toFixed(0)}%`);
+  console.log(`Notes: ${quality.notes.join("; ")}`);
+  console.log(`Wall: ${(wallMs / 1000).toFixed(1)}s | Tokens: ${tokensUsed} | Iters: ${iterations}`);
+
+  return {
+    taskId: def.id,
+    success,
+    output,
+    tokensUsed,
+    iterations,
+    wallMs,
+    quality,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+async function main() {
+  console.log(`MCP Comprehension Probe — model: ${MODEL} on ${PROVIDER}`);
+  console.log(`Repo: ${REPO}`);
+  console.log(`Tasks: ${TASKS.length}`);
+
+  const results: TaskResult[] = [];
+  for (const task of TASKS) {
+    const result = await runTask(task);
+    results.push(result);
+  }
+
+  // ── Summary ────────────────────────────────────────────────────────────────
+  console.log(`\n${"=".repeat(95)}`);
+  console.log("MCP COMPREHENSION PROBE SUMMARY");
+  console.log(`${"=".repeat(95)}`);
+  console.log(
+    "task                      | comp | correct | faith | mcp | no-fabr | iters | tok    | wall",
+  );
+  console.log("-".repeat(95));
+  for (const r of results) {
+    const q = r.quality;
+    console.log(
+      `${r.taskId.padEnd(25)} | ${(q.composite * 100).toFixed(0).padStart(3)}% | ${
+        (q.correctness * 100).toFixed(0).padStart(5)
+      }% | ${(q.faithfulness * 100).toFixed(0).padStart(3)}% | ${
+        (q.mcpComprehension * 100).toFixed(0).padStart(3)
+      }% | ${(q.noFabrication * 100).toFixed(0).padStart(5)}% | ${
+        String(r.iterations).padStart(5)
+      } | ${String(r.tokensUsed).padStart(6)} | ${(r.wallMs / 1000).toFixed(1)}s`,
+    );
+  }
+  console.log("-".repeat(95));
+  const avgComposite = results.reduce((s, r) => s + r.quality.composite, 0) / results.length;
+  console.log(`Average composite: ${(avgComposite * 100).toFixed(0)}%`);
+
+  // Write JSON report
+  mkdirSync(REPORTS_DIR, { recursive: true });
+  const reportPath = resolve(
+    REPORTS_DIR,
+    `mcp-comprehension-${MODEL.replace(/[:/]/g, "-")}-${TIMESTAMP}.json`,
+  );
+  writeFileSync(reportPath, JSON.stringify({ model: MODEL, repo: REPO, results }, null, 2));
+  console.log(`\nReport: ${reportPath}`);
+}
+
+await main();
+process.exit(0);

--- a/apps/examples/spot-test.ts
+++ b/apps/examples/spot-test.ts
@@ -16,9 +16,6 @@ const agent = await ReactiveAgents.create()
         enableStrategySwitching: false,
     })
     .withTools()
-    .withTools({
-        allowedTools: ['file-write', 'github/list_commits'],
-    })
     .withMCP({
         name: 'github',
         transport: 'stdio',
@@ -40,7 +37,8 @@ const agent = await ReactiveAgents.create()
     .build()
 
 const result = await agent.run(
-    'Fetch the last 15 commits to tylerjrbuell/reactive-agents-ts then summarize the recent changes to the repo as a blog post title and summary'
+    'Fetch the last 5 commits to tylerjrbuell/reactive-agents-ts and list them.'
 )
 console.log(result.output)
+console.log(result.debrief?.rationale)
 await agent.dispose()

--- a/packages/judge-server/package.json
+++ b/packages/judge-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactive-agents/judge-server",
-  "version": "0.9.5",
+  "version": "0.10.6",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/llm-provider/src/calibrations/cogito-14b.json
+++ b/packages/llm-provider/src/calibrations/cogito-14b.json
@@ -7,6 +7,6 @@
   "parallelCallCapability": "reliable",
   "observationHandling": "uses-recall",
   "systemPromptAttention": "strong",
-  "optimalToolResultChars": 2000,
+  "optimalToolResultChars": 4000,
   "toolCallDialect": "none"
 }

--- a/packages/llm-provider/src/calibrations/qwen3-14b.json
+++ b/packages/llm-provider/src/calibrations/qwen3-14b.json
@@ -7,6 +7,6 @@
   "parallelCallCapability": "reliable",
   "observationHandling": "uses-recall",
   "systemPromptAttention": "strong",
-  "optimalToolResultChars": 2000,
+  "optimalToolResultChars": 4000,
   "toolCallDialect": "none"
 }

--- a/packages/reactive-intelligence/tests/controller/dispatcher-compose-bridge.test.ts
+++ b/packages/reactive-intelligence/tests/controller/dispatcher-compose-bridge.test.ts
@@ -34,7 +34,6 @@ const makeContext = (
   iteration: 5,
   entropyScore: {
     composite: 0.7,
-    token: 0.7,
     structural: 0.6,
     semantic: 0.5,
     behavioral: 0.4,
@@ -79,7 +78,7 @@ const taps = (h: RegistrationHarness, sink: TapEntry[]) => {
     "lifecycle.failure",
     "nudge.healing-failure",
   ] as const) {
-    h.tap(tag, (payload) => { sink.push({ tag, payload }); });
+    h.tap(tag, (payload: unknown) => { sink.push({ tag, payload }); });
   }
 };
 
@@ -170,10 +169,10 @@ describe("dispatcher → Compose bridge (HS-112)", () => {
     const captured: TapEntry[] = [];
     taps(h, captured);
     // Also tap the 4 always-live tags so we'd catch any spurious emission.
-    h.tap("prompt.system", (payload) => captured.push({ tag: "prompt.system", payload }));
-    h.tap("observation.tool-result", (payload) => captured.push({ tag: "observation.tool-result", payload }));
-    h.tap("nudge.loop-detected", (payload) => captured.push({ tag: "nudge.loop-detected", payload }));
-    h.tap("message.tool-result", (payload) => captured.push({ tag: "message.tool-result", payload }));
+    h.tap("prompt.system", (payload: unknown) => { captured.push({ tag: "prompt.system", payload }); });
+    h.tap("observation.tool-result", (payload: unknown) => { captured.push({ tag: "observation.tool-result", payload }); });
+    h.tap("nudge.loop-detected", (payload: unknown) => { captured.push({ tag: "nudge.loop-detected", payload }); });
+    h.tap("message.tool-result", (payload: unknown) => { captured.push({ tag: "message.tool-result", payload }); });
     const pipeline = new HarnessPipeline(h._collected);
 
     const dispatcher = makeDispatcher({ ...defaultInterventionConfig, suppression: baseSuppression });
@@ -218,7 +217,7 @@ describe("dispatcher → Compose bridge (HS-112)", () => {
       "lifecycle.failure",
       "nudge.healing-failure",
     ] as const) {
-      h.tap(tag, (_payload, ctx) => { seenCtx.push({ tag, phase: (ctx as { phase: string }).phase }); });
+      h.tap(tag, (_payload: unknown, ctx: unknown) => { seenCtx.push({ tag, phase: (ctx as { phase: string }).phase }); });
     }
     const pipeline = new HarnessPipeline(h._collected);
 

--- a/packages/reasoning/src/context/context-profile.ts
+++ b/packages/reasoning/src/context/context-profile.ts
@@ -64,7 +64,13 @@ export type ContextProfile = typeof ContextProfileSchema.Type;
 export const CONTEXT_PROFILES: Record<ModelTier, ContextProfile> = {
   local: {
     tier: "local",
-    toolResultMaxChars: 2000,
+    // Bumped 2000 → 4000 (2026-05-28). Filter tasks ("top N by criterion")
+    // need ALL items visible — sort criterion may not be among the first 8.
+    // Local models routinely ship 32K+ context (qwen3:14b, cogito:14b), so
+    // 4000 chars (~1K tokens) for tool obs is well within budget. The 2000
+    // ceiling was tuned for 4K-context models that haven't shipped in a
+    // year. Try-fit pattern still compresses to preview when total exceeds.
+    toolResultMaxChars: 4000,
     toolResultPreviewItems: 8,
     toolSchemaDetail: "names-and-types",
     maxIterations: 8,

--- a/packages/reasoning/src/kernel/capabilities/act/act.ts
+++ b/packages/reasoning/src/kernel/capabilities/act/act.ts
@@ -406,7 +406,7 @@ export function handleActing(
             toolCallId: tc.id,
             observationResult: makeObservationResult(tc.name, false, blockedMsg),
           });
-          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments));
+          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments), { callId: tc.id, rationale: tc.rationale });
           yield* hooks.onObservation(
             transitionState(state, { steps: [...allSteps, actionStep] }),
             blockedMsg,
@@ -431,7 +431,7 @@ export function handleActing(
             toolCallId: tc.id,
             observationResult: makeObservationResult(tc.name, success, content),
           });
-          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments));
+          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments), { callId: tc.id, rationale: tc.rationale });
           yield* hooks.onObservation(
             transitionState(state, { steps: [...allSteps, actionStep] }),
             content,
@@ -492,7 +492,7 @@ export function handleActing(
               observationResult: makeObservationResult("final-answer", true, finalObsContent),
             });
 
-            yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments));
+            yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments), { callId: tc.id, rationale: tc.rationale });
             yield* hooks.onObservation(
               transitionState(state, { steps: [...allSteps, actionStep] }),
               finalObsContent,
@@ -543,7 +543,7 @@ export function handleActing(
             observationResult: makeObservationResult("final-answer", false, rejectObs),
           });
 
-          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments));
+          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments), { callId: tc.id, rationale: tc.rationale });
           yield* hooks.onObservation(
             transitionState(state, { steps: [...allSteps, actionStep] }),
             rejectObs,
@@ -579,7 +579,7 @@ export function handleActing(
                 toolCallId: batchCall.id,
                 observationResult: makeObservationResult(batchCall.name, !guardFailed, guardOutcome.observation),
               });
-              yield* hooks.onAction(state, batchCall.name, JSON.stringify(batchCall.arguments));
+              yield* hooks.onAction(state, batchCall.name, JSON.stringify(batchCall.arguments), { callId: batchCall.id, rationale: batchCall.rationale });
               yield* hooks.onObservation(
                 transitionState(state, { steps: [...allSteps, blockedActionStep] }),
                 guardOutcome.observation,
@@ -607,7 +607,7 @@ export function handleActing(
               allSteps = [...allSteps, actionStep];
               newToolsUsed.add(batchCall.name);
 
-              yield* hooks.onAction(state, batchCall.name, JSON.stringify(batchCall.arguments));
+              yield* hooks.onAction(state, batchCall.name, JSON.stringify(batchCall.arguments), { callId: batchCall.id, rationale: batchCall.rationale });
               const errContent = `[Tool "${batchCall.name}" requested but ToolService is not available]`;
               const errObsStep = makeStep("observation", errContent, {
                 toolCallId: batchCall.id,
@@ -635,7 +635,7 @@ export function handleActing(
             allSteps = [...allSteps, actionStep];
             actionIndexByCallId.set(batchCall.id, allSteps.length - 1);
             newToolsUsed.add(batchCall.name);
-            yield* hooks.onAction(state, batchCall.name, JSON.stringify(batchCall.arguments));
+            yield* hooks.onAction(state, batchCall.name, JSON.stringify(batchCall.arguments), { callId: batchCall.id, rationale: batchCall.rationale });
           }
 
           const executionResults = yield* Effect.all(
@@ -782,7 +782,7 @@ export function handleActing(
             toolCallId: tc.id,
             observationResult: makeObservationResult(tc.name, !guardFailed, guardOutcome.observation),
           });
-          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments));
+          yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments), { callId: tc.id, rationale: tc.rationale });
           yield* hooks.onObservation(
             transitionState(state, { steps: [...allSteps, actionStep] }),
             guardOutcome.observation,
@@ -808,7 +808,7 @@ export function handleActing(
         allSteps = [...allSteps, actionStep];
         newToolsUsed.add(tc.name);
 
-        yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments));
+        yield* hooks.onAction(state, tc.name, JSON.stringify(tc.arguments), { callId: tc.id, rationale: tc.rationale });
 
         if (toolService._tag === "None") {
           const errContent = `[Tool "${tc.name}" requested but ToolService is not available]`;

--- a/packages/reasoning/src/kernel/capabilities/act/act.ts
+++ b/packages/reasoning/src/kernel/capabilities/act/act.ts
@@ -648,7 +648,7 @@ export function handleActing(
                   batchCall,
                   input.agentId ?? "reasoning-agent",
                   input.sessionId ?? "reasoning-session",
-                  { compression, scratchpad: sharedScratchpad, memoryService },
+                  { compression, scratchpad: sharedScratchpad, memoryService, profile },
                 );
                 const durationMs = Date.now() - startMs;
                 yield* emitLog({
@@ -832,7 +832,7 @@ export function handleActing(
           tc,
           input.agentId ?? "reasoning-agent",
           input.sessionId ?? "reasoning-session",
-          { compression, scratchpad: sharedScratchpad },
+          { compression, scratchpad: sharedScratchpad, profile },
         );
         const toolDurationMs = Date.now() - toolStartMs;
         yield* emitLog({

--- a/packages/reasoning/src/kernel/capabilities/act/tool-execution.ts
+++ b/packages/reasoning/src/kernel/capabilities/act/tool-execution.ts
@@ -677,6 +677,8 @@ export function executeNativeToolCall(
   config?: {
     compression?: ResultCompressionConfig;
     scratchpad?: Map<string, string>;
+    /** Tier profile — supplies default budget when compression.budget unset. */
+    profile?: ContextProfile;
     /**
      * Optional MemoryService for semantic storage of successful tool results.
      * When present, each successful tool execution forks a daemon fiber to
@@ -716,8 +718,8 @@ export function executeNativeToolCall(
         // Apply result compression for large outputs
         let storedKey: string | undefined;
         if (config?.compression) {
-          const budget = config.compression.budget ?? 800;
-          const previewItems = config.compression.previewItems ?? 5;
+          const budget = config.compression.budget ?? config.profile?.toolResultMaxChars ?? 800;
+          const previewItems = config.compression.previewItems ?? config.profile?.toolResultPreviewItems ?? 5;
           const compressed = compressToolResult(content, toolCall.name, budget, previewItems);
           content = compressed.content;
           if (compressed.stored) {

--- a/packages/reasoning/src/kernel/capabilities/attend/tool-formatting.ts
+++ b/packages/reasoning/src/kernel/capabilities/attend/tool-formatting.ts
@@ -249,34 +249,52 @@ export function compressToolResult(
       };
 
       if (looksLikeGitHubCommitArray(parsed)) {
+        const renderCommit = (item: Record<string, unknown>, i: number): string => {
+          const commit = item.commit as Record<string, unknown>;
+          const authorObj = commit.author as Record<string, unknown>;
+          const rawMessage = String(commit.message ?? "");
+          const message = rawMessage
+            .split("\n")[0]
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, 140);
+          const author = String(authorObj.name ?? "").trim();
+          const date = String(authorObj.date ?? "").trim();
+          return `  [${i}] message=${message} | author=${author} | date=${date}`;
+        };
+
+        // Try-fit: if every commit fits at title-detail level within budget,
+        // show all of them. Listing tasks ("last N commits") fabricate the
+        // hidden tail when only `previewItems` are visible — the model has
+        // a real recall path but rarely uses it. Showing the full list when
+        // it fits is the structural fix.
+        const allItems = parsed.map((it, i) => renderCommit(it, i)).join("\n");
+        const headerOverhead = 220; // STORED + Type + Preview + coverage hint
+        const showAll = allItems.length + headerOverhead <= budget;
+
+        if (showAll) {
+          const content =
+            `[STORED: ${key} | ${toolName}]\n` +
+            `Type: Array(${parsed.length}) | Schema: commit.message, commit.author.name, commit.author.date\n` +
+            `All ${parsed.length} commits:\n` +
+            allItems +
+            `\n  ✓ Preview includes all commits with exact message/author/date values.`;
+          return { content, stored: { key, value: result } };
+        }
+
         const items = parsed
           .slice(0, previewItems)
-          .map((item, i) => {
-            const commit = item.commit as Record<string, unknown>;
-            const authorObj = commit.author as Record<string, unknown>;
-            const rawMessage = String(commit.message ?? "");
-            const message = rawMessage
-              .split("\n")[0]
-              .replace(/\s+/g, " ")
-              .trim()
-              .slice(0, 140);
-            const author = String(authorObj.name ?? "").trim();
-            const date = String(authorObj.date ?? "").trim();
-            return `  [${i}] message=${message} | author=${author} | date=${date}`;
-          })
+          .map((it, i) => renderCommit(it as Record<string, unknown>, i))
           .join("\n");
-
         const shownCount = Math.min(previewItems, parsed.length);
         const remaining = parsed.length - shownCount;
-        const moreStr = remaining > 0 ? `\n  ...${remaining} more` : "";
+        const moreStr = `\n  ...${remaining} more`;
         const coverageHint =
-          remaining === 0
-            ? `\n  ✓ Preview includes all commits with exact message/author/date values.`
-            : `\n  — full data is stored. Use recall("${key}", arrayStart: ${shownCount}, arrayCount: ${previewItems}) for remaining commits.`;
+          `\n  — full data is stored. Use recall("${key}", arrayStart: ${shownCount}, arrayCount: ${remaining}) for remaining commits.`;
         const content =
           `[STORED: ${key} | ${toolName}]\n` +
           `Type: Array(${parsed.length}) | Schema: commit.message, commit.author.name, commit.author.date\n` +
-          `Preview (first ${shownCount}):\n` +
+          `Preview (first ${shownCount} of ${parsed.length}):\n` +
           items +
           moreStr +
           coverageHint;
@@ -297,37 +315,57 @@ export function compressToolResult(
             .join(", ")
         : "unknown";
 
+      const renderRecord = (item: Record<string, unknown>, i: number): string => {
+        const pairs = Object.entries(item)
+          .slice(0, 4)
+          .map(([k, v]) => {
+            const val =
+              v !== null && typeof v === "object"
+                ? Object.values(v as object)
+                    .filter((x) => typeof x === "string")
+                    .map(String)[0] ?? "{...}"
+                : String(v).slice(0, 60);
+            return `${k}=${val}`;
+          })
+          .join("  ");
+        return `  [${i}] ${pairs}`;
+      };
+
+      // Try-fit: full coverage at row-summary detail wins over a partial
+      // preview when it fits the budget. Listing tasks ("top N", "all X")
+      // fabricate hidden rows when only `previewItems` are visible — the
+      // model has a recall path but rarely uses it. Showing the full list
+      // when it fits eliminates the fabrication surface entirely.
+      const allItems = (parsed as Array<Record<string, unknown>>)
+        .map((it, i) => renderRecord(it, i))
+        .join("\n");
+      const headerOverhead = 220;
+      const showAll = allItems.length + headerOverhead <= budget;
+
+      if (showAll) {
+        const content =
+          `[STORED: ${key} | ${toolName}]\n` +
+          `Type: Array(${parsed.length}) | Schema: ${schema}\n` +
+          `All ${parsed.length} items:\n` +
+          allItems +
+          `\n  ✓ Preview covers all items — you can use this data directly.`;
+        return { content, stored: { key, value: result } };
+      }
+
       const items = (parsed as Array<Record<string, unknown>>)
         .slice(0, previewItems)
-        .map((item, i) => {
-          const pairs = Object.entries(item)
-            .slice(0, 4)
-            .map(([k, v]) => {
-              const val =
-                v !== null && typeof v === "object"
-                  ? Object.values(v as object)
-                      .filter((x) => typeof x === "string")
-                      .map(String)[0] ?? "{...}"
-                  : String(v).slice(0, 60);
-              return `${k}=${val}`;
-            })
-            .join("  ");
-          return `  [${i}] ${pairs}`;
-        })
+        .map((it, i) => renderRecord(it, i))
         .join("\n");
-
       const shownCount = Math.min(previewItems, parsed.length);
       const remaining = parsed.length - shownCount;
-      const moreStr = remaining > 0 ? `\n  ...${remaining} more` : "";
-      // When the preview covers most/all items, tell the agent it can proceed
-      // without a recall — avoids wasting an iteration.
+      const moreStr = `\n  ...${remaining} more`;
       const coverageHint = remaining <= 2
-        ? `\n  ✓ Preview covers ${remaining === 0 ? "all" : "nearly all"} items — you can use this data directly.`
-        : `\n  — full data is stored. Use segmented recall if needed: recall("${key}", arrayStart: ${shownCount}, arrayCount: ${previewItems}) or recall("${key}", start: 0, maxChars: 1200).`;
+        ? `\n  ✓ Preview covers nearly all items — you can use this data directly.`
+        : `\n  — full data is stored. Use segmented recall if needed: recall("${key}", arrayStart: ${shownCount}, arrayCount: ${remaining}) or recall("${key}", start: 0, maxChars: 1200).`;
       const content =
         `[STORED: ${key} | ${toolName}]\n` +
         `Type: Array(${parsed.length}) | Schema: ${schema}\n` +
-        `Preview (first ${shownCount}):\n` +
+        `Preview (first ${shownCount} of ${parsed.length}):\n` +
         items +
         moreStr +
         coverageHint;

--- a/packages/reasoning/src/kernel/capabilities/attend/tool-formatting.ts
+++ b/packages/reasoning/src/kernel/capabilities/attend/tool-formatting.ts
@@ -317,14 +317,25 @@ export function compressToolResult(
         : "unknown";
 
       const renderRecord = (item: Record<string, unknown>, i: number): string => {
+        // Render up to 6 fields. Lifted from 4 — schema header advertises 6+
+        // typical fields but the model only saw the first 4 (e.g. HN posts:
+        // id/title/score/by — missing descendants/url). Filter tasks ("top N
+        // by COMMENTS") fail because the criterion field is invisible.
+        // Numeric fields (scores, counts, ids) are short so the budget impact
+        // is modest; try-fit still falls back to previewItems when total grows.
         const pairs = Object.entries(item)
-          .slice(0, 4)
+          .slice(0, 6)
           .map(([k, v]) => {
             const val =
               v !== null && typeof v === "object"
                 ? Object.values(v as object)
                     .filter((x) => typeof x === "string")
                     .map(String)[0] ?? "{...}"
+                : // URL-like fields get tighter truncation — 30 chars is enough
+                // to identify the domain; full URL adds 50 chars per row with
+                // little selection-criterion value.
+                /^https?:\/\//.test(String(v))
+                ? String(v).slice(0, 30) + (String(v).length > 30 ? "..." : "")
                 : String(v).slice(0, 60);
             return `${k}=${val}`;
           })

--- a/packages/reasoning/src/kernel/capabilities/attend/tool-formatting.ts
+++ b/packages/reasoning/src/kernel/capabilities/attend/tool-formatting.ts
@@ -260,7 +260,8 @@ export function compressToolResult(
             .slice(0, 140);
           const author = String(authorObj.name ?? "").trim();
           const date = String(authorObj.date ?? "").trim();
-          return `  [${i}] message=${message} | author=${author} | date=${date}`;
+          const shaShort = String(item.sha ?? "").slice(0, 7);
+          return `  [${i}] sha=${shaShort} | message=${message} | author=${author} | date=${date}`;
         };
 
         // Try-fit: if every commit fits at title-detail level within budget,
@@ -275,7 +276,7 @@ export function compressToolResult(
         if (showAll) {
           const content =
             `[STORED: ${key} | ${toolName}]\n` +
-            `Type: Array(${parsed.length}) | Schema: commit.message, commit.author.name, commit.author.date\n` +
+            `Type: Array(${parsed.length}) | Schema: commit.message, commit.author.name, commit.author.date, sha (7-char short)\n` +
             `All ${parsed.length} commits:\n` +
             allItems +
             `\n  ✓ Preview includes all commits with exact message/author/date values.`;
@@ -293,7 +294,7 @@ export function compressToolResult(
           `\n  — full data is stored. Use recall("${key}", arrayStart: ${shownCount}, arrayCount: ${remaining}) for remaining commits.`;
         const content =
           `[STORED: ${key} | ${toolName}]\n` +
-          `Type: Array(${parsed.length}) | Schema: commit.message, commit.author.name, commit.author.date\n` +
+          `Type: Array(${parsed.length}) | Schema: commit.message, commit.author.name, commit.author.date, sha (7-char short)\n` +
           `Preview (first ${shownCount} of ${parsed.length}):\n` +
           items +
           moreStr +

--- a/packages/reasoning/src/kernel/capabilities/reason/think-guards.ts
+++ b/packages/reasoning/src/kernel/capabilities/reason/think-guards.ts
@@ -425,17 +425,23 @@ export function guardEvidenceGrounding(
   if (state.iteration <= 0) return undefined;
   if (state.meta.evidenceGroundingDone) return undefined;
 
-  // Prefer extracted facts (compact, signal-rich) over raw observation bodies.
+  // Evidence corpus must be AUTHORITATIVE — never lossy. Raw observation
+  // bodies are the ground truth; extractedFact summaries are signal-rich
+  // augmentation. Using extracted facts ALONE produced false-positive
+  // rejections when the model's answer cited values present in raw obs
+  // bodies (e.g., a GitHub commit body containing "$77,505") but absent
+  // from the per-step extractedFact one-liner. The valid answer was then
+  // re-prompted, the loop stalled, and the harness shipped raw tool JSON
+  // — the upstream defect behind output poisoning.
   const extractedFacts = newSteps
     .filter((s) => s.type === "observation")
     .map((s) => (s.metadata?.extractedFact as string | undefined) ?? "")
     .filter(Boolean)
     .join("\n");
-
-  const evidenceCorpus =
-    extractedFacts.length >= 20
-      ? extractedFacts
-      : buildEvidenceCorpusFromSteps(newSteps);
+  const rawObservations = buildEvidenceCorpusFromSteps(newSteps);
+  const evidenceCorpus = extractedFacts.length > 0
+    ? `${rawObservations}\n\n${extractedFacts}`
+    : rawObservations;
 
   const check = validateOutputGroundedInEvidence(thought, evidenceCorpus);
   if (check.ok) return undefined;

--- a/packages/reasoning/src/kernel/loop/finalize.ts
+++ b/packages/reasoning/src/kernel/loop/finalize.ts
@@ -30,6 +30,7 @@ import {
   validateContentCompleteness,
   buildSynthesisPrompt,
 } from "./output-synthesis.js";
+import { validateGeneralizedGrounding } from "../capabilities/verify/evidence-grounding.js";
 import {
   extractThinkingSafeContent,
   THINKING_SAFE_MIN_TOKENS,
@@ -59,6 +60,18 @@ export function decideSynthesisInput(
   taskDescription: string,
   toolData: string | undefined,
 ): { needsSynthesis: boolean; rawForSynthesis: string } {
+  // Compression-marker echo is a structural failure regardless of format —
+  // the model shipped framework internal scaffolding ([STORED: _tool_result_N],
+  // "Type: Object(...)", "compressed preview", etc.) as the final answer
+  // instead of synthesizing real content. This was the MCP probe M4 failure
+  // mode on plan-execute: model echoed the github/search_repositories preview
+  // verbatim. Force synthesis-from-tool-data when detected.
+  const markerCheck = validateGeneralizedGrounding(output, "");
+  if (markerCheck.compressionEchoDetected) {
+    const rawForSynthesis = toolData && toolData.length > 0 ? toolData : output;
+    return { needsSynthesis: true, rawForSynthesis };
+  }
+
   const intent = extractOutputFormat(taskDescription);
   if (!intent.format) {
     return { needsSynthesis: false, rawForSynthesis: output };
@@ -121,9 +134,12 @@ export function enforceQualityGate(input: {
     return Effect.succeed({ output: input.output, tokens: 0, cost: 0 });
   }
   const intent = extractOutputFormat(input.taskDescription);
+  // Default to "prose" when no explicit format detected — covers compression-echo
+  // synthesis for free-form tasks (MCP probe M4: "summarize in one sentence").
+  const synthesisFormat = intent.format ?? "prose";
   const synthesisPrompt = buildSynthesisPrompt(
     decision.rawForSynthesis,
-    intent.format!,
+    synthesisFormat,
     input.taskDescription,
   );
 
@@ -145,7 +161,7 @@ export function enforceQualityGate(input: {
             cost: response.usage.estimatedCost,
           };
         }
-        const revalidation = validateOutputFormat(candidate, intent.format!);
+        const revalidation = validateOutputFormat(candidate, synthesisFormat);
         return {
           output: revalidation.valid ? candidate : input.output,
           tokens: response.usage.totalTokens,

--- a/packages/reasoning/src/kernel/loop/runner.ts
+++ b/packages/reasoning/src/kernel/loop/runner.ts
@@ -129,28 +129,70 @@ function resolveStoredToolObservation(
 
 // ── Harness deliverable assembly ──────────────────────────────────────────────
 
+/** Minimum thought length to be treated as a model-authored final synthesis. */
+const MIN_MODEL_SYNTHESIS_LENGTH = 100;
+
 /**
- * Assemble a deliverable from accumulated tool results.
+ * A harness-assembled deliverable, source-tagged.
  *
- * When the harness determines the model is spinning but has already gathered
- * useful data, this function extracts all successful non-meta tool observations
- * and joins them as the final output. The harness owns task completion —
- * it doesn't depend on the model calling `final-answer`.
+ *  - `model_synthesis` — a substantive trailing thought authored by the model.
+ *    In React-loop semantics, that thought IS the final answer; raw tool
+ *    observations are the evidence that fed it. Downstream gates should treat
+ *    this as a model-authored output (no forced LLM re-synthesis).
+ *  - `raw_artifacts` — concatenated tool observation bodies. The model never
+ *    produced a synthesizing thought, so the harness ships evidence directly.
+ *    Downstream gates should attempt LLM synthesis to format it for the user.
+ */
+export type Deliverable = {
+  readonly content: string;
+  readonly source: "model_synthesis" | "raw_artifacts";
+};
+
+/**
+ * Assemble the harness-owned deliverable.
  *
- * Filters out guard-blocked observations (which are marked success=true but
- * contain warning markers) by requiring the tool to be in `state.toolsUsed`
- * (only actually-executed tools are added to that set) and excluding known
+ * Priority order (design contract):
+ *   1. Model's most recent substantive synthesizing thought — when the model
+ *      produced a coherent terminal response after tool execution, that text
+ *      is the answer. Raw observations are evidence, not output.
+ *   2. Concatenated successful non-meta tool observations — last-resort when
+ *      no usable model thought exists. Marked `raw_artifacts` so the output
+ *      gate knows to synthesize before user delivery.
+ *   3. Empty-state sentinel — only when neither path has content.
+ *
+ * Filters out guard-blocked observations (success=true but warning markers)
+ * by requiring the tool to be in `state.toolsUsed` and excluding known
  * guard-block text patterns.
  */
-export function assembleDeliverable(state: KernelState): string {
-  const artifacts = collectDeliverableArtifacts(state);
-  if (artifacts.length > 0) return artifacts.join("\n\n");
-
-  // Fallback: use the last substantive thought
+export function assembleDeliverable(state: KernelState): Deliverable {
   const lastThought = [...state.steps]
     .reverse()
-    .find((s) => s.type === "thought" && (s.content ?? "").length > 20);
-  return lastThought?.content ?? "Task complete.";
+    .find(
+      (s) =>
+        s.type === "thought" &&
+        (s.content ?? "").trim().length >= MIN_MODEL_SYNTHESIS_LENGTH,
+    );
+  if (lastThought?.content) {
+    return { content: lastThought.content, source: "model_synthesis" };
+  }
+
+  const artifacts = collectDeliverableArtifacts(state);
+  if (artifacts.length > 0) {
+    return { content: artifacts.join("\n\n"), source: "raw_artifacts" };
+  }
+
+  return { content: "Task complete.", source: "raw_artifacts" };
+}
+
+/**
+ * Map a {@link Deliverable} to the `terminatedBy` reason that preserves its
+ * source semantics across the downstream gate. Model-authored synthesis must
+ * NOT trigger forced LLM re-synthesis in §9 — it's already a model output.
+ */
+function deliverableTerminationReason(
+  d: Deliverable,
+): "harness_deliverable" | "harness_synthesis" {
+  return d.source === "model_synthesis" ? "harness_synthesis" : "harness_deliverable";
 }
 
 function collectDeliverableArtifacts(state: KernelState): string[] {
@@ -1055,9 +1097,10 @@ export function runKernel(
           if (requiredToolNudgeCount > maxRequiredToolNudges) {
             if (totalArtifacts > 0) {
               yield* emitLog({ _tag: "warning", message: `[harness-deliverable] Required-tool nudge budget exhausted (${maxRequiredToolNudges}) — delivering ${totalArtifacts} artifacts`, timestamp: new Date() });
+              const d = assembleDeliverable(state);
               state = terminate(state, {
-                reason: "harness_deliverable",
-                output: assembleDeliverable(state),
+                reason: deliverableTerminationReason(d),
+                output: d.content,
               });
               break;
             }
@@ -1144,7 +1187,9 @@ export function runKernel(
           // artifacts before the harness ships them as-is. If retry budget
           // is exhausted (or verifier passes — should be impossible with
           // the new check), fall through to the original terminate path.
-          const candidateOutput = assembleDeliverable(state);
+          const candidateDeliverable = assembleDeliverable(state);
+          const candidateOutput = candidateDeliverable.content;
+          const candidateTerminationReason = deliverableTerminationReason(candidateDeliverable);
           const availableUserToolsForFallback =
             (currentInput.availableToolSchemas ?? []).map((t) => t.name);
           const fallbackVerdict = verifier.verify({
@@ -1158,7 +1203,7 @@ export function runKernel(
             toolsUsed: state.toolsUsed,
             availableUserTools: availableUserToolsForFallback,
             terminal: true,
-            terminatedBy: "harness_deliverable",
+            terminatedBy: candidateTerminationReason,
           });
           yield* emitVerifierVerdict({
             taskId: currentOptions.taskId ?? state.taskId,
@@ -1174,9 +1219,9 @@ export function runKernel(
           // to the §9.0 post-loop outer gate which marks the run failed.
           // Proceed with original
           // harness fallback. terminate() preserves the single-owner invariant.
-          yield* emitLog({ _tag: "warning", message: `[harness-deliverable] Assembling output from ${totalArtifacts} tool artifacts after ${consecutiveStalled} stalled iterations`, timestamp: new Date() });
+          yield* emitLog({ _tag: "warning", message: `[harness-deliverable] Assembling output from ${totalArtifacts} tool artifacts after ${consecutiveStalled} stalled iterations (source=${candidateDeliverable.source})`, timestamp: new Date() });
           state = terminate(state, {
-            reason: "harness_deliverable",
+            reason: candidateTerminationReason,
             output: candidateOutput,
           });
           break;
@@ -1463,9 +1508,10 @@ export function runKernel(
               requiredToolNudgeCount++;
               if (requiredToolNudgeCount > maxRequiredToolNudges) {
                 yield* emitLog({ _tag: "warning", message: `[harness-deliverable] Required-tool nudge budget exhausted in loop detection (${maxRequiredToolNudges}) — delivering ${loopArtifactCount} artifacts`, timestamp: new Date() });
+                const d = assembleDeliverable(state);
                 state = terminate(state, {
-                  reason: "harness_deliverable",
-                  output: assembleDeliverable(state),
+                  reason: deliverableTerminationReason(d),
+                  output: d.content,
                 });
                 break;
               }
@@ -1489,10 +1535,11 @@ export function runKernel(
               continue;
             }
 
-            yield* emitLog({ _tag: "warning", message: `[harness-deliverable] Loop detected but ${loopArtifactCount} artifacts gathered — delivering instead of failing`, timestamp: new Date() });
+            const loopDeliverable = assembleDeliverable(state);
+            yield* emitLog({ _tag: "warning", message: `[harness-deliverable] Loop detected but ${loopArtifactCount} artifacts gathered — delivering instead of failing (source=${loopDeliverable.source})`, timestamp: new Date() });
             state = terminate(state, {
-              reason: "harness_deliverable",
-              output: assembleDeliverable(state),
+              reason: deliverableTerminationReason(loopDeliverable),
+              output: loopDeliverable.content,
             });
             break;
           }
@@ -1693,10 +1740,10 @@ export function runKernel(
         const previousTerminatedBy = state.meta.terminatedBy;
         const deliverable = assembleDeliverable(state);
         state = transitionState(state, {
-          output: deliverable,
+          output: deliverable.content,
           meta: {
             ...state.meta,
-            terminatedBy: "harness_deliverable",
+            terminatedBy: deliverableTerminationReason(deliverable),
             previousTerminatedBy,
           },
         });
@@ -1844,6 +1891,12 @@ export function runKernel(
     // Validates format, optionally synthesizes when LLM is available.
     // Harness-assembled output (raw tool artifacts) always attempts synthesis.
     if (state.status === "done" && state.output) {
+      // `harness_synthesis` (introduced when assembleDeliverable picks a
+      // substantive model thought) is treated as a MODEL output here — the
+      // text was authored by the LLM, not concatenated from raw tool JSON.
+      // Routing it as "harness" would force a second LLM re-synthesis that
+      // can degrade clean prose into hallucinated structured output (e.g.,
+      // local small models compressing/reformatting valid answers).
       const terminationSource = (state.meta.terminatedBy === "oracle_forced" ? "oracle"
         : state.meta.terminatedBy === "harness_deliverable" || state.meta.terminatedBy === "low_delta_guard" ? "harness"
         : "model") as "model" | "harness" | "oracle" | "fallback";

--- a/packages/reasoning/src/kernel/loop/terminate.ts
+++ b/packages/reasoning/src/kernel/loop/terminate.ts
@@ -32,6 +32,7 @@ import { transitionState } from "../state/kernel-state.js";
  */
 export type TerminateReason =
   | "low_delta_guard" | "switching_exhausted" | "harness_deliverable"
+  | "harness_synthesis"
   | "oracle_forced" | "loop_graceful" | "budget_exceeded" | "max_iterations"
   | "kernel_error" | "controller_signal_veto" | "loop_detected_with_veto"
   | "end_turn" | "final_answer_tool" | "final_answer" | "llm_end_turn"

--- a/packages/reasoning/src/kernel/state/kernel-hooks.ts
+++ b/packages/reasoning/src/kernel/state/kernel-hooks.ts
@@ -61,16 +61,46 @@ export function buildKernelHooks(eventBus: MaybeService<EventBusInstance>): Kern
         } : {}),
       }),
 
-    onAction: (state: KernelState, tool: string, input: string): Effect.Effect<void, never> =>
-      publishReasoningStep(eventBus, {
-        _tag: "ReasoningStepCompleted",
-        taskId: state.taskId,
-        strategy: state.strategy,
-        step: state.steps.length + 1,
-        totalSteps: 0,
-        action: JSON.stringify({ tool, input }),
-        kernelPass: getKernelPass(state),
-      }),
+    onAction: (
+      state: KernelState,
+      tool: string,
+      input: string,
+      opts?: {
+        readonly callId?: string;
+        readonly rationale?: import("@reactive-agents/core").Rationale;
+      },
+    ): Effect.Effect<void, never> => {
+      const effects: Effect.Effect<void, never>[] = [
+        publishReasoningStep(eventBus, {
+          _tag: "ReasoningStepCompleted",
+          taskId: state.taskId,
+          strategy: state.strategy,
+          step: state.steps.length + 1,
+          totalSteps: 0,
+          action: JSON.stringify({ tool, input }),
+          kernelPass: getKernelPass(state),
+        }),
+      ];
+      // Symmetric to `ToolCallCompleted` emitted at onObservation. Without
+      // this `ToolCallStarted` emission the kernel-driven strategies
+      // (reactive / adaptive) silently drop tool-selection rationale —
+      // execution-engine's debrief subscriber only sees the event from
+      // plan-execute + runtime inline-act, so `debrief.rationale[]` lacks
+      // all tool entries on reactive runs.
+      if (opts?.callId) {
+        effects.push(
+          publishReasoningStep(eventBus, {
+            _tag: "ToolCallStarted",
+            taskId: state.taskId,
+            toolName: tool,
+            callId: opts.callId,
+            iteration: state.iteration,
+            ...(opts.rationale ? { rationale: opts.rationale } : {}),
+          }),
+        );
+      }
+      return Effect.all(effects).pipe(Effect.asVoid);
+    },
 
     onObservation: (state: KernelState, result: string, success: boolean): Effect.Effect<void, never> => {
       const lastStep = state.steps[state.steps.length - 1];

--- a/packages/reasoning/src/kernel/state/kernel-state.ts
+++ b/packages/reasoning/src/kernel/state/kernel-state.ts
@@ -615,7 +615,15 @@ export interface KernelHooks {
       rawResponse?: string;
     },
   ) => Effect.Effect<void, never>;
-  readonly onAction: (state: KernelState, tool: string, input: string) => Effect.Effect<void, never>;
+  readonly onAction: (
+    state: KernelState,
+    tool: string,
+    input: string,
+    opts?: {
+      readonly callId?: string;
+      readonly rationale?: import("@reactive-agents/core").Rationale;
+    },
+  ) => Effect.Effect<void, never>;
   readonly onObservation: (state: KernelState, result: string, success: boolean) => Effect.Effect<void, never>;
   readonly onDone: (state: KernelState) => Effect.Effect<void, never>;
   readonly onError: (state: KernelState, error: string) => Effect.Effect<void, never>;

--- a/packages/reasoning/src/strategies/plan-execute.ts
+++ b/packages/reasoning/src/strategies/plan-execute.ts
@@ -45,6 +45,7 @@ import {
 import type { StrategyServices } from "../kernel/utils/service-utils.js";
 import { emitKernelStateSnapshot } from "../kernel/utils/diagnostics.js";
 import { makeStep, buildStrategyResult } from "../kernel/capabilities/sense/step-utils.js";
+import { compressToolResult } from "../kernel/capabilities/attend/tool-formatting.js";
 import { isSatisfied } from "../kernel/capabilities/verify/quality-utils.js";
 import {
   extractThinkingSafeContent,
@@ -1180,10 +1181,25 @@ function executeStep(
       // Sanitize tool_call output: strip internal metadata (args, recipient, raw JSON)
       // so it doesn't leak into downstream steps or final synthesis.
       // Data-fetching tools keep full output; action tools get a clean confirmation.
-      const output = sanitizeToolOutput(step.toolName!, rawOutput, resolvedArgs);
+      const sanitized = sanitizeToolOutput(step.toolName!, rawOutput, resolvedArgs);
+
+      // Structured-result compression — symmetric to kernel/act path. Without
+      // this, plan-execute shipped raw 50KB+ MCP arrays (github/list_commits)
+      // into the next step's prompt AND the reflection prompt, blowing local-tier
+      // context and triggering fabrication-from-training (MCP probe M2/M3:
+      // composite 15-20%). The kernel's `compressToolResult` already produces
+      // a fit-aware preview with scratchpad pointer — reuse it here.
+      const compressionBudget = input.resultCompression?.budget ?? 2000;
+      const compressionPreviewItems = input.resultCompression?.previewItems ?? 8;
+      const compressed = compressToolResult(
+        sanitized,
+        step.toolName!,
+        compressionBudget,
+        compressionPreviewItems,
+      );
 
       return {
-        output,
+        output: compressed.content,
         tokens: 0,
         cost: 0,
         success: toolResult.success !== false,

--- a/packages/reasoning/tests/strategies/kernel/kernel-hooks.test.ts
+++ b/packages/reasoning/tests/strategies/kernel/kernel-hooks.test.ts
@@ -115,6 +115,42 @@ describe("buildKernelHooks", () => {
       expect(event.kernelPass).toBe("test:main");
     });
 
+    it("onAction also publishes ToolCallStarted (with rationale) when callId given", async () => {
+      const { events, eb } = makeMockEventBus();
+      const hooks = buildKernelHooks(eb);
+      const state = baseState();
+      const rationale = { why: "need fresh price data", confidence: 0.85 } as const;
+
+      await Effect.runPromise(
+        hooks.onAction(state, "web-search", '{"query":"effect-ts"}', {
+          callId: "tc-42",
+          rationale,
+        }),
+      );
+
+      // Both events fire: ReasoningStepCompleted (existing) + ToolCallStarted (new).
+      // Without ToolCallStarted, kernel-driven strategies (reactive/adaptive)
+      // silently drop tool-selection rationale from debrief.rationale[].
+      expect(events).toHaveLength(2);
+      const tcs = events.find((e) => (e as { _tag: string })._tag === "ToolCallStarted") as Record<string, unknown> | undefined;
+      expect(tcs).toBeDefined();
+      expect(tcs!.taskId).toBe("task-1");
+      expect(tcs!.toolName).toBe("web-search");
+      expect(tcs!.callId).toBe("tc-42");
+      expect(tcs!.rationale).toEqual(rationale);
+    });
+
+    it("onAction without callId does NOT emit ToolCallStarted (back-compat)", async () => {
+      const { events, eb } = makeMockEventBus();
+      const hooks = buildKernelHooks(eb);
+      const state = baseState();
+
+      await Effect.runPromise(hooks.onAction(state, "web-search", '{"query":"x"}'));
+
+      expect(events).toHaveLength(1);
+      expect((events[0] as { _tag: string })._tag).toBe("ReasoningStepCompleted");
+    });
+
     it("onObservation publishes ReasoningStepCompleted AND ToolCallCompleted", async () => {
       const { events, eb } = makeMockEventBus();
       const hooks = buildKernelHooks(eb);

--- a/packages/reasoning/tests/strategies/kernel/output-quality-gate.test.ts
+++ b/packages/reasoning/tests/strategies/kernel/output-quality-gate.test.ts
@@ -361,8 +361,8 @@ describe("output quality gate", () => {
       toolsUsed: new Set(["shell-execute"]),
       scratchpad: new Map([[key, fullText]]),
     });
-    expect(assembleDeliverable(st)).toContain("Usage: rax agent create");
-    expect(assembleDeliverable(st)).toContain("--name string");
+    expect(assembleDeliverable(st).content).toContain("Usage: rax agent create");
+    expect(assembleDeliverable(st).content).toContain("--name string");
   });
 
   it("assembleDeliverable resolves compressed previews via metadata.storedKey", () => {
@@ -400,7 +400,7 @@ describe("output quality gate", () => {
       scratchpad: new Map([[key, fullText]]),
     });
 
-    const assembled = assembleDeliverable(st);
+    const assembled = assembleDeliverable(st).content;
     expect(assembled).toContain('"find-xrp-price"');
     expect(assembled).toContain('"succeeded":4');
   });
@@ -433,7 +433,7 @@ describe("output quality gate", () => {
       scratchpad: new Map([[key, fullText]]),
     });
 
-    const assembled = assembleDeliverable(st);
+    const assembled = assembleDeliverable(st).content;
     expect(assembled).toContain("Bitcoin: 70836.96");
     expect(assembled).toContain("XLM: 0.1508");
   });

--- a/packages/verification/tests/hallucination-detection.test.ts
+++ b/packages/verification/tests/hallucination-detection.test.ts
@@ -136,6 +136,8 @@ describe("checkHallucinationLLM", () => {
             ],
           }),
         }),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     const result = await Effect.runPromise(
@@ -156,6 +158,8 @@ describe("checkHallucinationLLM", () => {
   test("falls back to heuristic on invalid JSON from LLM", async () => {
     const mockLLM = {
       complete: (_req: any) => Effect.succeed({ content: "not valid json at all" }),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     const result = await Effect.runPromise(
@@ -170,6 +174,8 @@ describe("checkHallucinationLLM", () => {
   test("falls back to heuristic on LLM error", async () => {
     const mockLLM = {
       complete: (_req: any) => Effect.fail(new Error("LLM unavailable")),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     const result = await Effect.runPromise(
@@ -186,6 +192,8 @@ describe("checkHallucinationLLM", () => {
         Effect.succeed({
           content: JSON.stringify({ claims: [] }),
         }),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     const result = await Effect.runPromise(

--- a/packages/verification/tests/layers.test.ts
+++ b/packages/verification/tests/layers.test.ts
@@ -69,6 +69,8 @@ describe("Multi-Source Layer", () => {
     const mockLLM = {
       complete: (_req: any) =>
         Effect.succeed({ content: '["TypeScript was created by Microsoft"]' }),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     try {
@@ -90,6 +92,8 @@ describe("Multi-Source Layer", () => {
     const mockLLM = {
       complete: (_req: any) =>
         Effect.fail(new Error("LLM unavailable")),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     try {
@@ -111,6 +115,8 @@ describe("Multi-Source Layer", () => {
 
     const mockLLM = {
       complete: (_req: any) => Effect.succeed({ content: "[]" }),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     try {
@@ -132,6 +138,8 @@ describe("Multi-Source Layer", () => {
 
     const mockLLM = {
       complete: (_req: any) => Effect.succeed({ content: "not valid json" }),
+      embed: (_texts: readonly string[], _model?: string) =>
+        Effect.succeed([] as readonly (readonly number[])[]),
     };
 
     try {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -62,8 +62,12 @@ if (targets.length === 0) fail("no public packages discovered");
 const names = new Set(targets.map((t) => t.name));
 
 // npm auth must be valid before we touch anything.
-const who = await $`npm whoami`.quiet().nothrow();
-if (who.exitCode !== 0) fail("not logged in to npm (`npm whoami` failed). Run `npm login` first.");
+// Skip when --dry-run / --no-publish: those modes don't push to the registry,
+// so `release:dry` functions as a drift gate without requiring `npm login`.
+if (!dryRun && !noPublish) {
+  const who = await $`npm whoami`.quiet().nothrow();
+  if (who.exitCode !== 0) fail("not logged in to npm (`npm whoami` failed). Run `npm login` first.");
+}
 
 // ── Topological sort over internal dependency edges ──────────────────────────
 

--- a/wiki/Architecture/Design-Specs/2026-05-28-canonical-architecture-model.md
+++ b/wiki/Architecture/Design-Specs/2026-05-28-canonical-architecture-model.md
@@ -1,0 +1,1031 @@
+---
+title: Canonical Architecture Model — Reactive Agents (North Star Structural Design)
+date: 2026-05-28
+status: AUTHORITATIVE design spec — companion to 00-VISION, 06-MISSION-STATEMENTS, 07-OPTIMAL-EXECUTION-ALGORITHM
+relationship-to-canon:
+  - 00-VISION.md says WHY (8 pillars; stable, unchanged)
+  - 06-MISSION-STATEMENTS.md says HOW IT BEHAVES at full realization (per-pillar / per-capability / per-trait)
+  - 07-OPTIMAL-EXECUTION-ALGORITHM.md says THE PER-ITER STEPS (10-step canonical loop + 10 invariants)
+  - THIS document says THE STRUCTURAL SHAPE (files, modules, types, contracts, dependency rules)
+authority-source:
+  - Mission statements demand the contracts
+  - Verified-working code embodies the patterns (createLightRuntime, arbitrator.ts, CapabilityRegistry, kernel-state.ts)
+  - Nothing in this document invents architecture not already present in canon or verified code
+companion-refactor-plan:
+  - wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md (gap analysis + workstream sequence to reach this model)
+---
+
+# Canonical Architecture Model — Reactive Agents
+
+> **One sentence.** The structural shape of Reactive Agents as a four-layer, capability-leafed, Tag-composed, Arbitrator-terminated, registry-driven harness — where every file's role, every dependency's direction, and every advertised surface's wiring is specified, falsifiable, and anchored to the canon.
+
+---
+
+## 0. Frame
+
+### 0.1 What this document is
+
+The **structural blueprint** the framework is targeting. Stated as positive, falsifiable invariants. Each section says "this IS the canonical shape" — not "this would be nice."
+
+The relationship to the existing canon:
+
+| Doc | Question it answers |
+|---|---|
+| `00-VISION.md` | Why does Reactive Agents exist? (8 pillars) |
+| `06-MISSION-STATEMENTS.md` | How does the runtime behave at full realization? (per-pillar / per-capability / per-trait positive declarations) |
+| `07-OPTIMAL-EXECUTION-ALGORITHM.md` | What are the per-iter steps? (10-step canonical loop + 10 algorithmic invariants) |
+| **THIS doc** | What is the canonical structural shape? (file layout, dependency rules, type contracts, Tag patterns, emit/consume law) |
+
+The vision says we want control. The missions say what control looks like in behavior. The algorithm says what control looks like per iter. This document says what control looks like in the code itself — the modules, the boundaries, the contracts.
+
+### 0.2 What this document is NOT
+
+- **Not a roadmap.** Sequencing of changes lives in the refactor plan, not here.
+- **Not aspirational.** Every statement is realizable today; gaps are documented in the refactor plan.
+- **Not invented.** Each pattern below is either (a) already working in verified code, (b) demanded by an existing mission statement, or (c) implied by an algorithmic invariant. Nothing here originates outside those three sources.
+- **Not soft.** Statements are imperative ("MUST", "SHALL", "is"), not advisory ("should consider", "may").
+
+### 0.3 How to use this document
+
+- **For new code:** does it match the shape this document specifies? If not, document why or change the code.
+- **For PR review:** point reviewers at the section the change touches.
+- **For onboarding:** read end-to-end. The framework's mental model lives here.
+- **For refactor decisions:** the gap between current code and this model IS the refactor scope. The refactor plan operates on that delta.
+- **For external comparison:** when another framework ships a feature, locate the corresponding section here. If absent, the model has a gap (file a finding, not an issue).
+
+---
+
+## 1. The Layered Model
+
+### 1.1 Four layers (canonical)
+
+The framework is organized in four layers. Each layer has one job. Each layer may only depend on layers below it. This is non-negotiable.
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  L4 — SURFACE          (consumer-visible APIs)                          │
+│                                                                         │
+│      reactive-agents  · runtime  · gateway  · channels  · a2a          │
+│      react · svelte · vue  ·  create-reactive-agent · diagnose         │
+│      eval · observe · replay · benchmarks · scenarios                   │
+└───────────────────────────────────────┬─────────────────────────────────┘
+                                        │
+┌───────────────────────────────────────▼─────────────────────────────────┐
+│  L3 — DOMAIN           (cognitive concerns)                             │
+│                                                                         │
+│      reasoning  ·  reactive-intelligence  ·  interaction                │
+│      memory · cost · identity · guardrails · verification               │
+│      tools · prompts · orchestration                                    │
+└───────────────────────────────────────┬─────────────────────────────────┘
+                                        │
+┌───────────────────────────────────────▼─────────────────────────────────┐
+│  L2 — SUBSTRATE        (cross-cutting capabilities)                     │
+│                                                                         │
+│      llm-provider · observability · trace · testing                     │
+│      compose · health · judge-server                                    │
+└───────────────────────────────────────┬─────────────────────────────────┘
+                                        │
+┌───────────────────────────────────────▼─────────────────────────────────┐
+│  L1 — FOUNDATION       (no agent semantics)                             │
+│                                                                         │
+│      core · runtime-shim                                                │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 1.2 The dependency rule
+
+For any two packages P_n (layer n) and P_m (layer m):
+
+- `P_n` MAY depend on `P_m` iff **m < n** (strictly lower layer)
+- `P_n` MAY depend on `P_o` (same layer) iff the dependency goes through a published Tag in L1 or L2
+- `P_n` MUST NOT depend on `P_q` (strictly higher layer) under any circumstance
+
+Cycles are forbidden. CI lint walks the package import graph and fails on any L_n → L_m where m ≥ n.
+
+### 1.3 What goes in each layer
+
+**L1 — Foundation.** No agent semantics. No cognitive concerns. Pure type definitions, primitives, runtime-shim utilities. Two packages: `core` (types + EventBus + service Tags), `runtime-shim` (Bun/Node cross-runtime primitives).
+
+**L2 — Substrate.** Cross-cutting capabilities consumed by every cognitive concern: LLM provider abstraction, observability, trace recording, test fixtures, killswitch compose, health, judge-server. **Do not** consume any L3 package. Do not contain cognitive semantics.
+
+**L3 — Domain.** The 10 cognitive capabilities and their adjacent specialized domains: reasoning (the kernel), memory, tools, cost, identity, guardrails, verification, prompts, orchestration, interaction, reactive-intelligence. **Each owns one concern.** Cross-domain dependency MUST go through L1/L2 Tags.
+
+**L4 — Surface.** The user-facing surface area: builder + agent class (runtime), umbrella facade (reactive-agents), gateway, channels, framework adapters (react/svelte/vue), CLI scaffolds, observation exporters, replay, benchmarks/scenarios. **Composes** lower layers; **does not define** new domain concerns.
+
+---
+
+## 2. The Kernel Architecture
+
+The kernel lives at `packages/reasoning/src/kernel/`. It is the heart of the framework. Its structural shape is the framework's most load-bearing design decision.
+
+### 2.1 Canonical file layout
+
+```
+packages/reasoning/src/kernel/
+├── state/                          ← State concern owner
+│   ├── kernel-state.ts             ← KernelState + transitionState() + KernelMessage + KernelMeta
+│   ├── kernel-hooks.ts             ← KernelHooks construction from EventBus
+│   └── kernel-constants.ts         ← META_TOOLS, INTROSPECTION_META_TOOLS, etc.
+│
+├── loop/                           ← Loop controller (the ONLY state mutator at runtime)
+│   ├── runner.ts                   ← The main per-iter loop body
+│   ├── react-kernel.ts             ← Default ReAct kernel; other strategies may register custom kernels
+│   ├── terminate.ts                ← Single-owner terminal status writer
+│   ├── auto-checkpoint.ts          ← Auto-checkpoint scheduling
+│   └── output-{assembly,synthesis}.ts  ← Output assembly + synthesis utilities
+│
+├── capabilities/                   ← The 10 cognitive capabilities — each is a leaf
+│   ├── sense/
+│   ├── attend/
+│   ├── comprehend/
+│   ├── recall/
+│   ├── reason/
+│   ├── decide/                     ← arbitrator.ts is canonical single-owner termination decision
+│   ├── act/
+│   ├── verify/
+│   ├── reflect/
+│   └── learn/
+│
+├── substrate/                      ← Primitive utilities consumed by multiple capabilities
+│   ├── tools/                      ← Tool dispatch + parsing + gating (extracted from act/)
+│   └── (other substrate dirs as needed; see §6)
+│
+└── utils/                          ← Pure cross-cutting helpers
+    ├── diagnostics.ts              ← emit* helpers (emitKernelStateSnapshot, emitVerifierVerdict, ...)
+    ├── ics-coordinator.ts
+    ├── lane-controller.ts
+    ├── service-utils.ts
+    └── (other pure helpers)
+```
+
+### 2.2 What each subdirectory MUST and MUST NOT do
+
+| Subdir | MUST | MUST NOT |
+|---|---|---|
+| `state/` | Define KernelState shape; export `transitionState()`; export typed messages + meta | Mutate state directly; depend on capability dirs |
+| `loop/` | Be the only place state mutates; call capabilities in canonical order; emit per-iter snapshots | Implement cognitive logic; reach into capability internals |
+| `capabilities/<cap>/` | Own that capability's logic; export Tag if it has cross-cap consumers; emit at boundary | Import from sibling capability's internal modules; mutate state outside `transitionState()` |
+| `substrate/` | Provide primitives consumed by multiple capabilities; be pure or kernel-state-coupled (declared) | Be a capability; emit capability-level events; have cross-capability semantics |
+| `utils/` | Be pure helpers + emit* wrappers + diagnostic surface | Have business logic; hold state |
+
+### 2.3 The leaf principle for capabilities
+
+Each capability directory under `kernel/capabilities/` is a **leaf** in the kernel's internal dependency graph:
+
+- It MAY import from `core`, `llm-provider`, `tools`, `memory`, `observability`, `trace` (L1/L2 packages)
+- It MAY import from `kernel/state/` (the state shape)
+- It MAY import from `kernel/substrate/` (shared primitives)
+- It MAY import from `kernel/utils/` (pure helpers + emit wrappers)
+- It MAY consume sibling capability's services **via a published Tag from `core/services/`**
+- It MUST NOT import from sibling capability's internal modules (no `from "../<other-cap>/internal.js"`)
+
+Violation = lint failure. CI enforces.
+
+### 2.4 The substrate distinction (introduced)
+
+`kernel/substrate/` is the canonical home for primitives that:
+
+- Are consumed by **multiple** capabilities
+- Encode primitive operations (tool dispatch, regex parsing, prompt utilities) rather than cognitive decisions
+- May couple to kernel state but do NOT make capability-level decisions
+
+This subdirectory does NOT exist in current code as a top-level entry. It is introduced by this model. The refactor plan WS-3 creates it.
+
+Substrate MUST be consumed by capabilities, never the reverse. A capability cannot be "demoted" to substrate by being imported broadly — substrate has its own boundary contract (pure-or-state-coupled, no cognitive decision logic).
+
+---
+
+## 3. The Runtime Composition Pattern
+
+### 3.1 The canonical shape
+
+The runtime is composed declaratively via `Layer.mergeAll`. The pattern is already in production at `packages/runtime/src/runtime.ts:1061` (`createLightRuntime`). It IS the canonical pattern.
+
+```typescript
+// Canonical shape (verified working at createLightRuntime)
+const layers: Array<ComposableLayer> = [
+  coreLayer,
+  eventBusLayer,
+  llmLayer,
+  memoryLayer,
+  hookLayer,
+  engineLayer,
+  CapabilityRegistryLive,
+];
+if (options.enableTools) layers.push(toolsLayer);
+if (options.enableReasoning) layers.push(reasoningLayer);
+if (options.enableIdentity) layers.push(identityLayer);
+// ... etc — one append per conditional layer
+
+const runtime: ComposableLayer = Layer.mergeAll(...layers) as ComposableLayer;
+return runtime;
+```
+
+### 3.2 The `ComposableLayer` erasure boundary (preserved)
+
+Effect's `Layer<Out, Err, In>` union types blow up under ~25 optional layers ("type instantiation excessively deep"). The framework deliberately uses `ComposableLayer = Layer.Layer<unknown, unknown, unknown>` as the single erasure boundary. This is a **documented engineering decision**, not a debt.
+
+The canonical pattern has **exactly one** `as ComposableLayer` cast: at the terminal `Layer.mergeAll(...)` call. The downstream `BuildBaseRuntimeResult` boundary in `builder/build-effect/runtime-construction.ts` re-narrows to concrete services. No cast anywhere else.
+
+### 3.3 Two runtime constructors
+
+| Constructor | Where | Purpose |
+|---|---|---|
+| `createRuntime(options)` | `packages/runtime/src/runtime.ts` | Full runtime — all optional layers |
+| `createLightRuntime(options)` | `packages/runtime/src/runtime.ts` | Sub-agent runtime — minimum viable substrate |
+
+Both MUST use the `Layer.mergeAll` pattern. Both share the conditional-append pattern for optional layers.
+
+### 3.4 Forbidden patterns
+
+- **Mutation chain.** `let runtime = baseLayer; runtime = Layer.merge(runtime, X) as ComposableLayer; runtime = Layer.merge(runtime, Y) as ComposableLayer; ...` — replaced by collected-array + terminal `mergeAll`.
+- **Per-link casts.** `Layer.merge(a, b) as ComposableLayer` followed by `Layer.merge(merged, c) as ComposableLayer` — replaced by one terminal cast.
+- **Implicit Layer ordering dependence.** Each layer's dependencies are made explicit via `.pipe(Layer.provide(depLayer))` at the layer's construction site, not by relying on merge order.
+
+---
+
+## 4. The State Model
+
+### 4.1 The immutability law
+
+`KernelState` is immutable. Every iter produces a **new** state via `transitionState()`. No code outside `kernel/loop/` may write to state directly.
+
+```typescript
+// Canonical (verified at kernel-state.ts)
+const nextState = transitionState(state, { status: "acting", iteration: state.iteration + 1 });
+// NOT: state.status = "acting"; state.iteration++;
+```
+
+### 4.2 The `transitionState()` canonical mutator
+
+Single function. Single signature. Single owner of all mutation. Lives at `packages/reasoning/src/kernel/state/kernel-state.ts`.
+
+```typescript
+export function transitionState(
+  state: KernelState,
+  patch: Partial<KernelState>,
+): KernelState;
+```
+
+Every status transition flows through this function. Every meta update flows through this function. Every step append flows through this function. No exceptions in production code.
+
+### 4.3 The ≤10 mutation site invariant (Mission Pillar 4)
+
+In the entire kernel, the number of code locations where state is mutated MUST be ≤10 total. These are:
+
+1. `runner.ts` per-iter state update (1 site)
+2. `runner.ts` terminal state finalization (1 site)
+3. `loop/terminate.ts` single-owner terminal status writer (1 site)
+4. `kernel/capabilities/decide/arbitrator.ts` Verdict-application (via `arbitrateAndApply`) — 1 site
+5. `loop/auto-checkpoint.ts` checkpoint write (1 site)
+6. (4 reserved for canonical phase transitions)
+
+Everything else mutating state is a lint violation. Capabilities MAY return patches; the loop controller applies them. No capability writes state.
+
+### 4.4 The KernelStatus state machine
+
+```typescript
+type KernelStatus = "thinking" | "acting" | "observing" | "done" | "failed" | "evaluating";
+```
+
+Allowed transitions (canonical):
+
+```
+START
+  ↓
+thinking → acting → observing → thinking → ... (loop)
+  ↓                                ↓
+evaluating ← arbitrator ←─────────┘
+  ↓
+done | failed
+```
+
+Other transitions (e.g. `done → thinking`) are forbidden by `transitionState()` validation. `done` and `failed` are terminal.
+
+### 4.5 The message + meta shapes
+
+```typescript
+type KernelMessage =
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string; toolCalls?: readonly ToolCallSpec[] }
+  | { role: "tool_result"; toolCallId: string; toolName: string; content: string; isError?: boolean; storedKey?: string };
+
+interface KernelMeta {
+  readonly entropy?: KernelEntropyMeta;          // RI signal cache
+  readonly controllerDecisions?: readonly ControllerDecisionLike[];  // intervention history
+  readonly maxIterations?: number;
+  readonly requiredTools?: readonly string[];
+  readonly pendingGuidance?: PendingGuidance;    // typed harness signals
+  readonly budgetLimits?: BudgetLimits;          // Pillar 6 declarative budgets
+  // ... etc; every field optional; every field typed
+}
+```
+
+`PendingGuidance` is typed (no string-bag pattern). Every harness signal MUST be a named optional field, never a free-form payload.
+
+---
+
+## 5. The Arbitrator
+
+### 5.1 Single-owner termination decision (with one emergency escape valve)
+
+`packages/reasoning/src/kernel/capabilities/decide/arbitrator.ts` exports `evaluateTermination(ctx, evaluators)` returning `TerminationDecision`. **This is the canonical termination decision function for normal exits** — every `done` or `failed` Verdict driven by reasoning, verifier, controller, or entropy MUST flow through here.
+
+**One acknowledged escape valve:** killswitch abort paths in `act.ts` + `runner.ts` write `status` directly when a compose-API killswitch (`maxIterations`, `timeoutAfter`, `watchdog`, etc.) fires `abort: 'stop' | 'terminate'`. This bypasses the Arbitrator deliberately — killswitches are emergency cutoffs for user-declared invariants (budget exceeded, wall-clock exhausted), not reasoning decisions. The runtime stamps `state.terminatedBy` so observability can distinguish "killswitch-fired" from "arbitrator-decided."
+
+Verified working today — no rework required for arbitrator.ts itself. The 27 raw `state.status =` mutation count surfaced in §3.6 F10 includes BOTH this legitimate killswitch escape valve AND illegitimate ad-hoc writes (the lint rule WS-3 Phase 4 ships distinguishes them via an allowlist on `terminate.ts` + killswitch-abort sites).
+
+### 5.2 The Verdict shape
+
+```typescript
+interface SignalVerdict {
+  readonly action: "exit" | "redirect" | "continue" | "fail";
+  readonly confidence: "high" | "medium" | "low";
+  readonly reason: string;
+  // ... evaluator-specific fields
+}
+
+interface TerminationDecision {
+  readonly shouldExit: boolean;
+  readonly action: SignalVerdict["action"];
+  readonly confidence: "high" | "medium" | "low";
+  readonly reason: string;
+  readonly evaluator: string;
+  readonly allVerdicts: ReadonlyArray<{ evaluator: string; verdict: SignalVerdict }>;
+}
+```
+
+Action maps to canonical mission verdicts:
+
+| arbitrator.ts action | Canon mission verdict |
+|---|---|
+| `continue` | `continue` |
+| `exit` | `exit-success` |
+| `fail` | `exit-failure` |
+| `redirect` | `escalate` (strategy switch / HITL) |
+
+### 5.3 The signal pipeline — canonical 6-category abstraction with concrete evaluators
+
+Per `07-OPTIMAL-EXECUTION-ALGORITHM` §1 step 6, the Arbitrator is **abstractly** characterized by six signal categories:
+
+| Canonical category | Concrete `TerminationSignalEvaluator`(s) in `arbitrator.ts` (verified) |
+|---|---|
+| `EntropySignal` (from `reactive-intelligence/sensor`) | `entropyConvergenceEvaluator`, `contentStabilityEvaluator` |
+| `VerifierSignal` (from `kernel/capabilities/verify`) | `completionGapEvaluator` |
+| `HealingSignal` (from substrate tools healing pipeline) | (implicit via failure streak feeding `controllerSignalVetoEvaluator`) |
+| `KillswitchSignal` (from `compose/killswitches`) | (escape valve — bypasses arbitrator; see §5.1) |
+| `LoopDetectorSignal` (from `kernel/capabilities/reflect`) | `controllerSignalVetoEvaluator` (consumes controller decision log) |
+| `BudgetSignal` (from `cost/budgets`) | (currently routes through KillswitchSignal; G-A gap per fresh-lens audit) |
+| **Agent-intent signals (not in canon 6 but currently present)** | `pendingToolCallEvaluator`, `finalAnswerToolEvaluator`, `finalAnswerRegexEvaluator`, `llmEndTurnEvaluator`, `reactiveControllerEarlyStopEvaluator` |
+
+**Verified inventory:** 9 concrete `TerminationSignalEvaluator` exports in arbitrator.ts (`defaultEvaluators` array). The 6-category canon is the conceptual model; the 9 evaluators are concrete refinements (multiple evaluators per category) PLUS 5 agent-intent evaluators that interpret the model's own exit signals (`final-answer` tool call, end-turn signal, etc.) which canon implicitly treats as "agent says done" pre-arbitration.
+
+**Gap (logged for §17 mapping):** `BudgetSignal` currently does NOT have a dedicated evaluator — budget enforcement routes through compose-killswitch abort. Fresh-lens gap G-A; refactor candidate.
+
+Each evaluator returns `SignalVerdict | null`; `evaluateTermination` short-circuits on first high-confidence FAIL/EXIT/REDIRECT, then aggregates remaining medium/low. Exactly one `TerminationDecision` per iter.
+
+### 5.4 The Verdict-Override pattern (anti-mission #4 enforcement)
+
+The Arbitrator may override a positive Verdict from one evaluator with a FAIL verdict from another when controller activity contradicts agent success. Specifically: if the agent's `final-answer` says exit-success but controller decisions show persistent failure pattern (high entropy + tool-failure streak + escalations), the FAIL veto fires. Status becomes `failed`, output becomes `null`. This is the trust differentiator: honest fail over fake success.
+
+---
+
+## 6. The Capability Boundary Contract
+
+### 6.1 What every capability IS
+
+A capability is:
+
+- A directory under `kernel/capabilities/<name>/`
+- One concern (Sense, Attend, Comprehend, Recall, Reason, Decide, Act, Verify, Reflect, Learn)
+- A set of pure-where-possible functions consumed by the Loop Controller
+- A boundary that emits its own observation events
+- A leaf in the kernel dependency graph
+
+### 6.2 The 10 capability boundary contracts
+
+| Capability | Purity class (see §6.3-6.5) | Owns | Emits | Reads from | Returns to loop |
+|---|---|---|---|---|---|
+| **Sense** | PURE | Observation construction | `observation-emitted` × N | state, env | `Observation[]` |
+| **Attend** | PURE | Salience + curation + prompt assembly | `curator-decision` per fragment | observations, history, budget | `CuratedContext` |
+| **Comprehend** | PURE | Task intent + soft-required-tools + format hints | `comprehend-result` | task text, state | `ComprehendResult` |
+| **Recall** | EFFECTFUL (memory IO) | Memory + skill + calibration lookup | `memory-recall` × type | query, modelId, taskCategory | `RecallResult` |
+| **Reason** | EFFECTFUL (LLM IO) | LLM invocation + provider abstraction | `llm-exchange` per round-trip | curatedContext, tools, calibration | `LLMResponse` |
+| **Decide** | PURE | Signal integration → Verdict | `arbitrator-verdict` (1 per iter) | 6 signal categories + state | `TerminationDecision` |
+| **Act** | EFFECTFUL (tool IO) | Tool dispatch via `executeToolCall()` | `tool-call-start/end`, `observation.tool-result` | Verdict, pending calls | `Observation[]` |
+| **Verify** | PURE-DECISION + EFFECTFUL-EMIT | Per-check severity ladder | `verifier-verdict` (with checks array) | output, intent, observations | `VerifierVerdict` |
+| **Reflect** | PURE-DECISION + EFFECTFUL-EMIT | Loop / trajectory / evidence signals | `reflection-signals` | history, observations, verdict | `ReflectionSignals` |
+| **Learn** | EFFECTFUL (memory IO, async) | Skill + calibration + memory writes | `learn-write` × target | observations, decisions, outcomes | (none — fire-and-forget) |
+
+### 6.3 The pure-by-default capabilities (Sense, Attend, Comprehend, Decide)
+
+These capabilities own pure decision logic:
+
+- Take only input + state + observations
+- Return a result derived deterministically (same input → same output)
+- Are testable with no Layer setup
+- Declare `Effect.Effect<Result, never, never>` for decision logic (zero error channel, zero requirement)
+- MAY use Effect monad for composition — using Effect is not the same as being effectful
+
+**First-hand verification:** sense, attend, comprehend, decide directories import ZERO IO-bearing services (LLMService, ToolService, MemoryService). Pure ✅.
+
+### 6.4 The pure-decision-effectful-emit capabilities (Verify, Reflect)
+
+These capabilities have **pure decision logic + side-effecting emit obligations**:
+
+- Decision functions (`verify()`, `reflect()`) are pure: same input → same severity ladder / signal output
+- Emit wrappers use `Effect` for trace event publication via `ObservableLogger` / `EventBus`
+- The emit is the side effect; the decision is not
+
+**First-hand verification:** `verify/` imports `Effect` + `ObservableLogger` (2 IO-bearing imports); `reflect/` imports `Effect` + `ObservableLogger` + `EventBus` (3). These are for emit, not for decision IO.
+
+The boundary contract: each public function in verify/reflect MUST be split into:
+- A pure inner function (`computeVerifierVerdict(state) → VerifierVerdict`) — testable with no Layer
+- A public effectful wrapper (`verify(state) → Effect.Effect<VerifierVerdict, never, ObservabilityService>`) — handles emit
+
+This split is partially present today; WS-3 + WS-5 codify it.
+
+### 6.5 The effectful capabilities (Recall, Reason, Act, Learn)
+
+These capabilities do real IO:
+
+- Declare typed errors via Effect's error channel (e.g. `Effect.Effect<Result, ToolError, LLMService | ToolService>`)
+- Never `Effect.runPromise` internally — the runtime controls execution
+- Never throw — errors flow through the typed channel
+- Never `catchAll(() => {})` — errors are routed through `emitErrorSwallowed` if intentionally absorbed, or propagated
+
+### 6.5 Capability emit obligation
+
+Every capability emits at its boundary. The Loop Controller (`runner.ts`) emits ONLY:
+
+- `kernel-state-snapshot` at iter start (1 per iter)
+- `phase-started` / `phase-completed` at canonical phase boundaries
+
+All other emits live in capabilities. The audit at `runner.ts:39 emit-related lines` MUST shrink to ≤10 after the refactor. The other 29+ relocate to their owning capability.
+
+---
+
+## 7. The Strategy Primitive
+
+### 7.1 The Pillar 3 mission
+
+> "Strategies are declarative compositions of capabilities, not parallel loop reimplementations. New algorithmic shapes are first-class primitives; new strategies are array literals."
+
+### 7.2 The canonical Strategy contract
+
+```typescript
+type Strategy = (ctx: StrategyContext) => Effect.Effect<ReasoningResult, ExecutionError | IterationLimitError, LLMService>;
+```
+
+`StrategyContext` is **≤15 fields** total. Substrate-derived; not a god-input.
+
+```typescript
+interface StrategyContext {
+  // ── Identity ──
+  readonly agentId?: string;
+  readonly sessionId?: string;
+  readonly taskId?: string;
+
+  // ── Task ──
+  readonly task: TaskInput;                     // taskDescription + taskType + initialMessages
+  readonly intent: ComprehendResult;            // softRequiredTools + formatHints + complexity
+
+  // ── Substrate ──
+  readonly tools: ToolSubstrate;                // availableTools + schemas + healing + gating
+  readonly memory: MemorySubstrate;             // memoryContext + briefResolvedSkills
+  readonly calibration: CalibrationSubstrate;   // contextProfile + modelId + temperature + tier
+
+  // ── Composition ──
+  readonly config: ReasoningConfig;             // strategy-specific config block
+  readonly harnessPipeline?: HarnessPipeline;   // compose API access
+
+  // ── Runtime ──
+  readonly resultCompression?: ResultCompressionConfig;
+  readonly metaTools?: KernelMetaToolsConfig;
+  readonly synthesisConfig?: SynthesisConfig;
+  readonly verifier?: Verifier;
+  readonly budgetLimits?: BudgetLimits;
+
+  // ── Adaptive ──
+  readonly strategySwitching?: StrategySwitchingConfig;
+}
+```
+
+Each grouping is a substrate object that the runtime derives once + threads through. Strategies pick out what they need; they do not need to know about 30+ scattered fields.
+
+### 7.3 Strategy combinators (the declarative primitive)
+
+```typescript
+// Combinators (the substrate strategies compose over)
+const iterateUntil: <S>(
+  step: (ctx: StrategyContext, state: S) => Effect.Effect<S>,
+  condition: (state: S) => boolean,
+  options?: { maxIter?: number }
+) => (ctx: StrategyContext) => Effect.Effect<S>;
+
+const branchAndPick: <S>(
+  branches: ReadonlyArray<(ctx: StrategyContext) => Effect.Effect<S>>,
+  picker: (results: readonly S[]) => S
+) => Strategy;
+
+const routedDispatch: (
+  routes: Readonly<Record<string, Strategy>>,
+  router: (ctx: StrategyContext) => string
+) => Strategy;
+```
+
+These three combinators cover the algorithmic shapes of all six current strategies:
+
+| Strategy | Combinator composition |
+|---|---|
+| `reactive` | `iterateUntil(thinkActObserve, doneOrMaxIter)` |
+| `direct` | `iterateUntil(thinkActObserve, doneOrMaxIter, { maxIter: 1 })` |
+| `reflexion` | `iterateUntil(initialThenCritique, convergedOrMaxIter)` |
+| `plan-execute-reflect` | `iterateUntil(plan ▷ executeWaves ▷ reflect ▷ refine, doneOrMaxIter)` |
+| `tree-of-thought` | `branchAndPick(bfsExplore × N, scoreAndSelect)` ▷ `iterateUntil(executeBest)` |
+| `code-action` | own substrate (Worker sandbox); does not use kernel loop |
+
+### 7.4 The ≤200 LOC strategy ceiling
+
+After refactoring to combinators, each strategy file MUST be ≤200 LOC. The current 774 LOC (reflexion), 727 LOC (tree-of-thought), 1548 LOC (plan-execute) implementations are all combinator candidates; their LOC budget shrinks because loop control is inherited.
+
+---
+
+## 8. The Service Tag Pattern
+
+### 8.1 The canonical Tag definition
+
+Every cross-package service is defined via Effect's `Context.Tag` pattern.
+
+```typescript
+// In core (or owning package)
+export class MyService extends Context.Tag("MyService")<
+  MyService,
+  {
+    readonly doThing: (input: Input) => Effect.Effect<Output, MyServiceError>;
+    readonly listThings: () => Effect.Effect<readonly Thing[]>;
+  }
+>() {}
+```
+
+### 8.2 The Live layer
+
+```typescript
+export const MyServiceLive = Layer.effect(
+  MyService,
+  Effect.gen(function* () {
+    const dep = yield* SomeOtherService;
+    return {
+      doThing: (input) => /* impl using dep */,
+      listThings: () => /* impl */,
+    };
+  })
+);
+```
+
+### 8.3 The Test layer
+
+```typescript
+export const MyServiceTest = (overrides?: Partial<MyServiceShape>) =>
+  Layer.succeed(
+    MyService,
+    {
+      doThing: () => Effect.succeed(defaultOutput),
+      listThings: () => Effect.succeed([]),
+      ...overrides,
+    }
+  );
+```
+
+### 8.4 When to publish a Tag (cross-package consumption)
+
+A service Tag is published in `@reactive-agents/core/services/` (or the owning L2 package) iff:
+
+- It is consumed by ≥2 different L3 or L4 packages
+- Its consumers cannot reasonably be re-rooted into the owning package
+- The Tag exposes a stable contract (rare schema changes)
+
+If only one consumer exists, keep the service local. If consumers proliferate, publish the Tag — never reach into a package's internals.
+
+### 8.5 The Tag-based cross-capability contract
+
+Inside the kernel, sibling capabilities consume each other ONLY via published Tags:
+
+- `act` exposes `ToolExecutionService` Tag from `core/services/`
+- `verify` exposes `VerificationService` Tag from `core/services/`
+- `reason` consumes those Tags; does not `import "../act/tool-execution.js"` directly
+
+This is the leaf principle enforcement.
+
+---
+
+## 9. The Emit/Consume Contract (Anti-Scaffold Law)
+
+### 9.1 The invariant
+
+**No declared surface element ships without a live emit site AND a live consumer site in the same commit.**
+
+Surface elements include:
+
+- TagMap entries (Compose API tags)
+- ControllerDecision union variants
+- CapabilityRegistry entries
+- Calibration fields
+- Public event types
+- Public service methods
+
+### 9.2 CI enforcement
+
+A CI lint walks the type graph at PR time:
+
+- For every TagMap entry: confirm ≥1 `emit(...)` call site exists for that tag
+- For every TagMap entry: confirm ≥1 `pipeline.transform(...)` consumer site exists
+- For every ControllerDecision variant: confirm ≥1 emitter + ≥1 dispatcher handler
+- For every CapabilityRegistry entry: confirm the registered name is referenced by ≥1 consumer (HarnessProfile, runtime decision logic, etc.)
+- For every calibration field: confirm ≥1 reader exists in production code
+
+Failure = PR blocked.
+
+### 9.3 The deliberate-sentinel exception
+
+A registry entry MAY ship with `liftEvidence: null` IFF the entry is documented as a load-bearing CI signal — i.e., the absence of evidence is the ablation-warden's gate input. Currently exactly one entry uses this (`strategy-switching`). Documented in `capability-registry.ts:218–229`.
+
+Any other case is a violation.
+
+### 9.4 The retroactive sweep rule
+
+Existing surface elements without emit + consumer pairs ARE in violation. They must be either:
+
+- **Wired** — emit site + consumer site shipped in the next commit touching the area
+- **Deleted** — surface removed, type union pruned, registry entry deleted
+
+There is no "deprecate later" path. Surface lives or dies.
+
+---
+
+## 10. The CapabilityRegistry & HarnessProfile
+
+### 10.1 CapabilityRegistry as single source of truth for defaults
+
+`packages/runtime/src/capabilities/registry.ts` is the canonical registry of default-on capabilities. Every default-on toggle in the runtime MUST have a CapabilityRegistry entry. No `_enableX: true =` literal in `runtime.ts` or `builder.ts` without a corresponding registry entry that explains why.
+
+Verified shape:
+
+```typescript
+interface CapabilityEntry {
+  readonly name: string;
+  readonly description: string;
+  readonly defaultOn: boolean;
+  readonly costSignature: CostSignature;          // tokens + latency + extraLLMCalls + tier
+  readonly liftEvidence: LiftEvidence | null;     // measuredOn + delta + evidence path + date
+  readonly riskNotes: string;
+  readonly rationale: string;
+  readonly ownerWarden: WardenOwner;
+  readonly lastAblation: string | null;
+}
+```
+
+Audit method returns:
+
+```typescript
+interface CapabilityAuditReport {
+  readonly totalEntries: number;
+  readonly defaultOnCount: number;
+  readonly entries: readonly CapabilityEntry[];
+  readonly byWarden: Readonly<Partial<Record<WardenOwner, readonly CapabilityEntry[]>>>;
+  readonly staleEntries: readonly CapabilityEntry[];           // > 90 days since last ablation
+  readonly violations: readonly CapabilityEntry[];             // defaultOn && liftEvidence === null
+}
+```
+
+### 10.2 HarnessProfile presets derive from registry
+
+`HarnessProfilePatch` MUST derive its field shape from the registry, not hard-code booleans:
+
+```typescript
+// Canonical (target)
+type HarnessProfilePatch = {
+  readonly name: HarnessProfileName;
+} & Partial<Record<RegisteredCapabilityName, boolean>>;
+
+// NOT canonical (current — F7 finding)
+interface HarnessProfilePatch {
+  readonly name: HarnessProfileName;
+  readonly enableMemory?: boolean;
+  readonly enableReactiveIntelligence?: boolean;
+  readonly enableVerifier?: boolean;
+  readonly enableStrategySwitching?: boolean;
+  readonly enableSkillPersistence?: boolean;
+}
+```
+
+Adding a new registry entry MUST NOT require touching `profile.ts`. Anti-mission #3 (preset proliferation) is prevented structurally.
+
+### 10.3 The three canonical presets
+
+| Preset | Capability set | Use case |
+|---|---|---|
+| `HarnessProfile.lean()` | All registry defaults OFF | Benchmark ablation cells; latency-critical paths; "model is the whole harness" |
+| `HarnessProfile.balanced()` | Registry defaults (no patch) | Today's production defaults |
+| `HarnessProfile.intelligent()` | Balanced + cross-session learning | Compounding intelligence; long-lived agents |
+
+`HarnessProfile.research()` MAY be added in future; the contract is stable at 3 named presets minimum.
+
+### 10.4 The ablation-warden gate
+
+Every default-on registry entry MUST have `liftEvidence !== null` (or the deliberate-sentinel exception). The ablation-warden CI gate (cf-25 in `packages/testing/`) fails the build if a default-on entry lacks evidence. This is the structural enforcement of Mission Pillar 6 (Efficiency — defaults justified empirically).
+
+---
+
+## 11. The User Surface
+
+### 11.1 The composition layers (preference order)
+
+1. **`HarnessProfile.lean()/balanced()/intelligent()`** — primary. Quickstart docs use this.
+2. **`.compose(harness => ...)`** — advanced. For users overriding specific tags / phases / hooks.
+3. **`.withX()` methods** — backward compat. Marked `@deprecated alias for HarnessProfile.X` when redundant.
+
+### 11.2 The ≤24 builder method ceiling (anti-mission #3)
+
+Mission anti-mission #3: "24 named override methods IS the failure mode." The current `builder.ts` has 59 withers (2.4× threshold). Target:
+
+- ≤24 builder methods total
+- Each remaining wither has a justification (no preset covers the case AND `.compose()` is too low-level)
+- Withers with redundant preset coverage are `@deprecated alias`
+
+The runtime API surface gets smaller, not bigger, as capability set grows. New defaults go to registry + presets; new methods do NOT.
+
+### 11.3 The compose harness API
+
+`compose` (L2 package) provides the typed harness chokepoints. Users override defaults by composing a `Harness` value:
+
+```typescript
+import { ReactiveAgents } from "reactive-agents";
+import { HarnessProfile } from "@reactive-agents/runtime";
+
+const agent = await ReactiveAgents
+  .create()
+  .withProfile(HarnessProfile.balanced())
+  .compose(harness => {
+    harness.on("prompt.system", () => "You are a helpful tax-prep assistant.");
+    harness.tap("observation.tool-result", (obs) => log(obs));
+    harness.before("act", (ctx) => guardrailCheck(ctx));
+  })
+  .build();
+```
+
+Every chokepoint is typed via TagMap. Every tag has a payload type via `PayloadFor<Tag>`. Wildcard + predicate patterns are supported. The full chokepoint catalog lives in `compose/src/harness-tag-catalog.generated.ts`.
+
+### 11.4 The killswitch set (frozen at 6)
+
+`compose/killswitches/` exports exactly 6 canonical killswitches:
+
+`budgetLimit · maxIterations · timeoutAfter · watchdog · requireApprovalFor · confidenceFloor`
+
+Adding a 7th requires architectural review (does it belong as a registry-driven capability instead?).
+
+---
+
+## 12. The Observability Architecture
+
+### 12.1 The four observation packages
+
+| Package | Layer | Role |
+|---|---|---|
+| `core/event-bus.ts` | L1 | The EventBus implementation; AgentEvent union |
+| `trace` | L2 | Trace event types + JSONL recorder + reader |
+| `observability` | L2 | Tracing service + metrics collector + logger |
+| `observe` | L4 | OpenTelemetry / OpenInference span exporter (consumes EventBus) |
+
+These compose:
+
+- `EventBus` publishes typed `AgentEvent` records
+- `trace` records to JSONL for replay
+- `observability` aggregates metrics + structured logs
+- `observe` bridges to external OTel sinks
+
+### 12.2 What every iter MUST emit (Pillar 2 enforcement)
+
+Per `07-OPTIMAL-EXECUTION-ALGORITHM` §3:
+
+| Iter step | Required emit |
+|---|---|
+| 0. Setup | `kernel-state-snapshot { iter, status: "entering" }` |
+| 1. Sense | `observation-emitted` × N |
+| 2. Attend | `curator-decision` per kept/dropped fragment |
+| 3. Comprehend | `comprehend-result { softRequiredTools, formatHints, complexity }` |
+| 4. Recall | `memory-recall` × { type, hits } |
+| 5. Reason | `llm-exchange { promptHash, responsePreview, tokens, latency }` |
+| 6. Decide | `arbitrator-verdict { verdict, signalSources }` (exactly 1) |
+| 7. Act | `tool-call-start/end` × N + `observation.tool-result` × N |
+| 8. Verify | `verifier-verdict { checks: [{name, severity, reason}] }` |
+| 9. Reflect | `reflection-signals` (for next iter's Arbitrator) |
+| 10. Learn | `learn-write` × { target, success, durationMs } |
+
+A run trace is complete iff every iter has all 10 required emits. Replay determinism requires this.
+
+### 12.3 The replay determinism property
+
+`packages/replay/` records every emit + every LLM round-trip + every tool result. `replay(traceId, overrides)` reproduces the run:
+
+- Same tool results: bytewise replay of observations
+- Same LLM responses (via cassette layer): bytewise replay of provider calls
+- With overrides: re-run prompts / tools / strategies on the same task and compare
+
+Replay is a **property**, not a feature. The trace IS the run.
+
+---
+
+## 13. The Verification Model
+
+### 13.1 Multi-severity ladder
+
+`VerifierVerdict` is NOT a boolean. It is:
+
+```typescript
+interface VerifierVerdict {
+  readonly checks: ReadonlyArray<{
+    readonly name: string;
+    readonly severity: "pass" | "warn" | "reject" | "escalate";
+    readonly reason: string;
+  }>;
+  readonly computedVerified: boolean;            // derived: all severities ∈ {pass, warn}
+}
+```
+
+The Arbitrator interprets severity:
+
+- `pass` → no impact on Verdict
+- `warn` → surface in trace; do not block exit
+- `reject` → block exit-success; force redirect or retry
+- `escalate` → force escalate Verdict (HITL or strategy switch)
+
+### 13.2 Output sanitization at exit-success
+
+Every `exit-success` Verdict MUST pass `state.output` through `output-assembly.ts:sanitizeOutput` before persisting. The sanitizer strips:
+
+- `<rationale>...</rationale>` XML (M2a leak)
+- `[CRITIQUE N] SATISFIED:` prefixes (M2b leak)
+- `[find result — compressed preview]` markers (M2c leak)
+- Any tag-injection from upstream context
+
+Output that fails sanitization triggers verifier severity `reject`; the Arbitrator converts the Verdict to `redirect` (re-synthesize).
+
+### 13.3 The honest-fail invariant
+
+```
+status === "failed"  ⇒  output === null
+status === "done"    ⇒  output !== null && output.length > 0 && output === sanitize(output)
+```
+
+Anti-mission #4 enforced structurally. No fallback string. No "I'm sorry, I couldn't complete..." synthesized text. Failure is honest or it is a bug.
+
+---
+
+## 14. The Performance Model
+
+### 14.1 The per-iter framework overhead budget
+
+Sum of non-LLM, non-tool time per iter MUST be ≤59ms:
+
+```
+Setup    ≤ 0.5ms
+Sense    ≤ 1ms
+Attend   ≤ 5ms
+Comprehend ≤ 2ms
+Recall   ≤ 10ms
+Decide   ≤ 5ms
+Verify   ≤ 10ms
+Reflect  ≤ 5ms
+Learn    ≤ 20ms (async, non-blocking)
+─────────────
+Total    ≤ 58.5ms
+```
+
+Anything above this is symptomatic of drift. Profiling identifies the offending capability.
+
+### 14.2 Tier-specific defaults
+
+Calibration drives tier-specific defaults:
+
+| Tier | Strategy default | Verifier | RI mode | LLM-exchange capture |
+|---|---|---|---|---|
+| Frontier | adaptive | warn-only | minimal | preview only |
+| Local Large | adaptive | warn → reject | full | full prompt+completion |
+| Local Mid | reactive | warn → reject → escalate | full + aggressive healing | full + reasoning trace |
+| Local Small | direct/reactive | escalate-fast | minimal | full |
+
+Tier is detected from capability snapshot (`packages/llm-provider/src/calibrations/`).
+
+### 14.3 Token + cost aggregation
+
+`AgentResult.metadata.tokensUsed` MUST aggregate from real per-call data (every `LLMRequestCompleted` event). Never declared as 0 when calls happened. Never fabricated. Invariant 8 of `07-OPTIMAL-EXECUTION-ALGORITHM`.
+
+---
+
+## 15. The Multi-Agent Composition
+
+### 15.1 A2A as the inter-agent substrate
+
+`@reactive-agents/a2a` (L4) provides AgentCard + JSON-RPC 2.0 + SSE streaming. Agents discover + invoke each other via A2A. The framework is **single-agent + A2A**, not a workflow DAG framework (LangGraph-style). Workflow composition is the user's domain.
+
+### 15.2 Sub-agent delegation contract
+
+When an agent invokes a sub-agent (via tool call to spawn-sub-agent or via A2A):
+
+- `createLightRuntime` constructs the sub-agent's runtime (minimum substrate)
+- Identity propagates through the call (auth claims, capability delegation)
+- Trace context propagates (parent runId, span IDs)
+- Memory scopes:
+  - Working memory (per-run): NOT shared
+  - Semantic memory (cross-session): MAY be shared (configurable)
+  - Episodic memory (trajectory log): NOT shared
+
+### 15.3 Identity propagation
+
+Identity context (auth claims) propagates through:
+
+- A2A messages: `Message.metadata.identity` preserves the caller's claims
+- Sub-agent spawning: child inherits parent's identity unless explicit re-auth
+- Tool calls: identity is checked at `executeToolCall()` boundary, not at tool implementation
+
+Identity is enforced at substrate boundaries, NOT advisory at L4. Verified by `packages/identity/` audit.
+
+### 15.4 What this framework does NOT ship
+
+- **Workflow DAG primitive (LangGraph-style `StateGraph`).** Out of scope. Compose externally.
+- **Manager-worker hierarchies (AutoGen-style `GroupChat`).** Out of scope. Use A2A + custom orchestration.
+- **Browser / computer-use primitive.** Out of scope today (G-K fresh-lens gap; decision deferred).
+
+---
+
+## 16. Non-Goals (what this model explicitly does NOT include)
+
+- **Multi-agent declarative graph language.** A2A + orchestration package is the multi-agent surface.
+- **A new strategy beyond the 6 canonical ones.** Code-action is the 7th; future strategies require architectural review.
+- **A second composition layer above HarnessProfile.** Three named presets is the cap; advanced users use `.compose()`.
+- **Audio / video / PDF modality blocks.** Text + image only. Multimodal expansion is demand-driven.
+- **A second LLM service Tag beyond `LLMService`.** Provider variations live inside the LLMService Layer.
+- **A second EventBus.** Single bus per run; subscribers are services, not parallel buses.
+- **A second canonical loop.** `react-kernel.ts` is the canonical kernel; custom kernels register via StrategyRegistry but obey the same structure.
+- **Inheritance hierarchies among capabilities.** Capabilities are functions, not classes; composition is the only relationship.
+
+---
+
+## 17. Mapping This Model to Current State
+
+This is the gap analysis at a glance. Full evidence + workstream sequencing lives in `wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md`.
+
+| Section | Current state | Gap | Refactor workstream |
+|---|---|---|---|
+| §1 Layered Model | 4 layers respected with some drift | AGENTS.md tree omits ~12 packages | WS-5 doc-drift |
+| §2 Kernel arch — capabilities | 10 dirs ✅ | `act/` 3053 LOC contains tool substrate; 3 cycles | **WS-3** |
+| §2 Kernel arch — substrate | `kernel/substrate/` does not exist | Create it; extract tool-parsing | **WS-3 Phase 1** |
+| §3 Runtime composition | `createLightRuntime` ✅ canonical; `createRuntime` mutation chain | 40× Layer.merge → 1× Layer.mergeAll | **WS-2** |
+| §4 State model | KernelState ✅ immutable; `transitionState()` exists | 27 raw `state.status =` violations | **WS-3 Phase 4 lint** |
+| §5 Arbitrator | ✅ verified canonical single-owner | none (some signal pipeline gaps) | (covered by WS-7 §1.6 of canon doc) |
+| §6 Capability contract | Capabilities exist; some emit at boundary | 38 cross-capability internal imports; `runner.ts` has 39 emit lines that belong at boundaries | **WS-3 Phase 4/5** |
+| §7 Strategy primitive | 8 strategies registered; `StrategyFn` has 30+ field input | Refactor to `StrategyContext` ≤15 fields; introduce combinators | **WS-3 Phase 6 (new)** + future combinator work |
+| §8 Service Tag pattern | Tags exist for major services | Cross-cap dep enforcement needs lint | **WS-3 Phase 4 lint** |
+| §9 Emit/Consume contract | `confidenceFloor` doc lies; observe pkg 0 callers; 4 dead Compose tags | Wire or delete; add CI lint | **WS-4** |
+| §10 CapabilityRegistry + HarnessProfile | Registry clean ✅; HarnessProfilePatch hard-coded fields | Generalize patch type | **WS-4** |
+| §11 User surface | 59 builder methods (2.4× threshold) | Reduce to ≤24; mark redundant as `@deprecated alias` | **WS-2 Phase 3** |
+| §12 Observability | EventBus ✅; trace ✅; observability ✅; observe (0 callers) | Wire or delete observe pkg | **WS-4** |
+| §13 Verification | Verifier exists; severity ladder partial | Multi-severity ladder formalization | **WS-7** |
+| §14 Performance | Per-iter budget unmeasured today | Stage telemetry bus (was MOVE-1) | (deferred to post-refactor) |
+| §15 Multi-agent | A2A ✅; sub-agent contract working | Identity propagation through A2A unaudited (G-J) | (separate spike) |
+
+---
+
+## 18. How This Model Evolves
+
+Strict rule: this document gets **stricter** over time, never vaguer.
+
+Amendment process:
+
+1. Empirical evidence the current statement is wrong OR aspirational target has changed
+2. Reference to the failure mode or capability gap motivating the change
+3. Updated invariant — declarative, not aspirational fog
+4. Cross-reference to the verified-working code that newly embodies the change
+
+Statements are added (as missions stricten). Statements are not removed except when they conflict with verified-working code that improves on them.
+
+---
+
+## 19. Cross-References
+
+- `00-VISION.md` — 8 pillars (the WHY)
+- `06-MISSION-STATEMENTS.md` — per-pillar / per-capability / per-trait missions (the BEHAVIOR)
+- `07-OPTIMAL-EXECUTION-ALGORITHM.md` — 10-step canonical loop + 10 invariants (the ITERATION)
+- `05-DESIGN-NORTH-STAR.md v5.0` — historic architecture target + roadmap (this doc supersedes §4-5 structural content)
+- `2026-05-28-canonical-refactor.md` — gap analysis + workstream sequence to reach this model
+- `2026-05-23-harness-convergence.md` — 22-issue convergence morph plan (subsumed by refactor plan WS-4 + WS-7)
+- `packages/reasoning/src/kernel/state/kernel-state.ts` — verified embodiment of §4
+- `packages/reasoning/src/kernel/capabilities/decide/arbitrator.ts` — verified embodiment of §5
+- `packages/runtime/src/runtime.ts:1061` (`createLightRuntime`) — verified embodiment of §3 canonical pattern
+- `packages/runtime/src/capabilities/registry.ts` — verified embodiment of §10.1
+- `packages/runtime/src/capabilities/profile.ts` — embodiment of §11.1 (with §10.2 growth-risk noted)
+
+---
+
+*This document is the structural north star. The vision says why. The missions say how it behaves. The algorithm says the per-iter steps. This document says what the code looks like. Every refactor decision is judged against this model. Every new feature is placed within it. Drift is measured against it. It does not move.*

--- a/wiki/Issues/Running Issues Log.md
+++ b/wiki/Issues/Running Issues Log.md
@@ -445,3 +445,33 @@ At that point, we expect to see:
 - **HS-31:** claimed "74 casts" — actually 55 (grep counted match lines, not occurrences)
 
 **Process fix:** every future health-sweep finding requires a `verified-by:` line citing concrete file:line evidence before filing. `.claude/skills/codebase-health-sweep/SKILL.md` updated to enforce this.
+
+---
+
+## Health Sweep — 2026-05-27 (pointer)
+
+**60 NEW findings** filed to `wiki/Research/Audit-Reports-2026-05-27/health-sweep.md`. Method: 4 parallel scan agents (codebase-health-sweep skill v3), all `verified-by:` per audit-of-audit protocol. Build was GREEN at baseline.
+
+**Counts:**
+- A — Type Safety / Dead Exports: 20 (1 P0, 8 P1, 11 P2)
+- B — Runtime Bug Patterns: 10 (0 P0, 3 P1, 7 P2)
+- C — Dead Weight / Inefficiency: 20 (0 P1, 16 P2, 4 P3)
+- D — Tests / Coverage: 20 (7 P1, 13 P2)
+
+**Top P0 / P1 (12):** see *Execution Priority* table in audit report. Top item: **HS-A-01** — `ReactiveAgent` Gateway helpers cast `this as any` (public API contract lie, single-class fix).
+
+**5 recommended /execute-backlog bundles** drafted in the audit report (honesty-pass, public-API-honesty, provider-helper-extraction, surface-coverage-gap, deferred-arch-debt-epic).
+
+**Cross-checked**: none of the 60 are open in GH #29-#149 or in this log above.
+
+### Iter 2 update — 2026-05-28 (apps/* + docs)
+
+**+27 NEW findings** (E:12 apps, F:15 docs). Filed as #159-#164 (6 GH issues).
+
+**🚨 P0 release-state drift (#159):** Root VERSION=0.11.1 + npm has 0.11.1 published, BUT 34/35 workspace package.json files at 0.10.6 AND no v0.10.x/v0.11.x git tags exist locally OR on remote. Tag-driven release flow violated; next `release:dry` will fail drift gate.
+
+**P1 supersedes #158:** #162 (`AgentResult.debrief` missing from public type) is the root-cause fix that closes #158 and erases 4+ casts across CLI + cortex/server in one PR.
+
+**Cross-app pattern:** 2 missing public types account for 17 casts in apps — `AgentResult.debrief` (#162) and `AgentEvent` discriminated union (#163).
+
+**Doc systemically lags code:** 04-PROJECT-STATE.md (the AGENTS.md-mandated "READ FIRST" doc) is 30+ days stale, says "v0.10.0 deferred". confidenceFloor killswitch unshipped 2026-05-19 but still in AGENTS.md killswitch list (#160 — re-add anti-pattern risk).

--- a/wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md
@@ -1,0 +1,819 @@
+---
+title: Canonical Refactor — Reactive Agents (Fresh-Start)
+date: 2026-05-28
+status: MASTER PLAN (single source of truth for this refactor cycle)
+supersedes: none (prior master plans 2026-05-26/27 treated as reference, NOT authority)
+authoritative-canon:
+  - wiki/Architecture/Specs/00-VISION.md
+  - wiki/Architecture/Specs/06-MISSION-STATEMENTS.md
+  - wiki/Architecture/Specs/07-OPTIMAL-EXECUTION-ALGORITHM.md
+  - wiki/Architecture/Design-Specs/2026-05-28-canonical-architecture-model.md   # THE STRUCTURAL NORTH STAR — what we are refactoring TOWARD
+authoritative-evidence:
+  - wiki/Research/Audit-Reports-2026-05-27/health-sweep.md   # 126 findings across 4 iters — VERIFIED + CORRECTED numerically in §3.4 below
+  - wiki/Research/2026-05-23-primitive-audit-fresh-lens.md   # 11 fresh-lens gaps G-A..G-K
+  - GH issues #151–#171 (post-audit) + #104–#125 (convergence backlog)
+  - First-hand audit 2026-05-28 (recorded inline §3.4) — supersedes prior-audit numbers where they diverge
+companion-thin-specs:
+  - 2026-05-28-ws-1-release-flow-integrity.md
+  - 2026-05-28-ws-2-runtime-canonical-seam.md
+  - 2026-05-28-ws-3-kernel-capability-dag.md
+  - 2026-05-28-ws-4-anti-scaffold-purge.md
+  - 2026-05-28-ws-5-honesty-pass.md
+---
+
+# Canonical Refactor — Reactive Agents (Fresh-Start)
+
+> **One sentence.** Bring the runtime in line with the canonical architecture already specified in `00-VISION` / `06-MISSION-STATEMENTS` / `07-OPTIMAL-EXECUTION-ALGORITHM`, by closing the five structural root causes the 2026-05-27 audit revealed, in a priority-ordered sequence where every workstream has a falsifiable verification gate.
+
+---
+
+## 0. Frame
+
+### 0.1 Why this plan exists
+
+Three things are simultaneously true today:
+
+1. **The canonical architecture target is fully specified.** Eight pillars, ten capabilities, five traits, a ten-step canonical loop, ten algorithmic invariants, eight anti-missions. We are not redesigning anything in this plan.
+2. **The runtime has drifted from that target.** The 2026-05-27 four-iter audit produced 126 findings (60 type/bug, 27 apps/docs, 19 CI/test, 20 effect-ts/arch) and filed 21 GH issues (#151–#171). Build is green; tests pass; the architecture is structurally wrong on the seams where Builder → Runtime → ReactiveAgent → Kernel meet.
+3. **Past master plans have themselves contributed to the drift.** Documents shipped, code did not. Surfaces shipped, callers did not. We treat prior plans as reference, NOT as authority. The only authoritative documents are the canon anchors and the audit evidence cited above.
+
+### 0.2 What this plan IS and is NOT
+
+| This plan IS | This plan is NOT |
+|---|---|
+| A priority-ordered execution sequence over five root causes | A new architecture proposal |
+| Anchored to the canonical missions + algorithm | An amendment to vision or pillars |
+| Falsifiable: every workstream has a verification gate that can fail | An aspirational manifesto |
+| Subsuming: in-flight convergence work (#104–#125) routes through here | A parallel stream that ignores existing GH issues |
+| Forensic: every claim is tied to a file:line or a GH issue | A new theory about how the framework should work |
+
+### 0.3 Status entering this refactor
+
+- **Branch:** `main`. All prior overhaul work merged.
+- **Build:** ✅ green (38/38 turbo tasks, 27 cached).
+- **Tests:** ✅ 3219/3219 across the six most-changed packages (iter-3 audit baseline).
+- **Version:** `VERSION=0.11.1` declared; `packages/*/package.json` drift at 0.10.6 (HS-H root-caused, #159 P0).
+- **Open issues:** #104–#125 convergence backlog (Phase 0 closed; Phases 0.5/1/2/3 ahead). #151–#171 post-audit (1 P0 + 15 P1 + 8 P2).
+- **Dirty state at session start:** 3 modified files (`.agents/MEMORY.md`, `apps/examples/spot-test.ts`, `wiki/Issues/Running Issues Log.md`) + 2 untracked artifacts in `wiki/Research/`.
+
+---
+
+## 1. Canon Anchors (NOT reopened in this plan)
+
+These are stated as anchors to avoid re-derivation cost. Every workstream cites the anchor it serves.
+
+### 1.1 The Vision (Pillars 1–8)
+
+`Control · Observability · Flexibility · Scalability · Reliability · Efficiency · Security · Speed`
+
+### 1.2 The Capability Set (10)
+
+`Sense → Attend → Comprehend → Recall → Reason → Decide → Act → Verify → Reflect → Learn`
+
+Each capability is owned by one directory under `packages/reasoning/src/kernel/capabilities/`. The directory is the canonical seam; logic for that capability lives nowhere else.
+
+### 1.3 The Trait Set (5)
+
+`Comprehension · Strategic-intent · Effective-action · Self-monitoring · Compounding-intelligence`
+
+### 1.4 The Canonical Per-Iter Algorithm
+
+10 steps with a 59ms framework-overhead budget per iter:
+
+```
+Setup → Sense → Attend → Comprehend → Recall → Reason → DECIDE (Arbitrator)
+                                                             ↓
+                                            Act → Verify → Reflect → Learn → loop
+```
+
+### 1.5 The 10 Algorithmic Invariants
+
+1. Single Arbitrator per iter — exactly one verdict
+2. `status=failed → output=null` (trust differentiator)
+3. `status=done → output≠null AND sanitized` (no M2a/b/c leak)
+4. Every emit site has ≥1 consumer (anti-scaffold)
+5. `state.status =` outside `transitionState()` = lint failure
+6. Verifier check failure → severity ≠ pass (no boolean collapse)
+7. Tool execution flows through `executeToolCall()` capability regardless of caller
+8. Token + cost metadata aggregates from real per-call data
+9. `success === true` IFF `output !== null && output.length > 0 && status === 'done'`
+10. Capability emit events fire from capability code, never from strategy code
+
+### 1.6 The 8 Anti-Missions
+
+`NOT magic black box · NOT frontier-only · NOT config menu · NOT hides failure · NOT instrumentation-late · NOT scaffold-without-callers · NOT owns app loop · NOT unitary intelligence`
+
+---
+
+## 2. The Canonical System Model (intent layer)
+
+This is the **purpose-and-boundary description** the user requested. Each system, what it owns, what it does not own, how it composes with the rest.
+
+### 2.1 What the framework IS
+
+> A **composable agent harness**: a layered runtime that turns a Builder spec into an Effect program that runs the ten-capability loop against any provider, where every default is justified, every surface is observable, every action is verified, every iter is one Arbitrator decision, and every advertised capability is backed by a live wired runtime.
+
+The framework is NOT the agent. The user owns the agent. The framework offers the loop.
+
+### 2.2 The four canonical layers
+
+Every package belongs to exactly one of four layers. The layer determines what it is allowed to depend on and what it is allowed to expose.
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│  L4 — SURFACE          (consumer-visible)                             │
+│      reactive-agents · runtime · gateway · channels · a2a            │
+│      react · svelte · vue · create-reactive-agent · diagnose         │
+│      eval · observe · replay · benchmarks · scenarios                │
+└───────────────────────────────────────────────────────────────────────┘
+                            ▲
+                            │ depends on
+┌───────────────────────────────────────────────────────────────────────┐
+│  L3 — DOMAIN           (cognitive concerns)                           │
+│      reasoning · reactive-intelligence · interaction                  │
+│      memory · cost · identity · guardrails · verification             │
+│      tools · prompts · orchestration                                  │
+└───────────────────────────────────────────────────────────────────────┘
+                            ▲
+                            │ depends on
+┌───────────────────────────────────────────────────────────────────────┐
+│  L2 — SUBSTRATE        (cross-cutting capabilities)                   │
+│      llm-provider · observability · trace · testing                   │
+│      compose · health · judge-server                                  │
+└───────────────────────────────────────────────────────────────────────┘
+                            ▲
+                            │ depends on
+┌───────────────────────────────────────────────────────────────────────┐
+│  L1 — FOUNDATION       (no agent semantics)                           │
+│      core · runtime-shim                                              │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+**The dependency rule (must hold):** L_n may only depend on L_m where m ≤ n. Within a layer, packages may depend on each other only via explicit Tag-based Layer wiring (no transitive import-graph cycles).
+
+### 2.3 The 35 packages by canonical role
+
+| Package | Layer | Role (one sentence) | Owns (what only it gets to do) |
+|---|---|---|---|
+| **core** | L1 | Shared types + EventBus + AgentService + TaskService | Type definitions, event bus implementation, shared service Tags |
+| **runtime-shim** | L1 | Bun/Node unified primitives | Cross-runtime filesystem/DB/HTTP primitives |
+| **llm-provider** | L2 | `LLMService` + 6 provider adapters + streaming + native FC | Provider semantics, response shape normalization, 7-hook adapter contract |
+| **observability** | L2 | Tracing + metrics + structured logging + MetricsCollector | Sink-agnostic observation pipeline |
+| **trace** | L2 | Trace event types + recorder + reader | Trace event schema + JSONL recording |
+| **testing** | L2 | Mock LLM + tool + bus + assertion helpers | Test fixture surface for downstream packages |
+| **compose** | L2 | Harness composition pipeline + 6 killswitches | Tag→callback registry, phase-hook injection, killswitch lifecycle |
+| **health** | L2 | Readiness/liveness primitives | Health endpoint shapes (consolidation candidate — see §2.4) |
+| **judge-server** | L2 | Internal judge HTTP wrapper for eval | LLM-as-judge endpoint isolation |
+| **tools** | L3 | `ToolService` + registry + 11 builtins + MCP + sandbox | Tool definition, dispatch, registry, MCP client, healing |
+| **memory** | L3 | 4-layer memory + SQLite/FTS5 + sqlite-vec + Zettelkasten | Memory persistence, recall, skill store, calibration store |
+| **reasoning** | L3 | Kernel + 6 strategies + 10 capability dirs | `runKernel`, capability emit, Arbitrator, every strategy primitive |
+| **reactive-intelligence** | L3 | Adaptive dispatcher + bandit + skill synthesis + calibration | Cross-iter control decisions, dispatcher FSM, RI policy |
+| **interaction** | L3 | 5 autonomy modes + checkpoints + approval gates + preference learning | HITL surface, checkpoint state machine, approval routing |
+| **cost** | L3 | Router + budget enforcer + semantic cache + pricing | Complexity routing, budget tracking, cost calculation |
+| **identity** | L3 | Ed25519 certs + RBAC + delegation + audit trail | Identity verification, capability delegation, audit append |
+| **guardrails** | L3 | Injection/PII/toxicity + KillSwitch + BehavioralContracts | Input/output filter pipeline |
+| **verification** | L3 | Semantic entropy + fact decomposition + NLI hallucination | Hallucination detection primitives (consolidation candidate — see §2.4) |
+| **prompts** | L3 | Template engine + version control + tier-adaptive variants | Prompt template surface (consolidation candidate — see §2.4) |
+| **orchestration** | L3 | Sequential/parallel/pipeline/map-reduce workflows | Multi-agent workflow primitives |
+| **a2a** | L4 | Agent Cards + JSON-RPC 2.0 + SSE streaming | Inter-agent transport |
+| **gateway** | L4 | Persistent harness + heartbeats + crons + webhooks + policy | Long-running gateway loop |
+| **channels** | L4 | Multi-transport I/O adapters | Channel adapters + bus shim |
+| **eval** | L4 | LLM-as-judge + EvalStore + scoring dimensions + regression | Eval suite execution + persistence |
+| **observe** | L4 | OTel/OpenInference span exporter | EventBus → OTel bridge (dead-surface candidate — see §3.5) |
+| **replay** | L4 | Deterministic trace replay + diff | Snapshot + replay tool layer + diffing |
+| **benchmarks** | L4 | Benchmark suites + sessions | Benchmark scaffolds (consolidation candidate — see §2.4) |
+| **scenarios** | L4 | Scenario fixtures | Scenario corpus (consolidation candidate — see §2.4) |
+| **diagnose** | L4 | `rax-diagnose` CLI | CLI for trace + run inspection |
+| **runtime** | L4 | `ExecutionEngine` + `ReactiveAgentBuilder` + `createRuntime()` | The runtime facade + builder API |
+| **reactive-agents** | L4 | Public umbrella façade + re-exports | Public API surface (single import point) |
+| **create-reactive-agent** | L4 | Scaffolding CLI | Template-driven onboarding |
+| **react** | L4 | React adapter (hooks + stream) | React-native consumer integration |
+| **svelte** | L4 | Svelte adapter | Svelte-native consumer integration |
+| **vue** | L4 | Vue adapter | Vue-native consumer integration |
+
+### 2.4 Documented consolidation candidates (NOT executed in this refactor cycle)
+
+`05-DESIGN-NORTH-STAR §5.4` proposed five consolidations that have NOT shipped: `verification → reasoning/kernel/capabilities/verify`, `prompts → reasoning/context`, `interaction → runtime`, `benchmarks + scenarios → testing`, `health → observability`. Net package count goal: 35 → 22.
+
+**Decision for this plan:** Consolidations are explicitly **deferred** to a later cycle. They are not in scope for the foundation-canonical refactor. Reason: consolidation is a value-extraction move, not a structural-correctness move. Structural correctness comes first.
+
+### 2.5 The 10-capability → kernel-dir canonical map
+
+Verified against current code state. ✅ = directory exists with primary owner file.
+
+| Capability | Kernel directory | Primary owner file | Status |
+|---|---|---|---|
+| Sense | `kernel/capabilities/sense/` | `step-utils.ts` | ✅ |
+| Attend | `kernel/capabilities/attend/` | `context-utils.ts`, `tool-formatting.ts` | ✅ |
+| Comprehend | `kernel/capabilities/comprehend/` | `task-intent.ts` | ✅ |
+| Recall | `kernel/capabilities/recall/` | `recall-service.ts` | ✅ |
+| Reason | `kernel/capabilities/reason/` | `think.ts`, `stream-parser.ts`, `think-guards.ts` | ✅ |
+| Decide | `kernel/capabilities/decide/` | `arbitrator.ts`, `oracle-nudge.ts` | ✅ |
+| Act | `kernel/capabilities/act/` | `act.ts`, `tool-execution.ts`, `guard.ts` | ✅ |
+| Verify | `kernel/capabilities/verify/` | `verifier.ts`, `evidence-grounding.ts`, `quality-utils.ts` | ✅ |
+| Reflect | `kernel/capabilities/reflect/` | `loop-detector.ts`, `reactive-observer.ts`, `strategy-evaluator.ts` | ✅ |
+| Learn | `kernel/capabilities/learn/` | `learning-pipeline.ts` | ✅ |
+
+**Structural completeness ✅.** All 10 directories exist with primary owner files. The remaining work is to ensure the mesh edges between them respect the leaf principle (no cycles) — see RC-2 / WS-3.
+
+### 2.6 The 5 cross-cutting concerns (where they live)
+
+| Concern | Owner location | Consumed by |
+|---|---|---|
+| State | `kernel/state/` (kernel-state.ts, kernel-hooks.ts, kernel-constants.ts) | Loop controller only mutates; all capability code reads |
+| Telemetry | `core/event-bus.ts` + `trace/` + `observability/` | Every capability emits via boundary helper |
+| Safety | `guardrails/` + `cost/` + `identity/` | Verifier consults; Arbitrator weighs |
+| Time | `core/` (mockable clock) | Sense + Reflect for budget/latency signals |
+| Provenance | `ObservationResult.trustLevel` + tool risk levels | Verify + Decide |
+
+### 2.7 The emit/consume contract (anti-scaffold law)
+
+This is the single load-bearing law for this refactor. Stated three ways for clarity:
+
+- **Imperative:** No declared surface element ships without an emit site and a consumer in the same commit.
+- **Compositional:** Every entry in `TagMap` / `ControllerDecision union` / `CapabilityRegistry` / calibration field set has a matching `emit(...)` call site AND a matching `on(...)` / read site shipped in the same commit.
+- **Lint:** A future CI lint rule (WS-4 deliverable) walks the type graph and flags entries without paired sites.
+
+---
+
+## 3. Current Drift From Canon (evidence-grounded)
+
+Each item below is tied to a GH issue or audit finding. No claims without citations.
+
+### 3.1 L1-metric drift (structural — auto-checkable in CI)
+
+| Mission L1 metric | Target | Current | Gap | Evidence |
+|---|---|---|---|---|
+| Workspace test pass rate | ≥99% | ~99.8% (3219/3219 audited) | ✅ on target | iter-3 audit |
+| `state.status=` mutation sites | ≤10 | not measured (lint rule unshipped) | unknown | #114 convergence backlog |
+| Declared TagMap entries with ≥1 emit site | 100% | < 100% (4 dead Compose tags audited) | -4 | G-9 / #112 |
+| Capability dirs match canonical 10 list | 100% | 100% (10/10 ✅) | 0 | §2.5 verified |
+| Type-checks clean | clean | clean | ✅ on target | turbo build green |
+
+### 3.2 L2-metric drift (observability — automatable per-run)
+
+| Mission L2 metric | Target | Current | Gap | Evidence |
+|---|---|---|---|---|
+| `kernel-state-snapshot` per `state.status` transition | 100% | partial; outer-loop strategies miss | ↓ | G-10 / #113 |
+| `llm-exchange` per LLM round-trip | 100% | provider-side wire present; full coverage gap | partial | #117 |
+| Trace duplication rate | ≤1% | known E5 duplications exist | unknown % | E5 in failure catalog |
+| Trace-to-replay determinism | ≥99% bytewise | tool-layer replay shipped; no LLM cassette | partial | G-F fresh-lens |
+
+### 3.3 L3-metric drift (outcome — out of scope for this refactor)
+
+The plan does NOT relitigate L3 outcomes. Outcome work routes through Phase 1.5 mechanisms (M3/M6/M7/M8/M10/M14) which proceed in parallel. The refactor's job is to make L1 + L2 hold structurally so L3 measurements are trustworthy.
+
+### 3.4 Failure pattern inventory (the five clusters)
+
+The 126 audit findings collapse into five mechanism-level root causes. Symptoms cluster on each:
+
+#### **RC-1 — Mutation-chain Layer composition adds N cast points instead of 1**
+
+**Reframed from prior-audit "service-locator anti-pattern."** First-hand read of `runtime.ts` (lines 55-76 + 215-870) shows the team made a **deliberate, documented engineering choice:** Effect's `Layer<Out,Err,In>` union types blow up at ~25 optional layers ("type instantiation excessively deep"), so `ComposableLayer = Layer.Layer<unknown,unknown,unknown>` is used as a single erasure boundary, with `BuildBaseRuntimeResult` as the re-narrowing site. The pattern has merit — Effect's compiler-perf problem is real.
+
+**The actual structural issue:** the runtime is built via **40+ mutations** of `let runtime` with `runtime = Layer.merge(runtime, X) as ComposableLayer` in conditional blocks. The pattern adds **44 cast points** (one per merge) instead of **one** (collected `Layer.mergeAll([...layers])` at the end).
+
+- 44× `as ComposableLayer` in `runtime.ts` alone (verified `grep -c`)
+- 40× `Layer.merge(runtime, X)` calls forming the mutation chain
+- Only 2× `Layer.mergeAll` calls (so the declarative-array primitive is known but underused)
+- 4× `as Context.Tag.Service` (prior audit said 64; **wrong by 16×**)
+- 74× `as unknown as` total in `packages/*/src/` (prior audit said 80; close)
+- `AgentResult.debrief` not on public type → casts at CLI/cortex/playground (real, #162)
+- `AgentEvent` union not discriminated on `_tag` → casts at cortex/ui (real, #163)
+
+**Mechanism:** chain pattern + per-link erasure. The fix is mechanical: collect every conditional layer into an `Array<ComposableLayer>`, terminal `Layer.mergeAll(layers)`, one cast at the boundary. Same type-erasure semantic; cleaner code; 44 casts → 1.
+
+**Cited:** #167, #162, #163, runtime.ts:55-76 (the team's own documentation of the tradeoff), runtime.ts:693-885 (the mutation chain), HS-A-01/04/05/07/15/16/19, HS-D-07/08/09.
+
+#### **RC-2 — Kernel mesh has cycles AND `act/` is a 3053-LOC monolith conflating capability + tool substrate**
+
+**Reframed from prior-audit "21 edges + 7 cycles."** First-hand walk (formal all-pairs grep of `import from ../$other/`) shows:
+
+- **38 cross-edges total** (prior audit said 21 — undercount by ~45%)
+- **3 confirmed cycles** (prior audit said 7 — overcount by ~2×):
+  - `act` ↔ `decide` (`act/act.ts` ↔ `decide/arbitrator.ts`)
+  - `act` ↔ `reason` (`act/{act,tool-execution}.ts` ↔ `reason/{think,think-guards}.ts`)
+  - `reason` ↔ `verify` (`reason/{think,think-guards}.ts` ↔ `verify/...`)
+
+**Root mechanism (the structural insight prior audits missed): `act/` conflates two distinct concerns** — the Act capability AND tool substrate (execution, parsing, gating). At 3053 LOC across 6 files:
+
+| File | LOC | Inbound from OTHER capabilities | Concern |
+|---|---|---|---|
+| `act/act.ts` | 1208 | 0 | Act capability (correct home) |
+| `act/tool-execution.ts` | 893 | **3** | Tool substrate (wrong home) |
+| `act/tool-parsing.ts` | 255 | **2** | Tool substrate (wrong home) |
+| `act/tool-gating.ts` | 270 | **4** | Tool substrate (wrong home) |
+| `act/tool-capabilities.ts` | 140 | 0 | Tool substrate (wrong home) |
+| `act/guard.ts` | 287 | 0 | Act capability (correct home) |
+
+**9 of the 38 cross-edges go into `act/tool-*.ts`** — these are NOT capabilities consuming Act; they are capabilities consuming tool primitives that happen to live in `act/`'s directory.
+
+**Fix mechanism:** extract `tool-execution.ts` + `tool-parsing.ts` + `tool-gating.ts` + `tool-capabilities.ts` into `kernel/substrate/tools/` (or back into `@reactive-agents/tools` package). Capabilities consume via Tag-based contract; not via direct file imports. Predicted collapse:
+
+- 9 cross-edges → 0 (substrate consumption is allowed; capability↔capability internal imports become impossible)
+- 3 cycles → 0–1 (act↔decide may persist as a true cross-capability cycle worth its own analysis; act↔reason and reason↔verify collapse because they're routed through tool/verify primitives)
+- `act/` LOC: 3053 → ~1495 (just `act.ts` + `guard.ts`)
+
+**Cited:** #169 (with corrected numbers), first-hand all-pairs cycle walk 2026-05-28, file LOC measurements.
+
+#### **RC-3 — Scaffold without callers (declared-surface drift)**
+
+- `@reactive-agents/observe` package: zero internal callers; only docs reference it (#170 / K-02).
+- 5 of 6 M12 `LocalProviderAdapter` hooks ship 270 LOC with zero call sites (K-08).
+- 4 Compose tags declared but no emit site (G-9 — partially closed by convergence Phase 1 #112).
+- `confidenceFloor` killswitch: documented + tested, **unshipped** per 2026-05-19 audit (#160).
+- `strategy-switching` registry entry: `defaultOn: true` but `liftEvidence: null` (deliberate per cf-25 gate).
+
+**Cited:** #170, #160, G-9 cluster, K-02, K-08.
+
+#### **RC-4 — Honesty debt (silent error swallow + lying state)**
+
+**Reframed with first-hand counts.** Prior audit was directionally right but materially overstated:
+
+- **34× `Effect<X, unknown>`** in `packages/*/src/` (prior audit said 105 — **wrong by ~3×**)
+- **27× `console.warn`** sites bypassing ObservabilityService (prior audit said "3 sites" — **understated**)
+- **24× `console.error`** sites in production code
+- **28× `Effect.runPromise`** — async boundary violations (matches prior count)
+- **113× `as any`** in `packages/*/src/` excluding tests (prior audit said ~490 — **wrong by ~4×**)
+- Lying comment at `gateway-bootstrap.ts:236`: claims "propagate" but actually `.catch(() => {})` (HS-B-02 confirmed)
+- Leftover `DEBUG_VERIFIER console.error` at `runner.ts:1740–1742` (HS-B-01 confirmed)
+- 4× memory-service bootstrap swallows missing `emitErrorSwallowed` (HS-B-04 confirmed)
+- Doc-drift: AGENTS.md tree omits some packages (per-package listing TBD verify); `04-PROJECT-STATE.md` 30+ days stale (#161, #171)
+
+The honesty debt is **real but smaller than reported**. The audit's count-inflation pattern (`grep -c` matching multiple times per line; missing test/non-test split) explains most of the gap. RC-4 work proceeds; thresholds in §8.1 are calibrated to corrected baselines.
+
+**Cited:** #168, #161, #171, HS-B-01..09, first-hand counts 2026-05-28.
+
+#### **RC-5 — Release-flow drift (P0, first-hand confirmed)**
+
+- ✅ `release.ts:197–208` stamps `packages/*/package.json` in ephemeral CI runner; mutations die with runner.
+- ✅ Root `VERSION=0.11.1` (verified `cat VERSION`)
+- ✅ npm published `@reactive-agents/core` at 0.11.1 (verified `npm view`)
+- ✅ All 35 `packages/*/package.json` workspace versions at **0.10.6** (verified `grep "version" packages/*/package.json`)
+- ✅ Local + remote git tags max at `v0.9.0` (verified `git tag | tail`); no v0.10.x or v0.11.x tags
+- ✅ Drift is structural, not accidental
+- Orphan v0.10.7 GH draft release residue (#165)
+
+**Cited:** #159 P0 + #165, HS-F-04, HS-H audit, first-hand 2026-05-28.
+
+### 3.6 First-Hand Deep-Audit Findings (2026-05-28 amendment 2)
+
+Deep-read of `runtime.ts` (full createRuntime body) + `act/{act,tool-execution,tool-parsing,tool-gating}.ts` + `reactive-agent.ts` + `runner.ts` emit sites + `arbitrator.ts` + `builder.ts` public surface produced six structural facts that materially shape the workstream scope.
+
+#### F1 — `createRuntime` is the holdout; `createLightRuntime` already uses the target pattern
+
+`runtime.ts:1061` (`createLightRuntime`):
+```ts
+let runtime: ComposableLayer = Layer.mergeAll(
+  coreLayer, eventBusLayer, llmLayer, memoryLayer, hookLayer, engineLayer, CapabilityRegistryLive,
+) as ComposableLayer;
+```
+
+`runtime.ts:215–940` (`createRuntime` — the main entry): 40× `runtime = Layer.merge(runtime, X) as ComposableLayer` mutation chain.
+
+**Implication:** WS-2 is purely mechanical. The team already knows + uses the declarative pattern; `createRuntime` is the holdout. Refactor scope = mirror `createLightRuntime` shape for `createRuntime`. No new patterns invented.
+
+#### F2 — `act/` files have differential mobility (NOT a 1:1 substrate extraction)
+
+| File | LOC | Inbound | Concern | Right home |
+|---|---|---|---|---|
+| `act/act.ts` | 1208 | 0 | Act capability orchestration | **stays in `act/`** |
+| `act/guard.ts` | 287 | 0 | Pre-act guard | **stays in `act/`** |
+| `act/tool-execution.ts` | 893 | 3 (reason) | Tool dispatch — kernel-state coupled; imports `kernel/state` + tools/memory pkgs | **stays in `act/` as canonical Act owner; expose via Tag to other capabilities** |
+| `act/tool-parsing.ts` | 255 | 2 (decide, reason) | Pure regex helpers (`FINAL_ANSWER_RE`, `extractFinalAnswer`, `evaluateTransform`) — no state coupling | **move to `kernel/utils/tool-parsing.ts`** (substrate) |
+| `act/tool-gating.ts` | 270 | 4 (reason) | Tool selection logic (`planNextMoveBatches`, `gateNativeToolCallsForRequiredTools`, `isParallelBatchSafeTool`) | **architectural decision required** — belongs to Comprehend (filter what's permitted) OR Decide (which to fire) OR stay Act with Tag |
+| `act/tool-capabilities.ts` | 140 | 0 | Tool capability declarations | stays in `act/` |
+
+**Implication:** WS-3 is a multi-phase architectural-review task, NOT a single mechanical move. Three distinct mobility classes. The thin spec needs a per-file disposition decision documented before any move.
+
+#### F3 — Emit is happening at capabilities AND at runner.ts (mission violation specific)
+
+| Location | Emit-related lines |
+|---|---|
+| `runner.ts` | 39 |
+| `act/` | **30** (most among capabilities) |
+| `reflect/` | 18 |
+| `reason/` | 15 |
+| `decide/` | 14 |
+| `comprehend/` | 5 |
+| `verify/` | 4 |
+| `attend/` | 2 |
+| `sense/` | 1 |
+| `recall/` | 1 |
+| `learn/` | 1 |
+
+**Implication:** Audit's claim "emit lives at runner.ts not at capability boundary" is **partially refuted**. Capabilities DO emit. The G-10 / #113 work is partially done. Remaining work: the 39 runner.ts emit calls are candidates for relocation to capability boundaries (mission invariant 10: "Capability emit events fire from capability code, never from strategy code"). Many of runner.ts's emit calls are likely legitimate (loop start/end, phase boundary) — needs per-call audit, not blanket move.
+
+#### F4 — `arbitrator.ts` IS canonical single-owner; mission invariant 1 holds
+
+`evaluateTermination(ctx, evaluators[])` + `TerminationDecision { action: 'exit' | 'redirect' | 'continue' | 'fail', ... }`. Action enum maps cleanly to canon's `continue | exit-success | exit-failure | escalate`. Verdict-Override pattern present (controller signal can override agent's apparent success — anti-mission #4 enforced). **No refactor needed for arbitrator.ts itself.** WS-3 + WS-5 may sharpen the emit + error shapes around it.
+
+#### F5 — `builder.ts` has 59 `withX()` methods (2.4× anti-mission #3 threshold)
+
+Anti-mission #3: "24 named override methods IS the failure mode." Current: 59. HarnessProfile presets shipped but withers proliferated alongside (not replaced). **Implication:** WS-2 co-located cleanup should mark redundant withers `@deprecated alias for HarnessProfile.X` and document HarnessProfile as primary API path.
+
+#### F6 — `reactive-agent.ts` casts are concentrated at internal-handoff sites
+
+`gatewayStatus()` line 1385: `queryGatewayStatus(this as any)`. `start()` line 1413: `startGateway(this as any)`. Pattern: handoff to extracted module functions that need the full `ReactiveAgent` instance. **Implication:** WS-2 co-located cleanup adds a `ReactiveAgentInternalView` interface OR types the receiver in `gateway-runner.ts` to accept the relevant subset. Mechanical, ~2 sites + 1 type.
+
+#### F7 — `CapabilityRegistry` (308 LOC) is well-designed; HarnessProfile (103 LOC) has a growth risk
+
+`packages/runtime/src/capabilities/registry.ts` ships a canonical schema (name + description + defaultOn + costSignature + liftEvidence + riskNotes + rationale + ownerWarden + lastAblation) with 4 bootstrap entries (memory ✅, reactive-intelligence ✅, verifier ✅, strategy-switching ⚠️ deliberately null `liftEvidence`). `audit()` returns `CapabilityAuditReport { totalEntries, defaultOnCount, entries, byWarden, staleEntries, violations }`. ✅ Anti-mission #6 wired (every default has rationale + cost + owner).
+
+`packages/runtime/src/capabilities/profile.ts` (`HarnessProfile.lean()/balanced()/intelligent()`) ships clean presets. **But `HarnessProfilePatch` hard-codes 5 boolean fields** (enableMemory / enableReactiveIntelligence / enableVerifier / enableStrategySwitching / enableSkillPersistence). As registry grows, patch type must grow in lockstep — risks the same anti-mission #3 pattern at the preset layer.
+
+**Implication for plan:** WS-4 (anti-scaffold purge) should generalize `HarnessProfilePatch` to derive from registry (e.g., `Partial<Record<RegisteredCapabilityName, boolean>>`) so adding a registry entry doesn't require touching profile.ts.
+
+#### F8 — `@reactive-agents/reactive-intelligence` is a substantial framework piece (50+ exports)
+
+`packages/reactive-intelligence/src/index.ts` re-exports across 8 sub-domains: calibration (entropy sensor priors, conformal threshold), controller (dispatcher FSM, intervention handlers, patch applier), learning (bandit, task classifier, skill synthesis, learning engine), sensor (token/structural/semantic/behavioral/context entropies + composite + trajectory), skills (resolver, distiller, registry, injection, compression), telemetry (install ID, signing, telemetry client), runtime (createReactiveIntelligenceLayer), events. **50+ public symbols.**
+
+**Implication for plan:** RI is NOT a peripheral concern. Its 15-caller heavy-use surface (verified earlier) is well-justified by the surface area shipped. WS-3 + WS-4 must treat RI as a peer of `@reactive-agents/reasoning`, not as a candidate for consolidation.
+
+#### F9 — Strategy input has 30+ fields; the real API surface is `StrategyFn`'s input shape, not just builder methods
+
+`packages/reasoning/src/services/strategy-registry.ts:StrategyFn` takes an input object with 30+ optional fields: taskDescription, taskType, memoryContext, availableTools, availableToolSchemas, allToolSchemas, config, systemPrompt, taskId, resultCompression, contextProfile, providerName, agentId, sessionId, requiredTools, requiredToolQuantities, relevantTools, maxCallsPerTool, maxRequiredToolRetries, strategySwitching, modelId, taskCategory, temperature, environmentContext, metaTools, briefResolvedSkills, initialMessages, synthesisConfig, observationSummary, verifier, harnessPipeline, budgetLimits.
+
+8 registered strategies: reactive, react (alias), reflexion, plan-execute-reflect, tree-of-thought, adaptive, direct, code-action + 1 kernel: `react`.
+
+**Implication for plan:** Mission Pillar 3 says "Strategies are declarative compositions of capabilities, not parallel loop reimplementations. New algorithmic shapes are first-class primitives; new strategies are array literals." A 30-field strategy input is the OPPOSITE of declarative — it's a god-input that every strategy must understand. **This is a Pillar 3 violation the audit missed.** WS-3 Phase 6 (new) or a later workstream should refactor `StrategyFn` input into a substrate-derived context object (most fields come from kernel context, not strategy choice).
+
+#### F10 — State mutation discipline: 27 raw `state.status=` sites violate Mission Pillar 4 by ~2.7×
+
+Mission Pillar 4 (Scalability): "≤10 mutation sites total across the kernel. `state.status =` outside `transitionState()` helper = lint failure."
+
+First-hand counts:
+- `state.status =` raw assignments: **27** (target: ≤10; violation 2.7×)
+- `transitionState()` callsites: **100** (the canonical helper is being USED)
+- Other raw `state.X =` assignments: ~33
+
+**Implication for plan:** WS-3 Phase 4 ESLint rule (`transitionState()` discipline + #114) is more urgent than ranked — 27 sites need migration to `transitionState()`. Add to §8.1 done-criteria.
+
+### 3.5 Package-role drift (where things live wrong — first-hand verified)
+
+| Drift | Evidence (first-hand 2026-05-28) | Disposition |
+|---|---|---|
+| `runner.ts` **1986 LOC** (regrown from 1739 baseline post-Stage-5) | `wc -l packages/reasoning/src/kernel/loop/runner.ts` | WS-6 re-decomp (post-foundation) |
+| `builder.ts` **2027 LOC** (post-W26 from 2407; > ≤500 target) | `wc -l packages/runtime/src/builder.ts` | WS-6 |
+| `runtime.ts` **1261 LOC** with 40× `Layer.merge` chain + 44× ComposableLayer casts | `wc -l + grep -c` | **WS-2** |
+| `act/` capability dir **3053 LOC** — conflates capability + tool substrate | `find ... wc -l + grep import` | **WS-3** (extract tool-* to substrate) |
+| `@reactive-agents/observe` **0 internal callers** (confirmed) | `grep -r "from .@reactive-agents/observe" packages apps` = 0 matches | **WS-4** delete or wire |
+| `@reactive-agents/compose` **2 callers** total (both in `apps/examples/`) | `grep -r "from .@reactive-agents/compose" packages apps` | **WS-4** investigate; surface barely consumed |
+| `@reactive-agents/reactive-intelligence` **15 callers** (heavy consumer surface) | `grep -r "from .@reactive-agents/reactive-intelligence"` | not drift — heavy use confirmed |
+| 9 production files >1000 LOC | HS-C-01..10 + first-hand confirmed for runner/builder/runtime/act.ts | WS-6 |
+| `compose/src/index.ts` **2 LOC** + 7 killswitch files (~186 LOC) is the entire package | `wc -l packages/compose/src/*` | WS-4 |
+| `observe/src/` **301 LOC, 3 files** (tracer.ts, otlp.ts, index.ts) shipping zero callers | `wc -l + grep` | **WS-4** |
+| Workspace pkg.json versions **all 0.10.6**; root VERSION **0.11.1**; tags max **v0.9.0** | `grep + git tag` | **WS-1** P0 |
+| `interaction/services/interaction-manager.ts` canonical HITL but "under-advertised" | fresh-lens audit | WS-4 docs surface |
+| `M12 LocalProviderAdapter` 5/6 hooks unused | K-08 | WS-4 prune |
+
+---
+
+## 4. Root Causes — Mechanism, Not Symptom
+
+The five clusters above each have a **single structural mechanism** that generates the symptoms. Naming the mechanism is the lever; fixing the mechanism collapses the symptoms.
+
+| RC | Mechanism (the lever) | Symptoms collapse when fixed |
+|---|---|---|
+| **RC-1** | **`runtime.ts` builds the runtime via mutation chain: 40× `runtime = Layer.merge(runtime, X) as ComposableLayer`. The `ComposableLayer` erasure boundary is a deliberate documented choice (Effect union explosion at scale); the chain pattern adds the cast at every link instead of one terminal cast.** | 44 ComposableLayer casts → 1. Pattern is mechanical: collect conditional layers into `Array<ComposableLayer>`, one terminal `Layer.mergeAll(layers) as ComposableLayer`. AgentResult/AgentEvent type cleanup is a separate but co-located concern. |
+| **RC-2** | **`act/` capability dir conflates the Act capability (`act.ts` + `guard.ts`, ~1495 LOC) with tool substrate (`tool-execution.ts` + `tool-parsing.ts` + `tool-gating.ts` + `tool-capabilities.ts`, ~1558 LOC, 9 cross-capability inbound).** Other capabilities import tool primitives by reaching into `act/`'s directory — that's what creates the mesh edges. The `leaf principle` is unenforced because there's no separation between "capability" and "primitives capabilities consume." | Extracting tool-* → `kernel/substrate/tools/` (or back into `@reactive-agents/tools`): `act/` 3053→~1495 LOC; 9 of 38 cross-edges disappear; act↔reason and reason↔verify cycles likely collapse; act↔decide may remain as one legitimate cross-capability dependency worth its own structural analysis. |
+| **RC-3** | **There is no enforced ship-time invariant that every declared surface element has a live emit + consumer in the same commit.** | Compose tags get callers (verified). `observe` (zero callers verified) either gets a caller or is deleted. M12 hooks get wired or removed. `confidenceFloor` ships or unships. |
+| **RC-4** | **The Effect-TS error channel is used as `unknown` instead of a tagged-error algebra; swallow happens at type level, not at code level.** Lying comments and `console.warn` bypasses are the same disease in different syntax. | 34 silent-swallow sites (corrected count) become explicit `Effect<X, KnownError>` declarations. 27 `console.warn` bypass sites route through ObservabilityService. Doc-drift gets a CI gate. |
+| **RC-5** | **Release stamping happens in CI ephemeral runner, not in local pre-tag step.** Mutations die with the runner. | Local `release.ts` stamps + commits + pushes BEFORE tag. CI publish becomes build+publish-only. Drift becomes structurally impossible. |
+
+---
+
+## 5. Workstream Sequence (priority-ordered execution path)
+
+The sequence is anchored to one principle: **fix the constraint that makes every other touch cheaper.**
+
+```
+Pre-flight: commit dirty state                     (15 min)
+   ↓
+WS-1: Release-Flow Integrity        (closes RC-5)  (1 day)   ← unblocks shipping
+   ↓
+WS-2: Runtime/Agent-Facade Seam     (closes RC-1)  (1 wk)    ← highest leverage
+   ↓
+WS-3: Kernel Capability DAG         (closes RC-2)  (1 wk)    ← unlocks parallel capability work
+   ↓
+WS-4: Anti-Scaffold Purge           (closes RC-3)  (3 days)  ← subsumes convergence Phase 1
+   ↓
+WS-5: Honesty Pass                  (closes RC-4)  (3 days)  ← surface lies become typed truth
+   ↓
+RE-AUDIT GATE                                                ← measurement: counts must drop ≥50%
+   ↓
+WS-6: Decomposition Restoration                    (1 wk)    ← re-measure after seam fix
+   ↓
+WS-7: Convergence Phases 0.5/2/3                   (2 wks)   ← #110–125 in flight
+   ↓
+WS-8: Fresh-Lens Primitives                        (2 wks)   ← G-A cost→Arbitrator, G-B, G-F
+```
+
+Total wall-clock estimate at one workstream-per-session-week cadence: ~8 weeks. Compressible to ~5 weeks with parallel WS-3+WS-4 after WS-2 lands.
+
+### 5.1 Why WS-1 is first (despite WS-2 being highest-leverage)
+
+WS-1 is small, isolated, and unblocks shipping. WS-2 is large and high-risk. If WS-2 reveals problems that need a release-cycle to fix, WS-1 must already be done. Order is sequencing not priority.
+
+### 5.2 Why WS-2 before WS-3
+
+The 30+ casts in the runtime/agent-facade seam currently force every kernel touch to widen types through casts. Fixing the seam first means WS-3's import-graph cleanup doesn't have to fight type debt simultaneously.
+
+### 5.3 Why WS-3 before WS-4
+
+WS-4 enforces the emit/consume invariant. WS-3 makes capability emit live at boundaries (not at runner.ts). The invariant cannot be enforced until the boundaries are real.
+
+### 5.4 Why WS-5 (honesty) last among foundation work
+
+WS-5 needs WS-2's typed seams in place to define tagged errors. Without WS-2, `Effect<X, KnownError>` declarations have nowhere clean to live (they'd ride on top of `as ComposableLayer` casts).
+
+### 5.5 Re-audit gate (REQUIRED before WS-6+)
+
+After WS-5 ships, re-run the audit (codebase-health-sweep skill v3) and confirm:
+
+- `as any` count drops ≥50% (current ~490 in production)
+- `as unknown as` count drops ≥50% (current ~80 in production)
+- `as ComposableLayer` count = 0
+- `Effect<X, unknown>` count drops ≥50% (current 105)
+- Dead-surface count = 0 (every declared TagMap/ControllerDecision/CapabilityRegistry entry has emit+consumer)
+- Lying-comment count = 0 (B-series audited zero)
+
+**If any threshold misses, WS-6+ does not start.** Stop the line, diagnose, fix-forward.
+
+---
+
+## 6. Per-Workstream Anatomy
+
+Each workstream gets a **thin spec doc** under `wiki/Planning/Implementation-Plans/2026-05-28-ws-N-<name>.md` with a uniform shape. The master plan does not duplicate per-WS detail.
+
+### 6.1 Thin spec template
+
+```markdown
+---
+title: WS-N — <name>
+date: 2026-05-28
+status: pending | in-progress | shipped | reverted
+master-plan: 2026-05-28-canonical-refactor.md
+root-cause-closed: RC-X
+gh-issues-closed: [#N, #M, ...]
+authoritative-anchor: <mission/algorithm citation>
+owner-warden: <kernel-warden | runtime-warden | compose-warden | release-warden | none>
+session-budget: <N hours / N days>
+---
+
+# WS-N — <name>
+
+## Goal (one sentence — what is structurally different after this ships)
+## Anchor (which mission statement / invariant this serves)
+## Scope IN (exact file paths + exact change shapes)
+## Scope OUT (explicit non-goals to prevent creep)
+## Pre-conditions (what must be true before starting)
+## Tests (RED before any code; specific assertions; existing-tests-that-must-still-pass)
+## Verification protocol (commands run, counts asserted, evidence captured)
+## Done criteria (falsifiable — each line is yes/no)
+## Rollback plan (one revert commit or N reverts; what gets re-opened)
+## Evidence artifact (where the post-ship report lives)
+```
+
+### 6.2 Workstream summaries (one paragraph each)
+
+#### WS-1 — Release-Flow Integrity (RC-5)
+
+Move version stamping out of CI runner. `release.ts` runs locally: stamps `packages/*/package.json` + CHANGELOG, commits, pushes, THEN tags. `publish.yml` becomes build+publish-only; no mutations. Add `test-clean-install.ts` target-version assertion (HS-H-04) as belt-and-suspenders. Backfill workspace pkg.jsons to 0.11.1. Delete orphan v0.10.7 draft (#165). Owner: release-warden (per MissionBrief).
+
+#### WS-2 — Runtime Layer Composition + Agent-Facade Type Truth (RC-1)
+
+**Phase 1 — Mechanical pattern alignment:** Refactor `runtime.ts:215–940` (`createRuntime`) from mutation chain `let runtime; runtime = Layer.merge(runtime, X) as ComposableLayer` to collected array + terminal `Layer.mergeAll(layers) as ComposableLayer`. **The target shape already exists at `runtime.ts:1061` in `createLightRuntime`** — mirror that pattern. Preserves the team's deliberate `ComposableLayer` type-erasure decision (lines 55-76 document why). Predicted impact: 44 ComposableLayer casts → 1.
+
+**Phase 2 — Co-located public type truth:**
+- Surface `AgentResult.debrief: AgentDebrief | undefined` on public type (closes #162 + collapses 4+ casts at CLI/cortex/playground)
+- Discriminate `AgentEvent` union on `_tag` for narrowing in user code (closes #163 + collapses 13+ casts at cortex/ui)
+- Add `ReactiveAgentInternalView` interface OR re-type `queryGatewayStatus`/`startGateway` receivers in `agent/gateway-runner.ts` to remove the 2× `this as any` casts at reactive-agent.ts:1385,1413 (HS-A-01)
+
+**Phase 3 — Builder anti-mission #3 mitigation:** `builder.ts` has 59 `withX()` methods (2.4× anti-mission threshold). Mark redundant withers `@deprecated alias for HarnessProfile.{lean,balanced,intelligent}()`. Quickstart docs use `HarnessProfile` as primary API path. Withers stay backward-compatible.
+
+**Scope explicitly OUT of WS-2:**
+- Rewriting layer construction logic (each individual layer's internals)
+- Decomposing `runtime.ts` further (WS-6 territory)
+- Touching `kernel/` capabilities (WS-3 territory)
+
+Owner: runtime-warden. Estimated 1 session for Phase 1; 1 session for Phase 2+3.
+
+#### WS-3 — Kernel `act/` Decomposition + Capability DAG (RC-2)
+
+**Phase 1 — Mechanical substrate move (high-confidence, low-risk):** Move `act/tool-parsing.ts` (255 LOC, 2 inbound) → `kernel/utils/tool-parsing.ts`. It is pure regex + parsing helpers (`FINAL_ANSWER_RE`, `extractFinalAnswer`, `evaluateTransform`) with zero state coupling. Update 2 import sites in `decide/arbitrator.ts` + `reason/think.ts`. Predicted impact: 2 cross-edges eliminated; no behavior change.
+
+**Phase 2 — Architectural-review decision (`act/tool-gating.ts`):** Tool gating is `planNextMoveBatches` + `gateNativeToolCallsForRequiredTools` + `isParallelBatchSafeTool`. The architectural question: gating is "which subset of permitted tools to fire" — that's a **Decide** concern (pre-Act filter), NOT an Act concern (Act executes what Decide selected). Three candidate dispositions:
+- **(a)** Move to `decide/tool-gating.ts` — semantically cleanest; mission Decide owns "select exactly ONE action."
+- **(b)** Move to `comprehend/tool-gating.ts` — gating reads required-tools (a Comprehend signal); could co-locate.
+- **(c)** Keep in `act/`, expose via `ToolGatingService` Tag — minimal file movement.
+Thin spec resolves via short ADR. Predicted impact: 4 cross-edges either eliminated or routed through Tag.
+
+**Phase 3 — `act/tool-execution.ts` Tag-based contract:** Tool-execution.ts is kernel-state-coupled and IS the canonical Act capability owner per mission. Do NOT relocate. Instead: introduce `ToolExecutionService` Tag in `core/services/`; other capabilities (3 inbound from `reason/think-guards.ts` for `makeObservationResult`, `extractObservationFacts`) consume the Tag, not the file path. Predicted impact: 3 file-path imports → 0; leaf principle restored.
+
+**Phase 4 — Cycle audit + ESLint boundary rule:** After Phase 1–3, re-walk cross-import graph. Document any remaining cycles in `wiki/Research/Refactor-Reports/2026-05-28-ws-3-import-graph.md` (first-hand evidence). Add ESLint rule banning capability-to-capability internal imports (cross-cap imports must route through `core/services/` Tag or `kernel/utils/`). Predicted impact: 3 confirmed cycles (act↔decide, act↔reason, reason↔verify) collapse to ≤1 (act↔decide may remain as a true cross-cap dep worth analysis).
+
+**Phase 5 — runner.ts emit relocation:** Audit the 39 emit-related lines in `runner.ts`. For each: is the emit a loop-control concern (legitimate at runner) or a capability concern (belongs at capability boundary)? Move capability-concern emits to the owning capability. Predicted impact: ~20–30 of 39 emit calls relocate; runner.ts LOC drops to ~1800 (still oversized; full WS-6 re-decomp later).
+
+**Evidence prerequisite:** import-graph dump committed to `wiki/Research/Refactor-Reports/2026-05-28-ws-3-import-graph.md` BEFORE Phase 1 begins. Already partially captured in §3.6 F2 above.
+
+Owner: kernel-warden. Estimated 2 sessions (Phase 1+2 = session 1; Phase 3+4+5 = session 2).
+
+#### WS-4 — Anti-Scaffold Purge (RC-3)
+
+For every declared surface element without paired live emit + consumer: ship the wiring in this WS, OR delete the declaration. Disposition table:
+
+- `@reactive-agents/observe` package (#170): wire one demo consumer in `examples/` + add to umbrella, OR remove from monorepo.
+- 5 unused M12 hooks (K-08): wire or remove (commit by commit).
+- 4 dead Compose tags (G-9 / #112): wire in capability emit (depends on WS-3 boundaries).
+- `confidenceFloor` killswitch (#160): ship or unship + docs delta.
+- `strategy-switching` registry entry with null liftEvidence (cf-25): gather evidence OR convert to opt-in.
+
+Owner: compose-warden (Compose) + ablation-warden (registry).
+
+#### WS-5 — Honesty Pass (RC-4)
+
+Define tagged-error algebra under `core/errors/` (or appropriate canonical location). Migrate 105× `Effect<X, unknown>` to `Effect<X, TaggedError>` in priority order (runtime first, then reasoning, then RI). Replace `console.warn` bypass sites with ObservabilityService routes. Remove leftover `DEBUG_VERIFIER console.error`. Fix lying comments at `gateway-bootstrap.ts:236`. Add CI doc-drift gate: AGENTS.md tree diff against `ls packages/*/package.json` (#171 K-04 recommendation). Owner: cross-cutting (multiple wardens).
+
+---
+
+## 7. Verification Discipline
+
+This section is non-negotiable. It applies to every workstream.
+
+### 7.1 TDD (RED → GREEN → ANALYSIS)
+
+Per `agent-tdd` skill discipline:
+
+1. **RED first.** Before any production code, write a test that fails for the right reason. No code without a red test.
+2. **GREEN minimal.** Write only enough to make the red test green. No "while I'm here" additions.
+3. **ANALYSIS.** Run the broader test suite. Run the verification commands declared in the thin spec. Confirm verified-by counts. No completion claim without the recheck output captured.
+
+### 7.2 Verified-by counts
+
+Every WS thin spec MUST cite `verified-by:` evidence for each "Done criterion" line, using the same convention as `codebase-health-sweep`: `grep -ro pattern packages/ | wc -l` produces a count; the PR body shows before/after.
+
+### 7.3 No silent swallow during refactor
+
+Refactor commits MUST NOT introduce new `Effect<X, unknown>` declarations or new `console.warn` bypass sites. If a refactor surfaces a swallow that pre-existed, it is fixed in the same commit OR documented as a follow-up issue with explicit `verified-by` cite.
+
+### 7.4 Cross-tier ablation on default-on changes
+
+If a WS changes a default-on capability (registry entry flip, behavior change visible to users), it MUST route through `ablation-warden` per pilot discipline:
+
+- ≥2 model tiers probed (frontier + local large minimum)
+- ≥3pp lift required to default-on; ≤15% token overhead ceiling
+- Failure → opt-in only or removal
+
+### 7.5 Branch + PR + warden ownership
+
+- Each WS = own branch off `origin/main`: `refactor/ws-N-<short-name>`
+- Each WS = one PR with `Closes #X, #Y, #Z` + verified-by table + evidence-artifact link
+- Wardens dispatch with MissionBrief; deliver with UpwardReport
+- No direct-to-main pushes
+
+### 7.6 Stop-the-line conditions
+
+Halt the sequence if any of:
+
+- Build goes red on `main` (fix-forward in a hotfix, do not push WS work over a broken main)
+- A WS verification gate fails after best-effort fix (diagnose; do NOT proceed to next WS)
+- Re-audit gate after WS-5 misses threshold (do NOT start WS-6; rework whichever upstream WS underdelivered)
+
+### 7.7 Evidence artifacts
+
+Every WS produces an artifact under `wiki/Research/Refactor-Reports/2026-05-28-ws-N-<name>.md` containing:
+
+- Before/after verified-by counts
+- N=1 (or N=3 if ablation) probe results
+- Cross-cutting test deltas
+- Any newly discovered issues filed with GH numbers
+
+---
+
+## 8. Done = ? (foundation canonical end-state)
+
+The refactor's foundation is declared canonical when ALL of the following hold simultaneously:
+
+### 8.1 Structural (auto-checkable — ABSOLUTE thresholds; baselines first-hand 2026-05-28)
+
+- [ ] `as ComposableLayer` count = **1** in `runtime.ts` (terminal cast at `Layer.mergeAll`); = **0** elsewhere (from baseline 44 in runtime.ts; 0 elsewhere)
+- [ ] `as any` count in `packages/*/src/` (production, excluding tests) ≤ **50** (from baseline 113)
+- [ ] `as any` count in `packages/runtime/src/` ≤ **15** (from baseline ~30+)
+- [ ] `as unknown as` count in `packages/*/src/` ≤ **20** (from baseline 74)
+- [ ] `as Context.Tag.Service` count ≤ **2** (from baseline 4)
+- [ ] `Effect<X, unknown>` count in `packages/*/src/` ≤ **15** (from baseline 34)
+- [ ] `Effect<X, unknown>` count in `packages/runtime/src/` = **0** (no silent swallow at the seam)
+- [ ] `console.warn` bypassing ObservabilityService in `packages/*/src/` = **0** (from baseline 27)
+- [ ] `console.error` in `packages/*/src/` = **0** (from baseline 24; all routed through ObservabilityService or removed)
+- [ ] `act/` capability dir LOC ≤ **1900** (from baseline 3053; tool-parsing extracted, tool-gating ADR resolved, tool-execution stays with Tag contract — net est. 1495-1900 LOC depending on Phase 2 disposition)
+- [ ] Kernel capability dirs form DAG (zero cycles; first-hand walk + CI lint; baseline 3 cycles)
+- [ ] `state.status =` raw assignment sites ≤ **10** (from baseline 27; migrate to `transitionState()`)
+- [ ] Other raw `state.X =` mutations ≤ **10** (from baseline ~33)
+- [ ] `builder.ts` `withX()` method count ≤ **30** (from baseline 59) — others marked `@deprecated alias for HarnessProfile.X`
+- [ ] `HarnessProfilePatch` type derives from CapabilityRegistry entries (no hard-coded boolean fields)
+- [ ] `StrategyFn` input shape ≤ **15 fields** (from baseline 30+; substrate-derived context object)
+- [ ] Every entry in TagMap / ControllerDecision union / CapabilityRegistry has paired emit + consumer (CI lint)
+- [ ] All 35 packages appear in AGENTS.md package tree (CI diff)
+- [ ] No production file >1500 LOC (relaxed from N* §8.1 ≤500; WS-6 target)
+
+### 8.2 Behavioral (test-checkable)
+
+- [ ] Workspace test pass rate ≥99% (current baseline: 3219/3219)
+- [ ] Build green (38/38 turbo tasks)
+- [ ] Type-check clean across all packages
+- [ ] At least N=3 cross-tier ablation on any default-on change passes ≥3pp lift gate
+
+### 8.3 Surface (consumer-checkable)
+
+- [ ] `AgentResult.debrief` on public type; zero `as` casts to access it
+- [ ] `AgentEvent` discriminates on `_tag` in TypeScript inference; zero casts to narrow
+- [ ] `withLeanHarness()` and `HarnessProfile.*()` semantics match registry truth
+- [ ] Every documented capability in README has a live wired runtime path
+- [ ] Version-drift impossible (WS-1 release-flow structurally enforces stamping pre-tag)
+
+### 8.4 Documentary (writer-checkable)
+
+- [ ] AGENTS.md package tree matches actual `packages/*/`
+- [ ] `04-PROJECT-STATE.md` reflects current shipped state (not 30+ days stale)
+- [ ] North Star §4.3 capability-dir list verified against code
+- [ ] No "@deprecated v0.10.0 — Removed in v0.11.0" zombie comments
+
+---
+
+## 9. What This Plan Explicitly DOES NOT Do
+
+Out of scope. Each has its own existing or proposed home; not blurring into this refactor:
+
+- **Memory v2 design** (`2026-05-23-memory-v2-design.md`) — not blocked by this refactor; separate track.
+- **HeavyDream multi-iter L4 harness** — speculative, no PR substrate.
+- **HITL bridge IX1** — separate roadmap item.
+- **τ²-bench external publication** — Phase F gate.
+- **Browser/computer-use primitive (G-K)** — decision pending; not refactor work.
+- **Audio/video/PDF modality (G-E)** — demand-driven.
+- **Consolidation of verification/prompts/interaction/benchmarks/scenarios/health** — value-extraction; not structural; deferred.
+- **New strategies (7th, 8th)** — capability set is complete enough; new strategies come after combinator substrate (separate effort).
+- **Multi-agent orchestration depth (G-G)** — needs spike before this refactor's foundations matter to it.
+- **L3 outcome metrics (gate-corpus runs)** — measured separately; this refactor makes the measurement trustworthy.
+
+---
+
+## 10. How This Plan Interacts With Existing GH Issues
+
+| Issue cluster | Disposition |
+|---|---|
+| #104–#109 (Phase 0 convergence) | ✅ Already closed |
+| #110–#111 (Phase 0.5 cost gates) | Folded into **WS-7** |
+| #112 (RI→Compose bridge — light 4 dead tags) | **WS-4** (dead-surface — emit source missing) |
+| #113 (capability-scoped emit, closes F1) | **WS-3** (emit-at-boundary mechanism) |
+| #114 (transitionState() discipline + ESLint rule) | **WS-3** (boundary lint) |
+| #115 (required-tool nomination via comprehend emit) | **WS-3** (capability emit) |
+| #116 (ControllerDecision union prune — 8 dead variants) | **WS-4** (scaffold purge) |
+| #117 (emitLLMExchange at provider boundary) | **WS-3** (reason boundary) |
+| #118 (plan-execute synthetic kernel state contract test) | **WS-3** (boundary contract) |
+| #119 (triple compression coordination) | **WS-4** (consumer-side coordination) |
+| #120 (open `learn/` capability) | **WS-4** (verify wiring; dir already exists) |
+| #121 (multi-severity verifier) | **WS-4** (severity-ladder scaffold) |
+| #122 (cross-session default-on) | **WS-4** (verify default+evidence pair) |
+| #123–#125 (Phase 3 compounding) | Folded into **WS-7** |
+| #151–#158 (audit iter 1) | Folded into **WS-4** + **WS-5** by category |
+| #159 (P0 release flow) | **WS-1** |
+| #160 (confidenceFloor docs lie) | **WS-4** |
+| #161 (doc-drift bundle) | **WS-5** |
+| #162 (AgentResult.debrief gap) | **WS-2** |
+| #163 (AgentEvent narrowing) | **WS-2** |
+| #164 (CLI template `as any`) | **WS-2** (downstream effect) |
+| #165 (orphan v0.10.7 draft) | **WS-1** |
+| #166 (MetricsCollectorTag in tests) | **WS-5** |
+| #167 (RuntimeAssembly refactor) | **WS-2** |
+| #168 (105 Effect<X, unknown>) | **WS-5** |
+| #169 (kernel mesh + 7 cycles) | **WS-3** |
+| #170 (dead surfaces — observe + M12) | **WS-4** |
+| #171 (manifest/doc drift) | **WS-5** |
+
+---
+
+## 11. Amendment Log
+
+| Date | Change | Reason |
+|---|---|---|
+| 2026-05-28 | Initial draft. | Replace prior master plans (treated as reference); plan from current main + 2026-05-27 audit + canon anchors. |
+| 2026-05-28 (amend 1) | First-hand audit pass corrected numerical baselines + reframed RC-1 + reframed RC-2 around `act/` monolith finding. | Prior-audit numbers were 2–4× inflated; runtime.ts `ComposableLayer` is a documented engineering choice (Effect union explosion), not service-locator anti-pattern; `act/` conflates capability + tool substrate which is the actual mesh generator. |
+| 2026-05-28 (amend 2) | Deep-audit of runtime.ts + act/* + reactive-agent.ts + runner.ts + arbitrator.ts + builder.ts. Added §3.6 (six structural facts F1-F6). Refined WS-2 + WS-3 with phased + differential-mobility decisions. | User-directed deep read of the seams to "fully understand the problem space before designing the ideal architecture." Found: (F1) `createLightRuntime` already uses target pattern; (F2) `act/tool-*` files have differential mobility — not all are substrate; (F3) capabilities DO emit; runner.ts emit calls need per-call audit; (F4) arbitrator.ts canonical owner intact; (F5) builder.ts 59 withers; (F6) reactive-agent.ts `this as any` casts have a 1-line fix. |
+| 2026-05-28 (amend 3) | Read CapabilityRegistry + HarnessProfile + RI package surface + StrategyRegistry + state-mutation counts. Added §3.6 F7-F11 + extended §8.1 done-criteria. | Both audit tracks per user. Found: (F7) CapabilityRegistry clean; HarnessProfile patch has growth risk; (F8) RI is 50+ exports framework piece; (F9) StrategyFn input has 30+ fields — Pillar 3 violation; (F10) 27 raw `state.status=` mutations vs ≤10 target = 2.7× Pillar 4 violation. |
+
+---
+
+## 12. Acceptance
+
+This plan is accepted when:
+
+1. The user approves the sequence (Pre-flight → WS-1 → WS-2 → WS-3 → WS-4 → WS-5 → re-audit → WS-6+).
+2. Each thin per-WS spec (WS-1..5) is authored and reviewed before its execution begins.
+3. The first execution begins (Pre-flight commit) only after the above two conditions hold.
+
+Until the user accepts, no production code changes. Plans and thin specs are written, that is all.
+
+---
+
+*The framework's canon is already correct. This plan exists to bring the runtime to canon, in a sequence whose first move makes every subsequent move cheaper, with a verification gate at every step, and an auditable evidence artifact after every workstream.*

--- a/wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md
@@ -344,17 +344,27 @@ The honesty debt is **real but smaller than reported**. The audit's count-inflat
 
 **Cited:** #168, #161, #171, HS-B-01..09, first-hand counts 2026-05-28.
 
-#### **RC-5 — Release-flow drift (P0, first-hand confirmed)**
+#### **RC-5 — REVISED (audit-driven correction, 2026-05-28 evening)**
 
-- ✅ `release.ts:197–208` stamps `packages/*/package.json` in ephemeral CI runner; mutations die with runner.
-- ✅ Root `VERSION=0.11.1` (verified `cat VERSION`)
-- ✅ npm published `@reactive-agents/core` at 0.11.1 (verified `npm view`)
-- ✅ All 35 `packages/*/package.json` workspace versions at **0.10.6** (verified `grep "version" packages/*/package.json`)
-- ✅ Local + remote git tags max at `v0.9.0` (verified `git tag | tail`); no v0.10.x or v0.11.x tags
-- ✅ Drift is structural, not accidental
-- Orphan v0.10.7 GH draft release residue (#165)
+**Original framing INVALID.** The release-warden Phase 0 audit (`wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md`) corrected three premises this plan and the prior health-sweep had wrong:
 
-**Cited:** #159 P0 + #165, HS-F-04, HS-H audit, first-hand 2026-05-28.
+| Original claim | Reality |
+|---|---|
+| Workspace `packages/*/package.json` at 0.10.6 = drift defect | **Intentional steady-state per `release.ts:205-208` comment** — "so `cat VERSION` always matches npm @latest (repo package.json stays unbumped by the tag-driven flow)" |
+| Git tags max at v0.9.0; no v0.10.x or v0.11.x | **v0.10.0–v0.10.6 + v0.11.0–v0.11.1 tags exist locally AND on origin**, deref'ing to the exact npm `gitHead` SHAs (cross-package verified) |
+| Release flow structurally broken | **Release flow works in steady state.** Four secondary defects exist but no structural rebuild needed |
+
+**Actual issues (P1, not P0):**
+
+- **F2 (NEW):** Typecheck RED at HEAD. `@reactive-agents/verification` test files reference stale `VerificationLLM` shape missing `embed`. 8 TS2345 errors across `tests/hallucination-detection.test.ts:145,162,176,192` + `tests/layers.test.ts:76,97,118,139`. Same pattern: mock objects declare `complete` but not `embed`. Blocks any future v0.12.0 tag-cut under release-warden gate.
+- **F3 (NEW):** `@reactive-agents/judge-server` at workspace version 0.9.5; never published to npm (404); not lockstep with other packages. User adjudication 2026-05-28: mark `private: true` + stamp to 0.10.6.
+- **F4 (NEW):** `release.ts` bails at `npm whoami` (line 65-66) BEFORE drift inspection logic runs. Cannot function as drift gate without `npm login`. Either run after login OR refactor script (drift check before auth).
+- **#165:** Orphan v0.10.7 GH draft release residue. Trivial delete.
+- **#159:** Invalid as framed — workspace lag is intentional steady-state. Close with comment.
+
+**Cited:** Release-warden audit 2026-05-28 (`wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md`); first-hand reproduction of F2 (`bun run typecheck` in `packages/verification`) + F3 (`npm view @reactive-agents/judge-server` → 404) + F1 (`git ls-remote --tags origin v0.10.6 v0.11.1` → both present).
+
+**Implication:** RC-5 was overstated in priority (P0 → P1 in reality) and overscoped in mechanism (structural rebuild → 4 small fixes). The CI ephemeral-runner stamping pattern at `release.ts:197-208` IS the design — the tag-driven flow leaves workspace pkg.jsons unbumped on purpose so `VERSION` is the source-of-truth single field. This was specified in the comment block all along; prior audits read the symptom without reading the rationale.
 
 ### 3.6 First-Hand Deep-Audit Findings (2026-05-28 amendment 2)
 
@@ -479,7 +489,7 @@ The five clusters above each have a **single structural mechanism** that generat
 | **RC-2** | **`act/` capability dir conflates the Act capability (`act.ts` + `guard.ts`, ~1495 LOC) with tool substrate (`tool-execution.ts` + `tool-parsing.ts` + `tool-gating.ts` + `tool-capabilities.ts`, ~1558 LOC, 9 cross-capability inbound).** Other capabilities import tool primitives by reaching into `act/`'s directory — that's what creates the mesh edges. The `leaf principle` is unenforced because there's no separation between "capability" and "primitives capabilities consume." | Extracting tool-* → `kernel/substrate/tools/` (or back into `@reactive-agents/tools`): `act/` 3053→~1495 LOC; 9 of 38 cross-edges disappear; act↔reason and reason↔verify cycles likely collapse; act↔decide may remain as one legitimate cross-capability dependency worth its own structural analysis. |
 | **RC-3** | **There is no enforced ship-time invariant that every declared surface element has a live emit + consumer in the same commit.** | Compose tags get callers (verified). `observe` (zero callers verified) either gets a caller or is deleted. M12 hooks get wired or removed. `confidenceFloor` ships or unships. |
 | **RC-4** | **The Effect-TS error channel is used as `unknown` instead of a tagged-error algebra; swallow happens at type level, not at code level.** Lying comments and `console.warn` bypasses are the same disease in different syntax. | 34 silent-swallow sites (corrected count) become explicit `Effect<X, KnownError>` declarations. 27 `console.warn` bypass sites route through ObservabilityService. Doc-drift gets a CI gate. |
-| **RC-5** | **Release stamping happens in CI ephemeral runner, not in local pre-tag step.** Mutations die with the runner. | Local `release.ts` stamps + commits + pushes BEFORE tag. CI publish becomes build+publish-only. Drift becomes structurally impossible. |
+| **RC-5 (REVISED)** | **Premise was wrong; release flow works in steady state.** Workspace pkg.json lag at 0.10.6 is intentional design per `release.ts:205-208` comment (so `VERSION` is sole source of truth matching npm @latest). Tags v0.10.x and v0.11.x exist on origin already. Actual residual issues: typecheck RED at HEAD (F2 — verification test files missing `embed` stub), judge-server inconsistency (F3 — mark `private: true` + stamp to 0.10.6), `release.ts` ordering (F4 — `npm whoami` gate trips before drift logic), #165 orphan v0.10.7 draft. | F2/F3/F4 + #165 fixes ship as small bundle; #159 closes as invalid; release flow continues to work as designed. |
 
 ---
 
@@ -577,9 +587,19 @@ session-budget: <N hours / N days>
 
 ### 6.2 Workstream summaries (one paragraph each)
 
-#### WS-1 — Release-Flow Integrity (RC-5)
+#### WS-1 — Release-Flow Residual Fixes (RC-5 REVISED — small bundle)
 
-Move version stamping out of CI runner. `release.ts` runs locally: stamps `packages/*/package.json` + CHANGELOG, commits, pushes, THEN tags. `publish.yml` becomes build+publish-only; no mutations. Add `test-clean-install.ts` target-version assertion (HS-H-04) as belt-and-suspenders. Backfill workspace pkg.jsons to 0.11.1. Delete orphan v0.10.7 draft (#165). Owner: release-warden (per MissionBrief).
+**Scope revised after warden audit 2026-05-28** (original premise invalidated; see §3.4 RC-5 REVISED). New scope:
+
+1. **F2 typecheck fix** — add `embed: () => Effect.succeed([])` (or matching stub) to 8 mock `VerificationLLM` objects in `packages/verification/tests/{hallucination-detection,layers}.test.ts`
+2. **F3 judge-server lockstep** — set `"private": true` in `packages/judge-server/package.json` + bump version 0.9.5 → 0.10.6
+3. **F4 release.ts ordering** — move drift inspection BEFORE `npm whoami` gate in `scripts/release.ts:42-66` so `release:dry` functions without auth
+4. **#165 cleanup** — `gh release delete v0.10.7 --yes`
+5. **#159 close** — comment + close as invalid framing
+
+NOT in WS-1 scope (premise invalidated): pkg.json stamping (intentional steady-state); tag backfill (already exists); publish.yml rebuild (not broken).
+
+Owner: claude main thread + user authorization (release-warden's manifest is GATE/AUDIT only — refused execution dispatch with cause). Risk: LOW. Budget: ~30 min execution.
 
 #### WS-2 — Runtime Layer Composition + Agent-Facade Type Truth (RC-1)
 
@@ -777,7 +797,7 @@ Out of scope. Each has its own existing or proposed home; not blurring into this
 | #122 (cross-session default-on) | **WS-4** (verify default+evidence pair) |
 | #123–#125 (Phase 3 compounding) | Folded into **WS-7** |
 | #151–#158 (audit iter 1) | Folded into **WS-4** + **WS-5** by category |
-| #159 (P0 release flow) | **WS-1** |
+| #159 (P0 release flow) | **CLOSE AS INVALID** (warden audit 2026-05-28: workspace lag is intentional steady-state per release.ts:205-208 comment; tags exist on origin) |
 | #160 (confidenceFloor docs lie) | **WS-4** |
 | #161 (doc-drift bundle) | **WS-5** |
 | #162 (AgentResult.debrief gap) | **WS-2** |
@@ -801,6 +821,7 @@ Out of scope. Each has its own existing or proposed home; not blurring into this
 | 2026-05-28 (amend 1) | First-hand audit pass corrected numerical baselines + reframed RC-1 + reframed RC-2 around `act/` monolith finding. | Prior-audit numbers were 2–4× inflated; runtime.ts `ComposableLayer` is a documented engineering choice (Effect union explosion), not service-locator anti-pattern; `act/` conflates capability + tool substrate which is the actual mesh generator. |
 | 2026-05-28 (amend 2) | Deep-audit of runtime.ts + act/* + reactive-agent.ts + runner.ts + arbitrator.ts + builder.ts. Added §3.6 (six structural facts F1-F6). Refined WS-2 + WS-3 with phased + differential-mobility decisions. | User-directed deep read of the seams to "fully understand the problem space before designing the ideal architecture." Found: (F1) `createLightRuntime` already uses target pattern; (F2) `act/tool-*` files have differential mobility — not all are substrate; (F3) capabilities DO emit; runner.ts emit calls need per-call audit; (F4) arbitrator.ts canonical owner intact; (F5) builder.ts 59 withers; (F6) reactive-agent.ts `this as any` casts have a 1-line fix. |
 | 2026-05-28 (amend 3) | Read CapabilityRegistry + HarnessProfile + RI package surface + StrategyRegistry + state-mutation counts. Added §3.6 F7-F11 + extended §8.1 done-criteria. | Both audit tracks per user. Found: (F7) CapabilityRegistry clean; HarnessProfile patch has growth risk; (F8) RI is 50+ exports framework piece; (F9) StrategyFn input has 30+ fields — Pillar 3 violation; (F10) 27 raw `state.status=` mutations vs ≤10 target = 2.7× Pillar 4 violation. |
+| 2026-05-28 (amend 4) | RC-5 reversal. Release-warden Phase 0 audit invalidated original framing; workspace pkg.json lag is intentional steady-state. WS-1 scope reduced from "structural release flow rebuild" to small bundle: F2 (typecheck embed stubs) + F3 (judge-server private+lockstep) + F4 (release.ts ordering) + #165 delete + #159 close-invalid. | First-hand reproduction of warden findings (`git ls-remote --tags origin v0.10.6 v0.11.1` returns both, `npm view @reactive-agents/judge-server` returns 404, `cd packages/verification && bun run typecheck` shows 8 TS2345 errors). Prior audit (HS-F-04 + HS-H + #159) read symptoms without reading `release.ts:205-208` rationale comment. |
 
 ---
 

--- a/wiki/Planning/Implementation-Plans/2026-05-28-ws-1-release-flow-integrity.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-28-ws-1-release-flow-integrity.md
@@ -1,0 +1,209 @@
+---
+title: WS-1 — Release-Flow Integrity
+date: 2026-05-28
+status: pending
+master-plan: 2026-05-28-canonical-refactor.md
+architecture-model: 2026-05-28-canonical-architecture-model.md
+root-cause-closed: RC-5 (release stamping in ephemeral CI runner)
+gh-issues-closed: [#159 (P0), #165]
+authoritative-anchor: master-plan §3.4 RC-5 + §3.6 first-hand verification
+owner-warden: release-warden
+session-budget: 1 day (~4-6 hours active work + 1 release dry run)
+risk: LOW (isolated, no kernel/runtime semantics touched, full rollback path)
+---
+
+# WS-1 — Release-Flow Integrity
+
+## Goal (one sentence)
+
+Move version stamping from CI ephemeral runner to local pre-tag step so workspace `packages/*/package.json` versions, root `VERSION`, npm published artifact, and git tags are structurally guaranteed to match.
+
+## Anchor
+
+Master plan §4 RC-5: "Release stamping happens in CI ephemeral runner, not in local pre-tag step. Mutations die with the runner." This violates the trust differentiator at the release surface: a `bun run release:dry 0.12.0` would today fail the drift gate AGAINST main even though npm shows 0.11.1 published.
+
+## Current State (first-hand verified 2026-05-28)
+
+```
+root VERSION:                          0.11.1
+npm @reactive-agents/core version:     0.11.1
+packages/core/package.json:            0.10.6
+packages/llm-provider/package.json:    0.10.6
+packages/memory/package.json:          0.10.6
+packages/reasoning/package.json:       0.10.6
+packages/tools/package.json:           0.10.6
+packages/runtime/package.json:         0.10.6
+packages/reactive-agents/package.json: 0.10.6
+packages/compose/package.json:         0.10.6
+... (35 packages total — ALL at 0.10.6 except judge-server at 0.9.5)
+git tags max:                          v0.9.0 (no v0.10.x, no v0.11.x)
+```
+
+The CI script at `release.ts:197-208` stamps inside the runner; the mutated files are not committed back to main. The drift compounds at every release.
+
+## Scope IN
+
+### Phase 1 — Restructure `release.ts` for local-stamp pattern
+
+**Files touched:** `scripts/release.ts`
+
+**Change:** Move the stamping logic OUT of the ephemeral path. Local invocation:
+
+```bash
+bun run release 0.12.0
+```
+
+MUST:
+1. Read `0.12.0` from CLI arg
+2. Stamp every `packages/*/package.json` `version` field to `0.12.0` (excluding `judge-server` if it stays on its own track — verify per policy)
+3. Update root `VERSION` to `0.12.0`
+4. Update workspace `package.json` references that pin versions
+5. `bun install` to sync lockfile
+6. `bun run build && bun run typecheck && bun test` to gate
+7. `bun run release:dry 0.12.0` to confirm no drift remains
+8. `git add` modified package.jsons + root VERSION + bun.lock
+9. `git commit -m "chore(release): stamp 0.12.0"`
+10. `git push origin main`
+11. `git tag v0.12.0`
+12. `git push origin v0.12.0`
+
+After this, CI's `publish.yml` triggers on the tag and runs build + publish only — no mutations.
+
+### Phase 2 — Simplify `publish.yml`
+
+**Files touched:** `.github/workflows/publish.yml`
+
+**Change:** Remove the "Sync VERSION to main" step (publish.yml:135-149) that commits only `VERSION` but not package.jsons. Replace with assertion: confirm tag commit's `packages/*/package.json` `version` field matches the tag (belt-and-suspenders).
+
+### Phase 3 — Belt-and-suspenders gate in `test-clean-install.ts`
+
+**Files touched:** `scripts/test-clean-install.ts` (per HS-H-04 audit recommendation)
+
+**Change:** After clean install, assert published version matches the tag's expected version. Fails the workflow if any drift slips through.
+
+### Phase 4 — Backfill workspace pkg.jsons + delete orphan draft
+
+**Files touched:** All 35 `packages/*/package.json` files. GitHub release page (manual).
+
+**Change:**
+1. Stamp every workspace `packages/*/package.json` to `0.11.1` (current published) via the new `release.ts` flow
+2. Commit + push the stamps (NO tag — this is backfill catching up reality to npm)
+3. CHANGELOG backfill entries for v0.10.6 → v0.11.1 in their respective package CHANGELOG.md files (per `feedback_npm_version_drift`)
+4. Delete orphan `v0.10.7` draft GH release (#165) via `gh release delete v0.10.7 --yes`
+
+## Scope OUT (non-goals — flagged for refusal)
+
+- Touching ANY package's source code (no behavior change)
+- Changing the semantic of `release:dry` itself (only how it's invoked)
+- Touching changesets (already removed May 2026)
+- Touching CI for non-release workflows (PR CI stays as-is)
+- Tagging a new version (this WS prepares the rails; an actual v0.12.0 release is downstream)
+
+## Pre-Conditions
+
+- `main` branch is current with `origin/main`
+- Build green (`bunx turbo run build` 38/38)
+- Tests green (`bun test` workspace pass)
+- No uncommitted changes in tree
+- `npm view @reactive-agents/core version` returns 0.11.1 (current truth)
+- `node`, `bun`, `gh` CLI all available locally
+
+## Tests (RED → GREEN)
+
+### RED first
+
+1. Manual repro: `bun run release:dry 0.12.0` against current main MUST fail with drift error
+2. Snapshot the failure message — this is the RED state
+
+### GREEN gates per phase
+
+| Phase | Verification command | Expected pass |
+|---|---|---|
+| 1 | `bun run release 0.11.1 --dry` (no-op) | exits clean; no diff to commit |
+| 1 | `bun run release 0.12.0-test --dry` (preview) | shows planned mutations; no actual writes |
+| 2 | `cat .github/workflows/publish.yml \| grep -c "Sync VERSION to main"` | 0 |
+| 2 | `cat .github/workflows/publish.yml \| grep -c "assert.*version.*tag"` | ≥1 |
+| 3 | `bun run scripts/test-clean-install.ts --target 0.11.1` | exits 0 |
+| 4 | `grep '"version": "0.11.1"' packages/*/package.json \| wc -l` | 35 (matches package count, allowing for judge-server policy) |
+| 4 | `git tag --list v0.11.*` | (no tag — backfill is not a re-release) |
+| 4 | `gh release list \| grep v0.10.7` | (empty) |
+
+### Existing tests that MUST still pass
+
+- All workspace `bun test` (3219+ tests at baseline)
+- `bunx turbo run build` 38/38
+- `bun run typecheck` clean
+
+## Verification Protocol (commands + counts captured in PR body)
+
+```bash
+# Before
+echo "Root VERSION: $(cat VERSION)"
+echo "npm published: $(npm view @reactive-agents/core version)"
+echo "pkg.json versions (unique):"
+grep '"version"' packages/*/package.json | awk -F'"' '{print $4}' | sort -u
+echo "Recent tags:"
+git tag | grep -E '^v0\.(1[01]|9)\.' | tail -5
+
+# Apply phases 1-3 changes (release.ts + publish.yml + test-clean-install.ts)
+git checkout -b refactor/ws-1-release-flow-integrity
+# ... edit release.ts, publish.yml, test-clean-install.ts ...
+
+# Run dry preview
+bun run release 0.12.0-preview --dry  # MUST exit clean
+
+# Apply phase 4 backfill (NOT in this PR — separate commit)
+bun run release 0.11.1  # this will stamp + commit + push (only the stamp commit, no tag)
+
+# After
+echo "pkg.json versions post-backfill:"
+grep '"version"' packages/*/package.json | awk -F'"' '{print $4}' | sort -u  # MUST show only 0.11.1 (and judge-server's policy)
+
+# Delete orphan draft
+gh release delete v0.10.7 --yes
+```
+
+## Done Criteria (falsifiable)
+
+- [ ] `grep '"version": "0.11.1"' packages/*/package.json | wc -l` == 35 (or 34 if judge-server has policy split)
+- [ ] `git tag --list v0.9.* v0.10.* v0.11.*` shows v0.9.0 + v0.10.6 + v0.11.1 (matching npm published artifacts; tags catch up to reality)
+- [ ] `bun run release:dry 0.12.0` exits clean (zero drift gate violations)
+- [ ] `.github/workflows/publish.yml` has zero "Sync VERSION to main" mutations
+- [ ] `gh release list` shows no orphan v0.10.7 draft
+- [ ] All 3219+ tests pass
+- [ ] Build 38/38 green
+- [ ] PR body cites every grep + count above
+
+## Rollback Plan
+
+Single revert commit reverts release.ts + publish.yml + test-clean-install.ts changes. Workspace pkg.json backfill stays committed (it represents truth catching up to reality). Tag backfill stays. Net: rollback restores the old (broken) CI pattern but keeps reality-truth alignment on main.
+
+If catastrophic (e.g. release.ts has a destructive bug): revert + immediately re-stamp pkg.jsons + push. Tagging is gated on local CLI.
+
+## Evidence Artifact
+
+`wiki/Research/Refactor-Reports/2026-05-28-ws-1-release-flow.md` containing:
+
+- Before/after `grep + wc -l` snapshots
+- The first successful `bun run release:dry 0.12.0` exit-clean output
+- The first successful clean release dry-run end-to-end output
+- Confirmation of #159 + #165 close
+
+## Why This Workstream Is First
+
+- Self-contained (no kernel/runtime semantics touched)
+- P0 blocker for any future release
+- Cheapest unblocker (≤1 day)
+- Failure mode is bounded (single revert returns status quo)
+- Subsequent WSes ship behavior changes — they need a working release flow to validate end-to-end
+
+## Owner + Handoff
+
+`release-warden` dispatch via Agent tool, with MissionBrief input. Warden produces UpwardReport on completion. Main thread reviews UpwardReport, runs the validation gates in `Verification Protocol`, merges PR.
+
+## Cross-Reference
+
+- Master plan: `wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md` §4 RC-5, §6.2 WS-1 summary
+- Architecture model: §1 (layered dependency rule applies — release is L4 surface concern), §17 mapping
+- Related closed issues: #159 P0, #165
+- Memory cross-ref: `feedback_npm_version_drift`, `project_release_flow`

--- a/wiki/Planning/Implementation-Plans/2026-05-28-ws-1-release-flow-integrity.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-28-ws-1-release-flow-integrity.md
@@ -1,209 +1,274 @@
 ---
-title: WS-1 — Release-Flow Integrity
+title: WS-1 — Release-Flow Residual Fixes (REVISED post-warden-audit)
 date: 2026-05-28
-status: pending
-master-plan: 2026-05-28-canonical-refactor.md
+revised: 2026-05-28 (evening)
+status: pending execution
+master-plan: 2026-05-28-canonical-refactor.md (§4 RC-5 REVISED)
 architecture-model: 2026-05-28-canonical-architecture-model.md
-root-cause-closed: RC-5 (release stamping in ephemeral CI runner)
-gh-issues-closed: [#159 (P0), #165]
-authoritative-anchor: master-plan §3.4 RC-5 + §3.6 first-hand verification
-owner-warden: release-warden
-session-budget: 1 day (~4-6 hours active work + 1 release dry run)
-risk: LOW (isolated, no kernel/runtime semantics touched, full rollback path)
+audit-evidence: wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md (release-warden Phase 0)
+root-cause-closed: RC-5 (residual fixes only — premise of original framing invalidated)
+gh-issues-closed: [#159 (close as invalid), #165 (orphan v0.10.7 draft)]
+gh-issues-touched: [F2 typecheck-fix, F3 judge-server-lockstep, F4 release.ts ordering — file as separate issues with `audit-2026-05-28-release-warden` label OR fold into this WS PR]
+authoritative-anchor: warden audit findings F2/F3/F4 + first-hand reproduction
+owner: claude main thread + user authorization
+session-budget: ~30 min execution + verification
+risk: LOW (4 small, isolated, well-bounded fixes)
 ---
 
-# WS-1 — Release-Flow Integrity
+# WS-1 — Release-Flow Residual Fixes (REVISED)
+
+## Revision Note
+
+**Original WS-1 thin spec scope was wrong.** Release-warden Phase 0 audit 2026-05-28 invalidated three premises:
+
+1. ❌ "Workspace pkg.jsons at 0.10.6 = drift defect" — ✅ Actually intentional steady-state per `release.ts:205-208` comment ("so `cat VERSION` always matches npm @latest")
+2. ❌ "Git tags max at v0.9.0; no v0.10.x/v0.11.x" — ✅ All v0.10.0-v0.11.1 tags exist on origin already, deref'ing to npm gitHead SHAs
+3. ❌ "Release flow structurally broken; needs rebuild" — ✅ Works in steady state; 4 small residual issues identified
+
+This revision aligns scope with reality. See master plan §3.4 RC-5 REVISED + §11 amendment 4.
+
+---
 
 ## Goal (one sentence)
 
-Move version stamping from CI ephemeral runner to local pre-tag step so workspace `packages/*/package.json` versions, root `VERSION`, npm published artifact, and git tags are structurally guaranteed to match.
+Fix the 4 residual release-flow issues identified by warden audit (typecheck RED at HEAD, judge-server inconsistency, release.ts auth-before-drift ordering, orphan GH draft) AND close #159 as invalid framing.
 
 ## Anchor
 
-Master plan §4 RC-5: "Release stamping happens in CI ephemeral runner, not in local pre-tag step. Mutations die with the runner." This violates the trust differentiator at the release surface: a `bun run release:dry 0.12.0` would today fail the drift gate AGAINST main even though npm shows 0.11.1 published.
+- **Master plan §4 RC-5 REVISED:** four small issues, not a structural rebuild
+- **Warden audit** `wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md` (F1-F5 findings, gate results)
+- **Architecture model §17 mapping:** release-flow is L4 surface concern; hygiene workstream
 
 ## Current State (first-hand verified 2026-05-28)
 
 ```
-root VERSION:                          0.11.1
-npm @reactive-agents/core version:     0.11.1
-packages/core/package.json:            0.10.6
-packages/llm-provider/package.json:    0.10.6
-packages/memory/package.json:          0.10.6
-packages/reasoning/package.json:       0.10.6
-packages/tools/package.json:           0.10.6
-packages/runtime/package.json:         0.10.6
-packages/reactive-agents/package.json: 0.10.6
-packages/compose/package.json:         0.10.6
-... (35 packages total — ALL at 0.10.6 except judge-server at 0.9.5)
-git tags max:                          v0.9.0 (no v0.10.x, no v0.11.x)
+✅ Origin tags v0.10.6 + v0.11.1 — present, deref to npm gitHead
+✅ Workspace pkg.json lag = intentional design (release.ts:205-208 documents)
+✅ Build green (turbo 38/38)
+✅ Tests green (5750 pass / 23 skip / 0 fail)
+❌ Typecheck RED — @reactive-agents/verification 8 TS2345 errors
+❌ judge-server unpublished (npm view 404) + not lockstep (0.9.5 vs 0.10.6 floor)
+❌ release.ts:42-66 npm whoami bails before drift inspection
+❌ Orphan v0.10.7 GH draft release
 ```
 
-The CI script at `release.ts:197-208` stamps inside the runner; the mutated files are not committed back to main. The drift compounds at every release.
+## Scope IN — 5 small fixes
 
-## Scope IN
+### Fix 1 — F2 typecheck stubs (the blocker)
 
-### Phase 1 — Restructure `release.ts` for local-stamp pattern
+**Files touched:** `packages/verification/tests/hallucination-detection.test.ts` + `packages/verification/tests/layers.test.ts`
 
-**Files touched:** `scripts/release.ts`
+**Lines:** 145, 162, 176, 192 (hallucination) + 76, 97, 118, 139 (layers) — 8 mock objects total
 
-**Change:** Move the stamping logic OUT of the ephemeral path. Local invocation:
-
-```bash
-bun run release 0.12.0
+**Change:** Each mock currently shapes:
+```typescript
+{ complete: (_req: any) => Effect.succeed({ content: "..." }) }
+```
+Add the missing `embed` method to match `VerificationLLM` interface:
+```typescript
+{
+  complete: (_req: any) => Effect.succeed({ content: "..." }),
+  embed: (_texts: readonly string[], _model?: string) => Effect.succeed([]),
+}
 ```
 
-MUST:
-1. Read `0.12.0` from CLI arg
-2. Stamp every `packages/*/package.json` `version` field to `0.12.0` (excluding `judge-server` if it stays on its own track — verify per policy)
-3. Update root `VERSION` to `0.12.0`
-4. Update workspace `package.json` references that pin versions
-5. `bun install` to sync lockfile
-6. `bun run build && bun run typecheck && bun test` to gate
-7. `bun run release:dry 0.12.0` to confirm no drift remains
-8. `git add` modified package.jsons + root VERSION + bun.lock
-9. `git commit -m "chore(release): stamp 0.12.0"`
-10. `git push origin main`
-11. `git tag v0.12.0`
-12. `git push origin v0.12.0`
+Pre-verify shape: `grep "interface VerificationLLM" packages/verification/src/` → confirm `embed`'s exact signature. Use matching signature in stubs. Use `Effect.succeed([])` or `Effect.die(new Error("not implemented"))` per test intent.
 
-After this, CI's `publish.yml` triggers on the tag and runs build + publish only — no mutations.
+**Verification:** `cd packages/verification && bun run typecheck` exits 0.
 
-### Phase 2 — Simplify `publish.yml`
+### Fix 2 — F3 judge-server private + lockstep
 
-**Files touched:** `.github/workflows/publish.yml`
-
-**Change:** Remove the "Sync VERSION to main" step (publish.yml:135-149) that commits only `VERSION` but not package.jsons. Replace with assertion: confirm tag commit's `packages/*/package.json` `version` field matches the tag (belt-and-suspenders).
-
-### Phase 3 — Belt-and-suspenders gate in `test-clean-install.ts`
-
-**Files touched:** `scripts/test-clean-install.ts` (per HS-H-04 audit recommendation)
-
-**Change:** After clean install, assert published version matches the tag's expected version. Fails the workflow if any drift slips through.
-
-### Phase 4 — Backfill workspace pkg.jsons + delete orphan draft
-
-**Files touched:** All 35 `packages/*/package.json` files. GitHub release page (manual).
+**Files touched:** `packages/judge-server/package.json`
 
 **Change:**
-1. Stamp every workspace `packages/*/package.json` to `0.11.1` (current published) via the new `release.ts` flow
-2. Commit + push the stamps (NO tag — this is backfill catching up reality to npm)
-3. CHANGELOG backfill entries for v0.10.6 → v0.11.1 in their respective package CHANGELOG.md files (per `feedback_npm_version_drift`)
-4. Delete orphan `v0.10.7` draft GH release (#165) via `gh release delete v0.10.7 --yes`
+1. Add `"private": true` field
+2. Bump `"version": "0.9.5"` → `"version": "0.10.6"` (lockstep with workspace floor)
+
+**Verification:**
+- `grep -E '"(private|version)"' packages/judge-server/package.json` shows both fields correctly set
+- Workspace consumers of judge-server (if any) continue to resolve (verify via `grep -r "@reactive-agents/judge-server" packages apps` and confirm workspace:* refs resolve)
+- `bun install` runs clean (lockfile regenerates if needed)
+
+### Fix 3 — F4 release.ts ordering (drift check before auth)
+
+**Files touched:** `scripts/release.ts` (~lines 42-66)
+
+**Change:** Move the workspace-version-drift inspection BEFORE the `npm whoami` auth gate so `bun run release:dry <ver>` functions as a drift gate without requiring login.
+
+**Read first:** Confirm current sequence at `scripts/release.ts:42-66`. Likely shape: `auth check → drift check → other gates`. Target: `drift check → auth check (only for non-dry runs) → other gates`. Dry-run path skips auth entirely.
+
+**Verification:**
+- `bun run release:dry 0.12.0` exits with a drift-specific message (or "clean — no drift detected") WITHOUT requiring npm login
+- `bun run release 0.12.0` (real, NOT dry) still requires `npm whoami` (auth still gated for actual publishing)
+
+### Fix 4 — #165 orphan v0.10.7 draft cleanup
+
+**Command:** `gh release delete v0.10.7 --yes`
+
+**Verification:** `gh release list | grep v0.10.7` returns empty.
+
+### Fix 5 — #159 close as invalid
+
+**Command:** `gh issue close 159 --comment "Closing as invalid framing. Release-warden Phase 0 audit 2026-05-28 (wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md) verified: workspace packages/*/package.json lag at 0.10.6 vs root VERSION 0.11.1 is the intentional steady-state per release.ts:205-208 comment (\"so cat VERSION always matches npm @latest (repo package.json stays unbumped by the tag-driven flow)\"). Git tags v0.10.0-v0.11.1 exist on origin and deref to the correct npm gitHead SHAs. Release flow works as designed. Residual issues (F2 typecheck, F3 judge-server, F4 release.ts ordering, #165 orphan draft) addressed in WS-1 follow-up bundle."`
 
 ## Scope OUT (non-goals — flagged for refusal)
 
-- Touching ANY package's source code (no behavior change)
-- Changing the semantic of `release:dry` itself (only how it's invoked)
-- Touching changesets (already removed May 2026)
-- Touching CI for non-release workflows (PR CI stays as-is)
-- Tagging a new version (this WS prepares the rails; an actual v0.12.0 release is downstream)
+- Touching ANY production source code (only test stubs + judge-server config + release script)
+- Stamping workspace pkg.jsons to 0.11.1 (premise was wrong — pkg.json lag is intentional)
+- Creating v0.10.x or v0.11.x tags (already exist)
+- Touching `.github/workflows/publish.yml` (not broken — actually-working flow per audit)
+- Touching `scripts/test-clean-install.ts` (premise was wrong — no belt-and-suspenders needed for non-existent drift)
+- npm publishing judge-server (user adjudicated: keep internal/private)
+- Major release.ts refactor (just move 2 lines — drift check before auth)
 
 ## Pre-Conditions
 
-- `main` branch is current with `origin/main`
-- Build green (`bunx turbo run build` 38/38)
-- Tests green (`bun test` workspace pass)
-- No uncommitted changes in tree
-- `npm view @reactive-agents/core version` returns 0.11.1 (current truth)
-- `node`, `bun`, `gh` CLI all available locally
+- `main` current with `origin/main` (verified: 8 commits ahead at session entry; pushed via WS-1 prep)
+- Build green (verified: 38/38)
+- Tests green (verified: 5750 pass / 23 skip)
+- Typecheck currently RED (this WS fixes that)
+- `gh` CLI authenticated (`gh auth status` returns success)
 
 ## Tests (RED → GREEN)
 
-### RED first
+### RED state (current baseline at HEAD)
 
-1. Manual repro: `bun run release:dry 0.12.0` against current main MUST fail with drift error
-2. Snapshot the failure message — this is the RED state
+| Gate | Current |
+|---|---|
+| `cd packages/verification && bun run typecheck` | ❌ 8 TS2345 errors |
+| `npm view @reactive-agents/judge-server version` | ❌ 404 (unpublished) |
+| `grep '"private"' packages/judge-server/package.json` | ❌ no match |
+| `bun run release:dry 0.12.0` (without npm login) | ❌ bails at `npm whoami` before drift logic |
+| `gh release list \| grep v0.10.7` | ❌ orphan present |
+| `gh issue view 159 --json state -q .state` | ❌ `OPEN` |
 
-### GREEN gates per phase
+### GREEN state (post-WS-1)
 
-| Phase | Verification command | Expected pass |
-|---|---|---|
-| 1 | `bun run release 0.11.1 --dry` (no-op) | exits clean; no diff to commit |
-| 1 | `bun run release 0.12.0-test --dry` (preview) | shows planned mutations; no actual writes |
-| 2 | `cat .github/workflows/publish.yml \| grep -c "Sync VERSION to main"` | 0 |
-| 2 | `cat .github/workflows/publish.yml \| grep -c "assert.*version.*tag"` | ≥1 |
-| 3 | `bun run scripts/test-clean-install.ts --target 0.11.1` | exits 0 |
-| 4 | `grep '"version": "0.11.1"' packages/*/package.json \| wc -l` | 35 (matches package count, allowing for judge-server policy) |
-| 4 | `git tag --list v0.11.*` | (no tag — backfill is not a re-release) |
-| 4 | `gh release list \| grep v0.10.7` | (empty) |
+| Gate | Expected |
+|---|---|
+| `cd packages/verification && bun run typecheck` | ✅ exits 0 |
+| `bunx turbo run typecheck` workspace-wide | ✅ exits 0 |
+| `grep '"private": true' packages/judge-server/package.json` | ✅ 1 match |
+| `grep '"version": "0.10.6"' packages/judge-server/package.json` | ✅ 1 match |
+| `bun run release:dry 0.12.0` (without npm login) | ✅ exits with drift-specific output (clean or specific drift); does NOT bail on auth |
+| `bun run release 0.12.0` (non-dry, no login) | ✅ bails on auth (expected — actual publish requires login) |
+| `gh release list \| grep v0.10.7` | ✅ empty |
+| `gh issue view 159 --json state -q .state` | ✅ `CLOSED` |
 
 ### Existing tests that MUST still pass
 
-- All workspace `bun test` (3219+ tests at baseline)
-- `bunx turbo run build` 38/38
-- `bun run typecheck` clean
+- All 5750+ workspace tests pass (`bun test`)
+- Build 38/38 (`bunx turbo run build`)
+- No regression in any package's test suite
 
-## Verification Protocol (commands + counts captured in PR body)
+## Verification Protocol
 
 ```bash
-# Before
-echo "Root VERSION: $(cat VERSION)"
-echo "npm published: $(npm view @reactive-agents/core version)"
-echo "pkg.json versions (unique):"
-grep '"version"' packages/*/package.json | awk -F'"' '{print $4}' | sort -u
-echo "Recent tags:"
-git tag | grep -E '^v0\.(1[01]|9)\.' | tail -5
+# Before (capture RED state)
+echo "=== Pre-WS-1 baseline ==="
+cd packages/verification && bun run typecheck 2>&1 | grep -c "error TS"     # expect: ≥8
+cd ../..
+npm view @reactive-agents/judge-server version 2>&1 | grep -c "404"          # expect: ≥1
+grep -c '"private"' packages/judge-server/package.json                       # expect: 0
+git status -s                                                                # expect: empty (clean)
 
-# Apply phases 1-3 changes (release.ts + publish.yml + test-clean-install.ts)
-git checkout -b refactor/ws-1-release-flow-integrity
-# ... edit release.ts, publish.yml, test-clean-install.ts ...
+# Apply Fix 1 (verification test stubs) + Fix 2 (judge-server config)
+# Apply Fix 3 (release.ts ordering)
+# (commit + push branch)
 
-# Run dry preview
-bun run release 0.12.0-preview --dry  # MUST exit clean
+# After (capture GREEN state)
+echo "=== Post-WS-1 ==="
+cd packages/verification && bun run typecheck 2>&1 | grep -c "error TS"     # expect: 0
+cd ../..
+bunx turbo run typecheck 2>&1 | tail -3                                      # expect: success
+grep '"private": true' packages/judge-server/package.json                    # expect: 1 match
+grep '"version": "0.10.6"' packages/judge-server/package.json                # expect: 1 match
+bun run release:dry 0.12.0 2>&1 | head -10                                   # expect: drift output (no whoami bail)
 
-# Apply phase 4 backfill (NOT in this PR — separate commit)
-bun run release 0.11.1  # this will stamp + commit + push (only the stamp commit, no tag)
-
-# After
-echo "pkg.json versions post-backfill:"
-grep '"version"' packages/*/package.json | awk -F'"' '{print $4}' | sort -u  # MUST show only 0.11.1 (and judge-server's policy)
-
-# Delete orphan draft
+# Apply Fix 4 (#165 cleanup) + Fix 5 (#159 close)
 gh release delete v0.10.7 --yes
+gh issue close 159 --comment "..." (see Fix 5)
+gh release list | grep -c v0.10.7                                            # expect: 0
+gh issue view 159 --json state -q .state                                     # expect: CLOSED
+
+# Full gate
+bun test 2>&1 | tail -3                                                      # expect: ≥5750 pass / 0 fail
+bunx turbo run build 2>&1 | tail -3                                          # expect: 38/38
 ```
 
 ## Done Criteria (falsifiable)
 
-- [ ] `grep '"version": "0.11.1"' packages/*/package.json | wc -l` == 35 (or 34 if judge-server has policy split)
-- [ ] `git tag --list v0.9.* v0.10.* v0.11.*` shows v0.9.0 + v0.10.6 + v0.11.1 (matching npm published artifacts; tags catch up to reality)
-- [ ] `bun run release:dry 0.12.0` exits clean (zero drift gate violations)
-- [ ] `.github/workflows/publish.yml` has zero "Sync VERSION to main" mutations
-- [ ] `gh release list` shows no orphan v0.10.7 draft
-- [ ] All 3219+ tests pass
-- [ ] Build 38/38 green
-- [ ] PR body cites every grep + count above
+### Fix 1 — F2 typecheck
+
+- [ ] `cd packages/verification && bun run typecheck` exits 0
+- [ ] `bunx turbo run typecheck` workspace-wide exits 0
+- [ ] No new test logic changed — only `embed` stub added to existing mocks
+
+### Fix 2 — F3 judge-server
+
+- [ ] `packages/judge-server/package.json` has `"private": true`
+- [ ] `packages/judge-server/package.json` has `"version": "0.10.6"`
+- [ ] No npm publish triggered (since `private: true`)
+- [ ] `bun install` runs clean
+
+### Fix 3 — F4 release.ts ordering
+
+- [ ] `bun run release:dry 0.12.0` runs the drift check without requiring `npm whoami`
+- [ ] `bun run release 0.12.0` (non-dry) still requires auth (no regression to actual publish gate)
+
+### Fix 4 — #165 cleanup
+
+- [ ] `gh release list` shows no v0.10.7 entry
+- [ ] No tag v0.10.7 ever materialized (it was draft-only)
+
+### Fix 5 — #159 close
+
+- [ ] Issue closed with the comment text above
+- [ ] Comment cites warden audit report path
+
+### Cross-cutting
+
+- [ ] All 5750+ tests pass
+- [ ] Build 38/38
+- [ ] Typecheck clean workspace-wide
+- [ ] PR body cites before/after for each fix's verification gate
+- [ ] No new `as any` or `as unknown as` introduced
 
 ## Rollback Plan
 
-Single revert commit reverts release.ts + publish.yml + test-clean-install.ts changes. Workspace pkg.json backfill stays committed (it represents truth catching up to reality). Tag backfill stays. Net: rollback restores the old (broken) CI pattern but keeps reality-truth alignment on main.
+Each fix is independent and rollback-isolated:
 
-If catastrophic (e.g. release.ts has a destructive bug): revert + immediately re-stamp pkg.jsons + push. Tagging is gated on local CLI.
+- **Fix 1 rollback:** revert test file changes; typecheck returns to RED
+- **Fix 2 rollback:** unset `private` + restore `0.9.5` version; judge-server returns to prior inconsistent state
+- **Fix 3 rollback:** revert release.ts changes; `release:dry` returns to bailing on auth
+- **Fix 4 rollback:** `gh release create v0.10.7 --draft` (recreate orphan — unlikely needed)
+- **Fix 5 rollback:** `gh issue reopen 159`
+
+Per-fix commits make granular rollback trivial. PR is one logical bundle but commits are atomic per fix.
 
 ## Evidence Artifact
 
-`wiki/Research/Refactor-Reports/2026-05-28-ws-1-release-flow.md` containing:
+`wiki/Research/Refactor-Reports/2026-05-28-ws-1-residual-fixes.md` containing:
 
-- Before/after `grep + wc -l` snapshots
-- The first successful `bun run release:dry 0.12.0` exit-clean output
-- The first successful clean release dry-run end-to-end output
-- Confirmation of #159 + #165 close
+- Before/after gate output for each fix
+- Confirmation that warden audit findings F2, F3, F4, #165, #159 are addressed
+- Reference to the warden audit baseline at `wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md`
 
-## Why This Workstream Is First
+## Execution Path
 
-- Self-contained (no kernel/runtime semantics touched)
-- P0 blocker for any future release
-- Cheapest unblocker (≤1 day)
-- Failure mode is bounded (single revert returns status quo)
-- Subsequent WSes ship behavior changes — they need a working release flow to validate end-to-end
+Original WS-1 brief was rejected by release-warden (correctly — outside its authority). This revision routes through claude main thread + user authorization:
 
-## Owner + Handoff
-
-`release-warden` dispatch via Agent tool, with MissionBrief input. Warden produces UpwardReport on completion. Main thread reviews UpwardReport, runs the validation gates in `Verification Protocol`, merges PR.
+1. Claude applies Fix 1 (test stubs — `Edit` tool) and Fix 2 (judge-server config — `Edit`) on branch `refactor/ws-1-residual-fixes`
+2. Claude applies Fix 3 (release.ts ordering — `Edit`) carefully — read full release.ts:1-100 first to confirm exact ordering target
+3. Claude commits with conventional message
+4. Claude runs verification gates locally; captures evidence
+5. User authorizes Fix 4 (`gh release delete v0.10.7 --yes`) + Fix 5 (`gh issue close 159 --comment ...`)
+6. Claude pushes branch; opens PR with verified-by table; closes #159 + #165 references in PR body
 
 ## Cross-Reference
 
-- Master plan: `wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md` §4 RC-5, §6.2 WS-1 summary
-- Architecture model: §1 (layered dependency rule applies — release is L4 surface concern), §17 mapping
-- Related closed issues: #159 P0, #165
-- Memory cross-ref: `feedback_npm_version_drift`, `project_release_flow`
+- Master plan: `wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md` §3.4 RC-5 REVISED, §4 RC-5 table row, §6.2 WS-1 summary REVISED, §10 #159 mapping
+- Architecture model: §17 mapping (L4 surface concern)
+- Warden audit: `wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md` (findings F1-F5)
+- Related closed: #159 (invalid), #165 (orphan), F2 typecheck-fix, F3 judge-server-lockstep, F4 release.ts-ordering
+- Memory: `feedback_npm_version_drift` (refined — workspace lag IS the design)

--- a/wiki/Planning/Implementation-Plans/2026-05-28-ws-2-runtime-canonical-seam.md
+++ b/wiki/Planning/Implementation-Plans/2026-05-28-ws-2-runtime-canonical-seam.md
@@ -1,0 +1,369 @@
+---
+title: WS-2 — Runtime Composition + Agent-Facade Canonical Seam
+date: 2026-05-28
+status: pending
+master-plan: 2026-05-28-canonical-refactor.md
+architecture-model: 2026-05-28-canonical-architecture-model.md
+root-cause-closed: RC-1 (mutation-chain Layer composition; agent-facade type debt)
+gh-issues-closed: [#162 (AgentResult.debrief), #163 (AgentEvent narrowing), #164 (CLI template `as any`), #167 (RuntimeAssembly refactor)]
+gh-issues-touched: [HS-A-01, HS-A-04, HS-A-05, HS-A-07, HS-A-15, HS-A-16, HS-A-19, HS-D-07, HS-D-08, HS-D-09]
+authoritative-anchor: master-plan §4 RC-1 + §3.6 F1/F5/F6 + architecture-model §3 + §11
+owner-warden: runtime-warden
+session-budget: 2 sessions — Phase 1 (1 session) + Phase 2+3 (1 session)
+risk: MEDIUM (Phase 1 mechanical; Phase 2 touches public types — requires careful changeset)
+---
+
+# WS-2 — Runtime Composition + Agent-Facade Canonical Seam
+
+## Goal (one sentence)
+
+Refactor `runtime.ts:createRuntime` from imperative mutation chain to declarative terminal `Layer.mergeAll` (mirroring the already-working `createLightRuntime` pattern at line 1061), surface `AgentResult.debrief` and discriminated `AgentEvent` on the public type, and reduce `builder.ts` 59 `withX()` methods toward the ≤24 anti-mission #3 ceiling.
+
+## Anchor
+
+- **Master plan §4 RC-1:** mutation chain adds 44 cast points instead of 1 terminal cast
+- **§3.6 F1:** `createLightRuntime` already uses `Layer.mergeAll` — refactor is pattern alignment, not invention
+- **§3.6 F5:** `builder.ts` has 59 withers (2.4× anti-mission #3 threshold of 24)
+- **§3.6 F6:** `reactive-agent.ts` `this as any` at 2 sites — `ReactiveAgentInternalView` interface fix
+- **Architecture model §3:** declarative composition with one `ComposableLayer` erasure boundary at the terminal `Layer.mergeAll` call
+- **Architecture model §11:** user surface principles — preset-primary, compose-secondary, ≤24 wither ceiling
+
+## Current State (first-hand verified 2026-05-28)
+
+```
+runtime.ts LOC:                                1261
+runtime.ts `Layer.merge(runtime, X)` calls:    40   (mutation chain)
+runtime.ts `Layer.mergeAll` calls:             2    (declarative — exists in createLightRuntime)
+runtime.ts `as ComposableLayer` casts:         44
+builder.ts LOC:                                2027
+builder.ts withX() method count:               59   (target ≤24)
+reactive-agent.ts LOC:                         1535
+reactive-agent.ts `this as any` sites:         2    (lines 1385, 1413)
+AgentResult.debrief on public type:            NO   (cast sites: 4+ across CLI/cortex/playground)
+AgentEvent discriminated on _tag in user code: NO   (cast sites: 13+ in cortex/ui)
+```
+
+## Scope IN
+
+### Phase 1 — Runtime composition (mechanical pattern alignment, 1 session)
+
+**Files touched:** `packages/runtime/src/runtime.ts`
+
+**Change shape:**
+
+```typescript
+// BEFORE (lines ~215-940 in createRuntime)
+let runtime: ComposableLayer = Layer.mergeAll(
+  coreLayer, eventBusLayer, llmLayer, memoryLayer, /* ... base ... */,
+) as ComposableLayer;
+if (options.enableTools)         runtime = Layer.merge(runtime, toolsLayer)        as ComposableLayer;
+if (options.enableReasoning)     runtime = Layer.merge(runtime, reasoningLayer)    as ComposableLayer;
+if (options.enableIdentity)      runtime = Layer.merge(runtime, createIdentityLayer()) as ComposableLayer;
+// ... 40 more conditional Layer.merge mutations ...
+return runtime;
+
+// AFTER
+const layers: ComposableLayer[] = [
+  coreLayer, eventBusLayer, llmLayer, memoryLayer, /* ... base ... */,
+];
+if (options.enableTools)         layers.push(toolsLayer);
+if (options.enableReasoning)     layers.push(reasoningLayer);
+if (options.enableIdentity)      layers.push(createIdentityLayer());
+// ... 40 more conditional `layers.push(...)` ...
+return Layer.mergeAll(...layers) as ComposableLayer;
+```
+
+**Pattern source:** `runtime.ts:1061` (`createLightRuntime`). DO NOT invent — copy the shape already working.
+
+**Preserved invariants:**
+- `ComposableLayer` type-erasure (documented at runtime.ts:55-76) STAYS
+- Behavior identical (same layers, same conditional logic, same options interpretation)
+- Test coverage unchanged (existing 3219+ tests cover the runtime composition path)
+
+**Special cases to handle:**
+- `effectiveLlmLayer` construction with fallback chain (runtime.ts:242-345) — stays as a derived layer; pushed to `layers[]`
+- `finalLlmLayer` with retry wrapping (lines ~347-367) — stays as derived layer
+- `gatewayLayer` with `Layer.unwrapEffect` (lines ~892-927) — pushed to `layers[]` post-construction
+- `A2aExtraLayer` (lines ~879-885) — pushed to `layers[]`
+- `options.extraLayers` (lines 936-938) — pushed last to preserve override semantics
+
+### Phase 2 — Agent-facade public type truth (1 session, alongside Phase 3)
+
+**Files touched:** `packages/runtime/src/types.ts`, `packages/core/src/types/agent-events.ts` (or wherever `AgentEvent` lives), `packages/runtime/src/reactive-agent.ts`, `packages/runtime/src/agent/gateway-runner.ts`, downstream consumers (CLI, cortex, playground)
+
+**Changes:**
+
+#### 2.1 — Surface `AgentResult.debrief` on public type (closes #162)
+
+```typescript
+// packages/runtime/src/types.ts
+export interface AgentResult {
+  readonly output: string | null;
+  readonly success: boolean;
+  readonly metadata: AgentResultMetadata;
+  readonly debrief?: AgentDebrief;   // ← ADD — was internal field, now public
+}
+```
+
+Migration: 4+ cast sites (CLI, cortex/server, playground) drop `(result as any).debrief` → `result.debrief`. Per-site grep before/after for verification.
+
+#### 2.2 — Discriminate `AgentEvent` on `_tag` for narrowing (closes #163)
+
+Existing `AgentEvent` is a union but consumers must cast to narrow. Add proper discriminated structure so TypeScript narrows on `if (event._tag === "AgentStarted")`:
+
+```typescript
+// packages/core/src/types/agent-events.ts
+export type AgentEvent =
+  | { readonly _tag: "AgentStarted"; readonly agentId: AgentId; readonly taskId: TaskId; /* ... */ }
+  | { readonly _tag: "AgentCompleted"; readonly agentId: AgentId; readonly taskId: TaskId; readonly success: boolean; readonly totalTokens: number; /* ... */ }
+  | { readonly _tag: "ToolCallStarted"; /* ... */ }
+  | { readonly _tag: "ToolCallCompleted"; /* ... */ }
+  | { readonly _tag: "LLMRequestStarted"; /* ... */ }
+  | { readonly _tag: "LLMRequestCompleted"; /* ... */ }
+  | { readonly _tag: "GuardrailViolationDetected"; /* ... */ }
+  // ... all variants explicit
+;
+```
+
+Migration: 13+ cast sites in `cortex/ui/chat-store.ts` + `RunChatTab.svelte` drop `(event as AgentStarted)` → switch on `event._tag`.
+
+#### 2.3 — Add `ReactiveAgentInternalView` to drop `this as any` (closes HS-A-01)
+
+```typescript
+// packages/runtime/src/types.ts (or reactive-agent.ts)
+export interface ReactiveAgentInternalView {
+  readonly _agentId: AgentId;
+  readonly _managedRuntime: ManagedRuntime.ManagedRuntime<unknown, never>;
+  readonly _gatewayConfig?: GatewayConfig;
+  // ... only the fields gateway-runner.ts actually needs
+}
+
+// packages/runtime/src/reactive-agent.ts
+gatewayStatus(): Promise<GatewayStatus | null> {
+  return queryGatewayStatus(this);   // ← was: queryGatewayStatus(this as any)
+}
+start(): GatewayHandle {
+  return startGateway(this);          // ← was: startGateway(this as any)
+}
+
+// packages/runtime/src/agent/gateway-runner.ts
+export function queryGatewayStatus(agent: ReactiveAgentInternalView): Promise<GatewayStatus | null> { ... }
+export function startGateway(agent: ReactiveAgentInternalView): GatewayHandle { ... }
+```
+
+### Phase 3 — Builder wither audit + deprecation (1 session)
+
+**Files touched:** `packages/runtime/src/builder.ts`
+
+**Method:**
+
+1. `grep -nE "^\s*public\s+with[A-Z]" packages/runtime/src/builder.ts` → enumerate all 59 withers
+2. For each wither, decide:
+   - **Keep** — no preset covers this concern + `.compose()` is too low-level for users
+   - **Deprecate-alias** — preset already covers; method stays but marked `@deprecated alias for HarnessProfile.<X>()`
+   - **Remove** — preset covers AND `.compose()` covers AND method has no callers in tests/examples
+3. Target distribution:
+   - **Keep:** ~20-24 (the irreducible essential surface)
+   - **Deprecate-alias:** ~25-30 (covered by HarnessProfile presets)
+   - **Remove:** ~5-10 (true dead weight)
+4. Update `Quickstart.mdx` + `README.md` to use `HarnessProfile.balanced()` as primary entry point
+
+**Backward compatibility:** ALL `@deprecated` withers continue to work. No breaking changes. The next major release evaluates removal candidates per usage telemetry.
+
+## Scope OUT (non-goals — flagged for refusal)
+
+- Refactoring the LAYER CONSTRUCTION logic (e.g. how `reasoningLayer` is built) — Phase 1 only changes how layers are ASSEMBLED, not what they are
+- Decomposing `runtime.ts` further (WS-6 territory if it ships)
+- Decomposing `builder.ts` further (W26-style decomposition is separate)
+- Touching `kernel/` capabilities (WS-3 territory)
+- Touching `packages/reactive-intelligence/` (separate workstream)
+- Changing user-facing API SHAPES (only deprecating redundant methods)
+- Adding new HarnessProfile presets (model §11 caps at 3-4)
+
+## Pre-Conditions
+
+- WS-1 shipped (release flow works) — so any post-WS-2 release can validate end-to-end
+- `main` current with `origin/main`
+- Build green (`bunx turbo run build`)
+- Tests green (`bun test` workspace)
+- No uncommitted changes
+
+## Tests (RED → GREEN)
+
+### RED first
+
+Phase 1 RED: write a test that asserts `Layer.merge(runtime, X) as ComposableLayer` mutation pattern is absent — initially fails because the pattern is present 40 times.
+
+```typescript
+// packages/runtime/tests/runtime-composition.test.ts
+import { readFileSync } from "node:fs";
+import { test, expect } from "bun:test";
+
+test("createRuntime uses Layer.mergeAll pattern (canonical) — no mutation chain", () => {
+  const src = readFileSync("packages/runtime/src/runtime.ts", "utf-8");
+  const createRuntimeStart = src.indexOf("export const createRuntime");
+  const createRuntimeEnd = src.indexOf("export const createLightRuntime");
+  const createRuntimeBody = src.slice(createRuntimeStart, createRuntimeEnd);
+
+  const mutationChainCount = (createRuntimeBody.match(/runtime = Layer\.merge\(runtime,/g) ?? []).length;
+  const mergeAllCount = (createRuntimeBody.match(/Layer\.mergeAll\(/g) ?? []).length;
+
+  expect(mutationChainCount).toBe(0);
+  expect(mergeAllCount).toBeGreaterThanOrEqual(1);
+});
+```
+
+Phase 2 RED: write tests asserting `AgentResult.debrief` accessible without cast; `AgentEvent` narrows on `_tag`.
+
+```typescript
+// packages/runtime/tests/agent-result-public-types.test.ts
+test("AgentResult.debrief is on the public type (no cast)", () => {
+  const result: AgentResult = { output: "x", success: true, metadata: { /* ... */ }, debrief: { rationale: "y" } };
+  // TypeScript compilation alone is the test — if `debrief` is not on the public type, this fails to compile
+  expect(result.debrief?.rationale).toBe("y");
+});
+
+test("AgentEvent narrows on _tag", () => {
+  const event: AgentEvent = { _tag: "AgentStarted", agentId: AgentId("a"), taskId: TaskId("t") };
+  if (event._tag === "AgentStarted") {
+    // TypeScript should narrow event to AgentStartedEvent here
+    expect(event.agentId).toBe("a");
+  }
+});
+```
+
+Phase 3 RED: lint test (or grep) asserts `builder.ts` wither count is ≤30 (with @deprecated allowed).
+
+### GREEN gates per phase
+
+| Phase | Gate | Expected |
+|---|---|---|
+| 1 | `grep -c "runtime = Layer.merge(runtime," packages/runtime/src/runtime.ts` | 0 (was 40) |
+| 1 | `grep -c "as ComposableLayer" packages/runtime/src/runtime.ts` | ≤3 (was 44; allowing terminal cast + 2 sub-functions) |
+| 1 | `grep -c "Layer.mergeAll" packages/runtime/src/runtime.ts` | ≥2 (was 2; createLightRuntime + new createRuntime) |
+| 1 | Workspace tests pass | 3219+ pass |
+| 2.1 | `grep -r "(result as any).debrief\|as unknown as.*debrief" apps packages` | 0 |
+| 2.2 | `grep -rE "as AgentEvent\|as.*AgentStarted" apps/cortex packages/runtime` | 0 (all narrowing via `_tag`) |
+| 2.3 | `grep -c "this as any" packages/runtime/src/reactive-agent.ts` | 0 (was 2) |
+| 3 | `grep -cE "^\s*public\s+with[A-Z]" packages/runtime/src/builder.ts` | ≤30 (was 59; with @deprecated on the rest) |
+| 3 | `grep -c "@deprecated" packages/runtime/src/builder.ts` | ≥20 (alias annotations) |
+
+### Existing tests that MUST still pass
+
+- All workspace `bun test` (3219+ baseline)
+- `bunx turbo run build` 38/38
+- `bun run typecheck` clean across ALL packages (Phase 2 may surface latent cast violations — fix in scope)
+
+## Verification Protocol
+
+```bash
+# Before
+echo "Phase 1 baseline:"
+grep -c "Layer.merge(runtime," packages/runtime/src/runtime.ts        # → 40
+grep -c "as ComposableLayer" packages/runtime/src/runtime.ts          # → 44
+
+echo "Phase 2 baseline:"
+grep -rn "(result as any).debrief\|as.*\.debrief" apps/ packages/ | wc -l     # → 4+
+grep -rn "as AgentEvent\|as.*Started\b" apps/cortex/ | wc -l                  # → 13+
+grep -c "this as any" packages/runtime/src/reactive-agent.ts                  # → 2
+
+echo "Phase 3 baseline:"
+grep -cE "^\s*public\s+with[A-Z]" packages/runtime/src/builder.ts     # → 59
+
+# (apply WS-2 changes)
+
+# After
+echo "Phase 1 post:"
+grep -c "Layer.merge(runtime," packages/runtime/src/runtime.ts        # → 0
+grep -c "as ComposableLayer" packages/runtime/src/runtime.ts          # → ≤3
+grep -c "Layer.mergeAll" packages/runtime/src/runtime.ts              # → ≥2
+
+echo "Phase 2 post:"
+grep -rn "(result as any).debrief\|as.*\.debrief" apps/ packages/ | wc -l     # → 0
+grep -rn "as AgentEvent\|as.*Started\b" apps/cortex/ | wc -l                  # → 0
+grep -c "this as any" packages/runtime/src/reactive-agent.ts                  # → 0
+
+echo "Phase 3 post:"
+grep -cE "^\s*public\s+with[A-Z]" packages/runtime/src/builder.ts     # → ≤30
+grep -c "@deprecated" packages/runtime/src/builder.ts                  # → ≥20
+
+# Build + test
+bunx turbo run build && bun test && bun run typecheck
+```
+
+## Done Criteria (falsifiable — each line is yes/no)
+
+### Phase 1
+
+- [ ] `runtime.ts` createRuntime uses `Layer.mergeAll(...layers)` pattern
+- [ ] Zero `runtime = Layer.merge(runtime, X)` mutations in `createRuntime`
+- [ ] `as ComposableLayer` count in `runtime.ts` ≤ 3 (from baseline 44)
+- [ ] Behavior identical: existing tests pass (3219+)
+- [ ] Build 38/38 green
+- [ ] Typecheck clean
+
+### Phase 2
+
+- [ ] `AgentResult.debrief` declared on public type in `packages/runtime/src/types.ts`
+- [ ] Zero cast sites accessing `debrief` via `as` (closes #162)
+- [ ] `AgentEvent` discriminates on `_tag` for TypeScript narrowing
+- [ ] Zero cast sites narrowing `AgentEvent` via `as Started` (closes #163)
+- [ ] `ReactiveAgentInternalView` interface defined and consumed
+- [ ] Zero `this as any` in `reactive-agent.ts` (closes HS-A-01)
+
+### Phase 3
+
+- [ ] `builder.ts` wither count ≤ 30 (from baseline 59)
+- [ ] ≥20 redundant withers annotated `@deprecated alias for HarnessProfile.X`
+- [ ] Quickstart docs use `HarnessProfile.balanced()` as primary entry point
+- [ ] All deprecated withers still functional (backward compat)
+
+### Cross-cutting
+
+- [ ] Workspace tests pass (3219+ from baseline)
+- [ ] Build green (38/38)
+- [ ] Typecheck clean across ALL packages
+- [ ] No new `as any` or `as unknown as` introduced (CI grep)
+
+## Rollback Plan
+
+Phase 1: single revert of the runtime.ts diff. The mutation chain returns; no other code touched.
+
+Phase 2: revert is multi-file (types.ts, reactive-agent.ts, gateway-runner.ts, downstream consumer cleanups). If any downstream consumer ships before WS-2 merges, that consumer's cast removal stays (it's correct cleanup). The TYPE declarations revert; consumers continue to compile because casts come back.
+
+Phase 3: revert removes `@deprecated` annotations. All withers continue to function. Net: rollback is annotation-level.
+
+Per-phase commits make rollback granular.
+
+## Evidence Artifact
+
+`wiki/Research/Refactor-Reports/2026-05-28-ws-2-runtime-seam.md` containing:
+
+- Before/after grep counts (Phase 1: ComposableLayer 44→3; Phase 2: cast sites 17→0; Phase 3: withers 59→≤30)
+- Diff statistics (runtime.ts net LOC, builder.ts net LOC)
+- Behavior verification: N=1 probe run across reactive + reflexion + plan-execute on local + frontier tier — output sanitized matches pre-WS-2 baseline
+- Confirmation of #162, #163, #167 close + HS-A-01/04/05/07/15/16/19 close
+- Mock drift secondary effect: count of `as` casts in mock-test files (D-07/08/09) before/after — should drop since source types are now precise
+
+## Why This Workstream Is Second
+
+After WS-1 unblocks release flow:
+
+- Highest-leverage cleanup — the runtime/agent-facade seam is the type-debt epicenter (~30 of 80 `as unknown as` cluster here)
+- Mock drift collapses downstream automatically (D-07/08/09 follow from source types)
+- Every subsequent WS becomes cheaper (fewer cast collisions when WS-3 touches kernel)
+- Phase 1 is mechanical and proven (pattern already works in createLightRuntime)
+- Phase 2+3 are independent of Phase 1; can ship as separate PR if Phase 1 takes longer
+
+## Owner + Handoff
+
+`runtime-warden` dispatch via Agent tool with MissionBrief input per pilot. UpwardReport on each phase completion. Main thread runs verification gates before merge.
+
+For Phase 2.2 (AgentEvent discriminated union), coordinate with cortex/ui consumer changes — likely a coordinated multi-package PR.
+
+## Cross-Reference
+
+- Master plan: `wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md` §4 RC-1, §3.6 F1/F5/F6, §6.2 WS-2 summary
+- Architecture model: §3 (runtime composition canonical shape), §11 (user surface), §17 mapping
+- Related closed issues: #162, #163, #164, #167, HS-A-01/04/05/07/15/16/19, HS-D-07/08/09
+- Verified-working reference: `packages/runtime/src/runtime.ts:1061` (createLightRuntime)

--- a/wiki/Research/Audit-Reports-2026-05-27/health-sweep.md
+++ b/wiki/Research/Audit-Reports-2026-05-27/health-sweep.md
@@ -1,0 +1,331 @@
+---
+tags: [audit, health-sweep, 2026-05-27]
+date: 2026-05-27
+---
+
+# Health Sweep — 2026-05-27
+
+**Method:** 4 parallel scan agents (codebase-health-sweep skill v3). Per-finding `verified-by:` per audit-of-audit protocol. Cross-checked against GH #29-#149 and `Running Issues Log.md`. No fixes applied.
+
+**Baseline:** Build GREEN (38/38 turbo tasks), 27 cached. Branch `main`. v0.11.1.
+
+**Counts:** 60 NEW findings — A:20 type, B:10 bugs, C:20 dead/inefficiency, D:20 tests.
+
+---
+
+## Execution Priority (top 12)
+
+Sorted: severity × leverage × bounded-fix-fit.
+
+| Rank | ID | Sev | Action | Why now |
+|---|---|---|---|---|
+| 1 | HS-A-01 | P0 | Type Gateway helpers; drop `this as any` at reactive-agent.ts:1385,1413 | Public API contract lie; single-class fix |
+| 2 | HS-B-01 | P1 | Delete leftover `DEBUG_VERIFIER` console.error at runner.ts:1740-1742 | Hot.md says removed; reality says no; 3-line fix |
+| 3 | HS-B-02 | P1 | Fix lying comment + add obs.log at gateway-bootstrap.ts:236 | Gateway init failures invisible in prod |
+| 4 | HS-A-18 | P2→P1 | Implement `onApprovalRequest` on ReactiveAgent (or remove example) | Example calls nonexistent method; ship-blocker for HITL story |
+| 5 | HS-A-03 | P1 | Remove `validateRationale`/`isRationale`/`Rationale` from trace/src/index.ts | Zero consumers; public API bloat; 1-line delete |
+| 6 | HS-B-04 | P2 | Add `emitErrorSwallowed` at memory-service.ts:113,118,123,194 | Honesty-debt; matches established convention (108/141/156) |
+| 7 | HS-C-11 + HS-C-12 | P2 | Extract shared `completeStructured` schema-clone helper; replace `JSON.parse(JSON.stringify())` with `structuredClone()` across 3 providers | Bounded ~50 LOC consolidation; perf + correctness |
+| 8 | HS-A-19 | P2 | Add public `getLastDebrief()` accessor; drop `(agent as any)._lastDebrief` in playground | Private-access via cast; encapsulation breach |
+| 9 | HS-C-14 | P2 | Drop `MAX_RECURSION_DEPTH` deprecated export from tools/src/index.ts; migrate test to `resolveMaxRecursionDepth()` | Single test caller; bounded fix |
+| 10 | HS-A-04 | P1 | Reuse `adaptHandler` pattern (3 sites at reactive-agent.ts:204,346,375) | Typed solution already exists locally |
+| 11 | HS-D-17 + HS-D-19 | P1 | Surface tests for `@reactive-agents/health` + `reactive-agents` umbrella exports | API surface gaps; small per-file effort |
+| 12 | HS-A-15 | P1 | Type Builder options exactly (runtime.ts:854,921-923) | 4 casts at single seam; public Builder surface |
+
+---
+
+## Full Finding Tables
+
+### A — Type Safety + Dead Exports (20)
+
+See `/tmp/sweep-2026-05-27-scan-A.md` for full table. Highlights:
+- **HS-A-01 P0** Gateway helpers cast `this as any`
+- **HS-A-02 P1** `createReactiveIntelligenceLayer` 4× `Layer.merge as any` — Layer<unknown,unknown,unknown>
+- **HS-A-03 P1** Dead trace exports `validateRationale`/`isRationale`/`Rationale`
+- **HS-A-04 P1** 3× ToolService Tag casts; `adaptHandler` unused
+- **HS-A-05 P1** `metadata.reasoningSteps` + `lastDialectObserved` untyped on RunResult
+- **HS-A-06 P1** `toolResults.slice()` discarded to `as any[]` (2×)
+- **HS-A-07 P1** Double `as any` on `completeStructured` calls (runtime.ts:323,327)
+- **HS-A-08 P2** BusLike adapter erases AgentEvent
+- **HS-A-09 P1** `LLMMessage` missing `tool_calls`/`tool_call_id` variants (validation.ts 4×)
+- **HS-A-10 P2** Ollama chunk untyped (3 sites)
+- **HS-A-11 P2** Gemini `cfg as any` (7 sites)
+- **HS-A-12 P2** Calibration `tools as any`
+- **HS-A-13 P2** SQLite params `as any[]`
+- **HS-A-14 P2** `KernelStateView` interface missing → cross-pkg `as any`
+- **HS-A-15 P1** Builder options 4× `as any` at runtime.ts:854,921-923
+- **HS-A-16 P1** `buildToolInitLayer` returns `Layer<never,unknown,unknown>`
+- **HS-A-17 P2** `with-session-persistence` example 3× builder cast
+- **HS-A-18 P1** HITL example calls nonexistent `onApprovalRequest`
+- **HS-A-19 P2** `playground.ts` reaches into private `_lastDebrief`
+- **HS-A-20 P2** Strategy registry mutates fn objects via double-cast
+
+**Theme totals:** 80 `as unknown as` + ~490 `as any` matches in production. Zero `@ts-ignore` (HS-30 win). Concentration: runtime/agent-facade seam (≈30 sites).
+
+### B — Runtime Bug Patterns (10)
+
+See `/tmp/sweep-2026-05-27-scan-B.md`. Highlights:
+- **HS-B-01 P1** Leftover `DEBUG_VERIFIER` console.error at runner.ts:1740-1742 (Hot.md says removed)
+- **HS-B-02 P1** Lying "propagate" comment at gateway-bootstrap.ts:236; actually `.catch(() => {})`
+- **HS-B-03 P1** Telemetry `fetch.catch(() => {})` — sink health invisible
+- **HS-B-04 P2** 4× memory-service bootstrap swallows missing `emitErrorSwallowed`
+- **HS-B-05 P2** `process.stdout.write` ANSI in sub-agent hot path
+- **HS-B-06 P2** `Effect.runPromise` in agent-stream getter no `.catch`
+- **HS-B-07 P2** `void Effect.runPromise` should be `Effect.runFork`
+- **HS-B-08 P2** Gateway obs.log `.catch(() => {})`
+- **HS-B-09 P2** llm-provider `console.warn` bypasses ObservabilityService (2 sites)
+- **HS-B-10 P2** `pricing-fetch.ts` `console.warn` bypass
+
+**No P0** — no data races, no swallow in LLM/tool critical paths, no rogue `process.exit`.
+
+### C — Dead Weight + Inefficiency (20)
+
+See `/tmp/sweep-2026-05-27-scan-C.md`. Highlights:
+- **HS-C-01** runner.ts regrew 1739→1934 LOC (CLAUDE.md stale)
+- **HS-C-02..10** 9 files >1000 LOC: builder, reactive-agent, execution-engine, event-bus, think, runtime, act, arbitrator, llm-provider/types
+- **HS-C-11/12 P2** Provider `completeStructured` duplication + JSON deep-clone (3 files, ~50 LOC consolidation, use `structuredClone`)
+- **HS-C-13..16** 4 stale `@deprecated` aliases (kernel-state.ReActKernelInput, MAX_RECURSION_DEPTH, ModelTier, llm-config Phase1 S1.3)
+- **HS-C-17/18** 2 `// legacy` comments on active branches
+- **HS-C-19** `fs.existsSync`/`writeFileSync` in calibration service tier (Effect leak)
+- **HS-C-20** Stale `@deprecated v0.10.0 — Removed in v0.11.0` comment for reverted symbol
+
+**0 dist/ committed; 0 redundant Array.from; 0 fully-dead public exports.**
+
+### D — Tests + Coverage (20)
+
+See `/tmp/sweep-2026-05-27-scan-D.md`. Highlights:
+- **HS-D-01 P1** `observe`: `setupOpenInferenceExporter` + `autoConfigureExporter` zero coverage
+- **HS-D-02 P1** `vue` package zero tests (marked @unstable)
+- **HS-D-03..06** 4 test mega-files (1385/995/961/911 LOC); D-05 is near-duplicate across reasoning+tools
+- **HS-D-07/08/09 P1** Mock-type drift hotspots: reasoning (12 casts), runtime (10), RI (4) — LLMService internal shape diverged from public
+- **HS-D-10..16** 7 fixed-millisecond `setTimeout` sites (5/10/20/50/200ms) → flake-prone (compose acknowledges)
+- **HS-D-17 P1** `health` 1 test for 5 public exports
+- **HS-D-19 P1** `reactive-agents` umbrella has single integration test
+- **HS-D-20 P2** `scenarios` test at non-standard `__tests__/`
+
+**Clean:** 0 `.skip`/`.todo`/`xit`/`xdescribe`/`@ts-nocheck`/`dist/` imports across tests; 100% files have `expect()`.
+
+---
+
+## Patterns Observed
+
+1. **Runtime / agent-facade seam is the type-debt epicenter** — ~30 of 80 `as unknown as` cluster in 4 files at the Builder→Runtime→ReactiveAgent boundary. Suggests a missing seam interface (`ReactiveAgentGatewayView`, `BuilderOptionsResolved`).
+2. **Mock drift mirrors source drift** — D-07/08/09 cast clusters are downstream of the same Builder/Runtime/LLMService shape that A-04/A-07/A-15 cast around. Fixing source types automatically reduces mock casts.
+3. **Honesty-debt is consistent NOT silent** — B-04 is the *outlier* among memory-service swallows; B-02 lies, B-03/B-08 acknowledge tradeoff. Convention (`emitErrorSwallowed`) exists but is unevenly applied.
+4. **Decomposition target list grew** — 9 files now >1000 LOC; HS-20 (May 21) only tracked 7 secondary files. runner.ts regrew post-decomp.
+5. **Provider duplication is the cheapest structural win** — HS-C-11/12 single helper extraction removes ~50 LOC + 3 deep-clone anti-patterns + 1 perf delta.
+
+---
+
+## Recommended Bundles (for /execute-backlog)
+
+**Bundle 1 — honesty-pass (P1, ~30 LOC across 3 files):**
+- HS-B-01 (delete DEBUG_VERIFIER console.error)
+- HS-B-02 (gateway-bootstrap loopPromise.catch propagate)
+- HS-B-03 (telemetry-client failedReports counter)
+
+**Bundle 2 — public-API-honesty (P0+P1, ~80 LOC across ~5 files):**
+- HS-A-01 (Gateway view typing)
+- HS-A-03 (delete trace dead exports)
+- HS-A-18 (HITL example: implement or remove)
+- HS-A-19 (getLastDebrief accessor)
+
+**Bundle 3 — provider-helper-extraction (P2, ~50 LOC):**
+- HS-C-11 + HS-C-12 (shared completeStructured + structuredClone)
+
+**Bundle 4 — surface-coverage-gap (P1):**
+- HS-D-01 (observe exporter coverage)
+- HS-D-17 (health surface tests)
+- HS-D-19 (umbrella re-export verification)
+
+**Bundle 5 — DEFER as `architecture-debt` epic (planning, not fix):**
+- HS-A-15 + HS-A-04 + HS-A-07 (Builder→Runtime→LLMService seam re-typing)
+- HS-D-07/08/09 cluster (collapses once Bundle 5 ships)
+- HS-C-01..10 monolith decomp (W26+ planning)
+
+---
+
+## Verification protocol — confirmed
+
+Every finding row carries a `verified-by:` clause naming exact grep/wc command and matched count or file:line. Per audit-of-audit (2026-05-21) inflation guard, occurrence counts use `grep -ro pattern | wc -l` not `grep -c`.
+
+Staged finding tables at `/tmp/sweep-2026-05-27-scan-{A,B,C,D,E,F}.md`.
+
+---
+
+## Iter 2 — apps/* + Wiki/Docs Staleness (2026-05-28)
+
+**Counts:** 27 NEW findings — E:12 apps, F:15 docs.
+
+### Filed GH issues iter 2
+
+| # | Sev | Title | Source |
+|---|---|---|---|
+| #159 | **P0** | Workspace version drift + missing v0.10.x/v0.11.x git tags — release-flow broken | HS-F-04 + new |
+| #160 | P1 | confidenceFloor killswitch documented but unshipped 2026-05-19 | HS-F-08 |
+| #161 | P2 | Doc-drift bundle: AGENTS/README/CLAUDE/Hot/04-PROJECT-STATE/North Star | HS-F-01/02/05/06/07/09/10/11/12/13/15 |
+| #162 | P1 | AgentResult.debrief missing from public type — 4+ casts; supersedes #158 | HS-E-20/21 + HS-A-19 |
+| #163 | P1 | AgentEvent union not narrowing on `_tag` — 13+ casts in cortex/ui | HS-E-22/23 |
+| #164 | P1 | create-reactive-agent template ships `as any` to users | HS-E-24 |
+
+### 🚨 P0 release-state drift (issue #159)
+
+Three artifacts contradict each other:
+- Root `VERSION` = `0.11.1`
+- `npm view @reactive-agents/core version` = `0.11.1` (published)
+- All 35 `packages/*/package.json` = `0.10.6` (or `0.9.5` for judge-server)
+- Local + remote git tags max at `v0.9.0` (no v0.10.x or v0.11.x tags)
+
+Per memory `feedback_npm_version_drift`: next `bun run release:dry 0.12.0` will fail the drift gate. Per `project_release_flow`: tag-driven flow was bypassed. Either tags were created+deleted, or releases were done via manual `npm publish` (memory says "never do this").
+
+### Cross-app pattern: 2 missing public types
+
+**Root 1:** `AgentResult.debrief` not declared → 4+ casts across CLI + cortex/server (HS-A-19, HS-E-20, HS-E-21). Single 5-LOC fix in `packages/runtime/src/types.ts` resolves all 4 sites + closes #158.
+
+**Root 2:** `AgentEvent` union not discriminated on `_tag` → 13+ casts in cortex/ui chat-store + RunChatTab. Single union refactor resolves the wall.
+
+### apps/* health verdict
+
+| App | State | Notes |
+|---|---|---|
+| apps/cli | 🟢 mostly healthy | 1 shipped-template lie (#164), 2 P2 internal casts |
+| apps/cortex/server | 🟠 needs root-fix (#162) | 11 ts casts; 6 trace to AgentResult.debrief gap |
+| apps/cortex/ui | 🔴 type-lie cluster | 14 ts + 11 svelte casts; AgentEvent narrowing fix needed |
+| apps/meta-agent | 🟢 healthy | clean baseline |
+| apps/examples | 🟠 multiple issue spurs | HS-A-17/18, HS-E-29/30/31 |
+
+### Load-bearing doc lies (HS-F)
+
+1. **HS-F-04 + new** (P0 #159) — release-state drift
+2. **HS-F-08** (P1 #160) — confidenceFloor still documented; fresh agents will re-add
+3. **HS-F-11** (P2 #161) — `04-PROJECT-STATE.md` (the "READ FIRST" doc per AGENTS.md L:145) says "v0.10.0 deferred"; v0.11.1 actually shipped, 30+ days stale
+
+### Iter 2 totals
+
+- **6 new GH issues** (#159-#164)
+- **0 comments on existing** (no overlap)
+- **Build still GREEN** (no regression introduced)
+
+### Combined iter 1+2 totals
+
+- **87 NEW findings** (60 iter 1 + 27 iter 2)
+- **14 new GH issues** (#151-#164)
+- **3 comments on existing** (#77, #78, #87)
+- **1 P0** (#159 release-state)
+- **8 P1**, **5 P2**
+
+---
+
+## Iter 3 — CI/Release Root Cause + Live Test Scan (2026-05-28)
+
+**Counts:** 19 findings — H:13 CI/release flow, I:6 test scan.
+
+### Filed GH issues iter 3
+
+| # | Sev | Title | Source |
+|---|---|---|---|
+| #165 | P2 | Orphan v0.10.7 draft GH release (release-drafter residue) | HS-H-03 |
+| #166 | P1 | MetricsCollectorTag missing in test Layers (WARN noise; potential prod under-counting) | HS-I-02 |
+
+**Comment on #159 (correction + root cause):** Tags DO exist (my iter 2 `git tag | tail -10` only showed 10 entries, missed v0.10.x). Real bug per H: `publish.yml:135-149` "Sync VERSION to main" commits only `VERSION`, not stamped `packages/*/package.json` files. Drift is structural, not accidental.
+
+### #159 Root Cause (per H audit)
+
+`release.ts:197-208` stamps pkg.jsons in ephemeral CI runner; mutations die with runner. Same mechanism stales CHANGELOG. Recommended structural fix: move stamping OUT of CI into local `release.ts` — stamp+commit+push BEFORE tag. CI publish just builds + publishes the already-stamped commit. Drift becomes structurally impossible.
+
+### Live test verdict (I)
+
+**3219/3219 tests GREEN** across 6 most-changed packages (reasoning, runtime, llm-provider, RI, memory, compose). Net +761 since Hot.md's May-23 baseline of 2458. **Zero regressions.** Strongest signal: HS-I-02 MetricsCollectorTag (filed #166); HS-I-06 runtime suite 41s wall (flake risk on slow CI).
+
+### Combined iter 1+2+3 totals
+
+- **106 findings** (60 + 27 + 19)
+- **16 GH issues** (#151-#166)
+- **4 comments on existing** (#77, #78, #87, #159)
+- **1 P0** (#159 + corrected root cause via H)
+- **11 P1, 8 P2**
+- **Build GREEN + tests GREEN (3219/3219)**
+
+---
+
+## Iter 4 — Effect-TS Abstraction + Architecture Drift (2026-05-28)
+
+**Counts:** 20 findings — J:12 Effect-TS, K:8 arch drift.
+
+### Filed GH issues iter 4
+
+| # | Sev | Title | Source |
+|---|---|---|---|
+| #167 | P1 | runtime.ts uses Effect as service locator — RuntimeAssembly + Layer.mergeAll eliminates 38 Layer.merge + 64 ComposableLayer casts | HS-J-01/02/03 |
+| #168 | P1 | 105 `Effect<X, unknown>` sites — silent swallow at type level; tagged-error algebra needed | HS-J-06 |
+| #169 | P1 | Kernel capabilities form mesh with 21 cross-edges + 7 cycles — violates "leaf" principle | HS-K-01 |
+| #170 | P1 | Dead surfaces: @reactive-agents/observe + 5 M12 LocalProviderAdapter hooks (no internal callers) | HS-K-02 + HS-K-08 |
+| #171 | P2 | Manifest/doc drift: AGENTS.md tree omits 7/35 + 2 unused deps + North Star §4.3 stale | HS-K-03/04/06/07 |
+
+### Effect-TS Verdict (J)
+
+**Mid-maturity.** Tag-based services widespread (102 files), Layer composition used, Effect.gen standard. But:
+- **0 SubscriptionRef** despite 409 Ref ops
+- Only **1 acquireRelease** in entire monorepo
+- **105 `Effect<X, unknown>`** sites — silent swallow at type level
+- **28 Effect.runPromise** calls (15 in runtime alone)
+- **7 Effect.gen + try/catch** mixes
+- Persistent `as ComposableLayer` / `as Context.Tag.Service` casts
+
+**Structural insight:** `runtime.ts:479-868` functions as **imperative DI container masquerading as Effect Layer composition** — 38× `runtime = Layer.merge(runtime, X) as ComposableLayer`. Team using Effect as service locator, not type-driven composition. Replace mutable `runtime` with `RuntimeAssembly` collector + `Layer.mergeAll(allPieces)` terminal merge. Eliminates `ComposableLayer` entirely.
+
+### Architecture Drift Verdict (K)
+
+**Mild-to-serious.** Key findings:
+- **K-01 systemic:** kernel capabilities form mesh w/ 7 cycles, violating documented leaf principle
+- **K-02 + K-08 dead surfaces:** `@reactive-agents/observe` pkg has zero internal callers (only docs reference it); 5 M12 adapter hooks ship 270 LOC w/ zero call sites (memory claims removal 2026-05-24 — only 1 of 6 removed)
+- **K-04:** AGENTS.md package tree omits 7/35 packages incl. heavily-used reactive-intelligence (39 inbound consumers)
+- **Doc-sync observation:** inline memory + per-fix CHANGELOGs faithful; central reference docs (AGENTS.md tree, North Star §4.3) write-once-then-drift
+
+**Recommended CI guardrail:** diff `packages/*/package.json` `name` against AGENTS.md "Package Dependency Tree" + fail on missing.
+
+### Combined iter 1+2+3+4 totals
+
+- **126 findings** (60 + 27 + 19 + 20)
+- **21 GH issues** (#151-#171)
+- **4 comments on existing** (#77, #78, #87, #159)
+- **1 P0** (#159 with root cause via H)
+- **15 P1**, **8 P2**
+- **Build GREEN + tests GREEN (3219/3219)**
+
+### Domain coverage
+
+| Domain | Iter | State |
+|---|---|---|
+| packages/* type/dead/bugs/tests | 1 | ✅ covered |
+| apps/* | 2 | ✅ covered |
+| wiki/docs staleness | 2+4 | ✅ covered |
+| CI/release flow | 3 | ✅ covered + root cause |
+| Live tests | 3 | ✅ GREEN baseline |
+| Effect-TS abstraction | 4 | ✅ covered |
+| Architecture drift | 4 | ✅ covered |
+| Live LLM probe | — | not done — expensive, recommend dedicated session |
+| Security deep audit | — | partially (H-09); recommend dedicated session |
+| Memory v2 design review | — | not done — recommend separate session with advisor |
+
+### Domain coverage
+
+| Domain | Iter | State |
+|---|---|---|
+| packages/* type/dead/bugs | 1 | covered (60 findings) |
+| apps/* | 2 | covered (12 findings, 2 root-cause types) |
+| wiki/docs staleness | 2 | covered (15 findings, 1 P0) |
+| CI/release flow | 3 | covered (13 findings, #159 root cause found) |
+| Live tests | 3 | covered (3219 GREEN, 6 findings, 1 P1 actionable) |
+| Effect-TS abstraction audit | — | not done (different lens; recommend separate session) |
+| Security/secrets | — | partially (H-09 token exposure) |
+| Live LLM probe | — | not done (expensive; recommend specific harness session) |
+
+### Recommended Bundle 0 (execute before any other work)
+
+**#159 release-flow fix** — single structural change unblocks future releases:
+1. Local-stamp pattern in `release.ts` (commit pkg.json + CHANGELOG before tag)
+2. CI publish.yml simplified to build+publish-only (no mutations)
+3. Add target-version assertion to `test-clean-install.ts` (HS-H-04) as belt-and-suspenders
+4. Delete v0.10.7 orphan draft (#165)
+5. Backfill workspace pkg.json bumps to 0.11.1 + CHANGELOG entries for v0.10.6→v0.11.1

--- a/wiki/Research/Harness-Reports/improvement-2026-05-28.md
+++ b/wiki/Research/Harness-Reports/improvement-2026-05-28.md
@@ -133,3 +133,52 @@ weakness. qwen3:14b 3pp better overall but inherits the synthesis gap.
   title-citation in paragraph summary) may not match the task's actual
   ask ("categorize by topic"). Reconsider per-task scoring before
   treating T5=0% as a fabrication signal.
+
+---
+
+## Session 2 (2026-05-28 continued)
+
+### Fixes shipped
+
+| Commit | Change | Impact |
+|--------|--------|--------|
+| `a9ba4f8e` | MCP comprehension trio: plan-execute compression, GitHub SHA in preview, compression-echo synthesis | MCP probe: 67% → 84-86% |
+| `ab531990` | Render 6 fields, tighter URL trim, calibration `optimalToolResultChars` 2000→4000 (cogito/qwen3:14b) | Filter task visibility: 8 of 25 → All 25 |
+
+### MCP comprehension probe added
+
+`mcp-comprehension-probe.ts` exercises 5 realistic MCP scenarios via the public
+github MCP server (Docker). Tasks: single-record field, array listing, selective
+filter, multi-tool workflow, error recovery.
+
+### Comprehensive results
+
+| Probe | cogito:14b | qwen3:14b |
+|-------|------------|-----------|
+| MCP probe avg | 84-86% (was 67%) | 79% |
+| Quality-gate avg | 86% | 89% |
+
+### Bottlenecks identified — root-cause classification
+
+| Class | Symptom | Root |
+|-------|---------|------|
+| **Compression visibility** ✅ FIXED | Filter tasks see only first 8 of N items | renderRecord shows 4 fields; budget 2000 too tight for modern context windows |
+| **Code-path asymmetry** ✅ FIXED | Plan-execute fabricates from training data on listing tasks | plan-execute bypassed kernel's compressToolResult |
+| **Synthesis gate blindness** ✅ FIXED | Compression preview echoed as final answer (FM-A2) | decideSynthesisInput skipped compression-marker check on no-format tasks |
+| **MCP field stripping** ✅ FIXED | Model fabricates SHAs on filter tasks | GitHub commit preview omitted SHA field entirely |
+| **Model attention** ⚠️ OUT-OF-SCOPE | cogito:14b ignores `descendants` field even when visible | Local 14b model behavior — not framework |
+| **Long-form synthesis citation** ⚠️ OUT-OF-SCOPE | T5 0% title-citation rate in paragraph summary | Quality-gate metric vs paraphrase mismatch (advisor flagged) |
+| **Classifier wrong tool** 📋 NEXT | "Stars on repo X" classified as web-search not github | LLM classifier lacks task-shape heuristic for owner/repo paths |
+| **`synthesis-grounded` no-op** 📋 NEXT | Fabrication passes verifier | Claim-grounding disabled by default (Stage 5 rollback) |
+
+### Open hypotheses for next session
+
+- **Classifier post-process rule**: when task contains `owner/repo` path AND github
+  tools available, demote web-search from required → relevant. Pure heuristic,
+  no LLM round-trip.
+- **Task-shape gated `synthesis-grounded`**: enable only when
+  `taskIntent.expectedEntities.length > 0`. Lower false-positive surface than the
+  general claim-grounding case Stage 5 rolled back.
+- **Per-tier render-detail calibration**: bump cogito:8b, qwen2.5:14b, llama3:14b
+  to 4000 once individually validated.
+

--- a/wiki/Research/Harness-Reports/improvement-2026-05-28.md
+++ b/wiki/Research/Harness-Reports/improvement-2026-05-28.md
@@ -1,0 +1,135 @@
+---
+title: Harness Improvement Session 2026-05-28
+date: 2026-05-28
+tags: [harness, debugging, fabrication, mcp]
+---
+
+# Harness Improvement Session — 2026-05-28
+
+## Scope
+
+Triggered by spot-test cogito:14b on `github/list_commits` shipping a
+hallucinated `ollama_prices` JSON blob as the final answer. Expanded
+into a multi-probe sweep against cogito:14b + qwen3:14b to find related
+failure modes.
+
+## Fixes shipped this session
+
+### 1. Output poisoning loop (commit 7acbf351)
+
+`guardEvidenceGrounding` rejected legitimate prose answers whose cited
+numbers (e.g. `$77,505`) appeared in raw commit-body text but not in
+the per-step `extractedFact` summary. The loop stalled, harness assembled
+the 131KB raw tool dump as the deliverable, and `output-gate` forced a
+synthesis LLM call that hallucinated unrelated JSON.
+
+- Evidence corpus is now **authoritative** (raw obs ∪ extracted facts).
+- `assembleDeliverable` returns source-tagged `Deliverable`; a substantive
+  trailing thought wins over raw artifacts.
+- New `harness_synthesis` termination reason routes model-authored
+  outputs around the forced re-synthesis path.
+
+### 2. Kernel ToolCallStarted gap (folded into 1c08d73)
+
+Reactive/adaptive strategies were silently dropping tool-selection
+rationale from `debrief.rationale[]`. Only `plan-execute.ts` and the
+runtime `inline-act.ts` published `ToolCallStarted`; the kernel path
+emitted `ToolCallCompleted` from `kernel-hooks.onObservation` but never
+the symmetric start event.
+
+- `KernelHooks.onAction` accepts optional `{ callId, rationale }`.
+- `buildKernelHooks.onAction` publishes `ToolCallStarted` when callId
+  is provided. 9 sites in `act.ts` thread `tc.id` + `tc.rationale`.
+
+### 3. Structured-result fabrication (commit 1c08d73)
+
+`compressToolResult` always truncated array results to `previewItems`
+(8 on local tier) regardless of whether the full row-summary detail
+would fit the byte budget. Listing tasks ("last N commits", "top N
+posts") could not succeed when N > previewItems — the model has a
+recall path but rarely uses it, defaulting to pattern-completing with
+fabricated rows from training data.
+
+- Try-fit pattern: render all rows at title-detail; if joined output +
+  header overhead ≤ budget, emit full list with `All N items:` header.
+- Otherwise fall back to existing previewItems-truncated path with
+  recall hint. Applied to GitHub-commit specialization + generic array.
+
+## Failure modes identified but NOT fixed this session
+
+### F1 — `synthesis-grounded` is structurally a no-op
+
+`validateGeneralizedGrounding` defaults `enableClaimGrounding: false`
+to avoid the 64-73% false-positive rate Stage 5 rolled back. Net
+effect: the check only catches compression-marker echoes — every other
+output trivially passes. cogito:14b T5 traces shipped 0% faithfulness
+(quality-gate measure) with `synthesis-grounded: passed`.
+
+Per advisor review, fixing this requires a discriminating
+hypothesis distinguishing legitimate paraphrase from fabrication. The
+quality-gate's faithfulness metric (cited-titles ratio) and the
+verifier's claim-grounding (substring match) are heuristics for
+different task shapes. Deferred until cross-tier data establishes
+whether the gap is model-behavior or framework-blindness.
+
+### F2 — `output-not-shallow-giveup` patterns too narrow
+
+memory-recall-invocation trace 01KSPAA95TB1VY3AH46TPHWZFW shipped a
+805-byte giveup ("It appears that...", "you may want to...", "since
+this key is unknown") that passed the check. Five literal regex
+patterns miss deflection phrasing.
+
+Adding `you (may|might|should|could) (want to )?(run|call|try)…` would
+catch it, but the AND-with-unusedUserTools guard would still let this
+specific trace pass (model called both web-search AND recall). Needs a
+deflection-detection signal independent of tool usage.
+
+### F3 — Classifier mis-classifies tool requirements
+
+spot-test "How many stars does tylerjrbuell/reactive-agents-ts have?"
+classifier emitted `required: web-search` when the canonical answer
+source is `github/search_repositories`. Model wasted an iteration on
+web-search before pivoting. Affects iteration count + latency.
+
+### F4 — Recall by query when model needs key-lookup
+
+memory-recall-invocation: model called `recall(query: "popular
+javascript frameworks")` (semantic-search mode, returned 0 matches)
+instead of `recall(key: "_tool_result_N")`. Tool description / system
+prompt may not distinguish modes clearly enough for local-tier models.
+
+### F5 — Strategy-switching off by default in spot-test, on in builder
+
+Probe summary showed `interventionsSuppressed > 0` on multiple runs.
+RI evaluator flagged stalls but couldn't dispatch — strategy-switching
+was explicitly disabled (`enableStrategySwitching: false` in
+spot-test.ts). Worth a separate decision: should sensible defaults
+keep it on?
+
+## Cross-tier evidence
+
+| Task | cogito:14b composite | qwen3:14b composite |
+|------|---------------------|---------------------|
+| T1-knowledge-recall    | 100% | 100% |
+| T2-single-tool         | 100% | 100% |
+| T3-selective-filter    | 67-77% | 88% |
+| T4-multi-criteria      | 91% | 91% |
+| T5-long-form-synthesis | 65-70% | 65% |
+| **avg** | 85-87% | 89% |
+
+T5 is universally weak (both tiers ≤ 70%). T3 is cogito-specific
+weakness. qwen3:14b 3pp better overall but inherits the synthesis gap.
+
+## Open hypotheses for next session
+
+- **F1 with task-shape gating**: enable claim-grounding only when
+  `taskIntent.expectedEntities.length > 0` (specific named entities).
+  Lower false-positive surface than generic enumeration heuristic.
+  Validate on T3 (selective filter on named criterion) before broader.
+- **F3 classifier rules**: when task contains repo path like
+  `owner/repo` AND github tools available, classify `github/*` as
+  required, not web-search.
+- **Quality-gate scoring revision**: T5's faithfulness metric (literal
+  title-citation in paragraph summary) may not match the task's actual
+  ask ("categorize by topic"). Reconsider per-task scoring before
+  treating T5=0% as a fabrication signal.

--- a/wiki/Research/Mastra-Comparison-2026-05-25.md
+++ b/wiki/Research/Mastra-Comparison-2026-05-25.md
@@ -1,0 +1,164 @@
+---
+tags: [benchmark, comparison, mastra, competitive-analysis, private]
+date: 2026-05-25
+status: complete (v1, private)
+public: false
+mastra-version: 1.36.0 (current Agent.generate() + createTool() + AI SDK v5)
+ra-version: 0.11.1 + PR #141 (workspace HEAD)
+total-cells: 66 (11 tasks × 2 frameworks × 3 tiers)
+---
+
+# Reactive Agents vs Mastra — Head-to-Head Benchmark (private)
+
+**Status:** Internal characterization. Decide publish y/n after review.
+
+**Headline:** RA wins correctness in every tier (33/33 vs Mastra 27/33). Mastra wins efficiency on every tier except frontier (where token usage breaks even). Both frameworks have real weaknesses surfaced by the corpus.
+
+## Methodology
+
+- **Frameworks**
+  - **Reactive Agents** v0.11.1 (workspace HEAD, includes PR #141 empty-run invariant). `withReasoning({ defaultStrategy: "reactive" })`. No `.withReactiveIntelligence()` (Mastra has no equivalent — kept fair).
+  - **Mastra** v1.36.0 — `new Agent({...}).generate(prompt, { stopWhen: stepCountIs(N) })`. Current API per docs (not deprecated `generateLegacy()`). AI SDK v5 stack: `@ai-sdk/anthropic@3.0.79`, `@ai-sdk/openai@3.0.65`, `ollama-ai-provider-v2@1.5.5`, `ai@6.0.191`. Tools defined via `createTool({ id, description, inputSchema, execute })`.
+- **Fairness fixes applied**
+  - Bench tools renamed with `bench_` prefix (`bench_web_search`, `bench_lookup`, `bench_calculator`) to avoid name collision with RA's built-in tools. RA's `web-search` built-in shadowed the synthetic bench tool in v1 (documented at `packages/tools/src/skills/builtin.ts:178` — known RA bug).
+  - Both frameworks see identical tool names, descriptions, parameters, behaviors.
+- **Tiers**
+  - `frontier` — Anthropic `claude-sonnet-4-6` ($3/$15 per 1M tokens)
+  - `mini` — OpenAI `gpt-4o-mini` ($0.15/$0.60 per 1M tokens)
+  - `local` — Ollama `qwen3.5:latest` (free)
+- **Tasks** — 11 across 5 categories: knowledge (3), tool-required (3), multi-step (2), critique (1), failure-recovery (2). See `bench/mastra-vs-ra/tasks.ts`.
+- **Verifier** — deterministic substring / regex / long-form rubrics (no LLM-as-judge variance).
+- **Budget** — 180s per-cell timeout.
+- **Total cells** — 66 (11 × 2 × 3).
+
+## Per-tier summary
+
+| tier | framework | pass/N | tokens (in+out) | $cost | avg dur |
+|---|---|---|---|---|---|
+| frontier | **ra** | **11/11** | 17965 (0+17965) | $0.2695 | 23.7s |
+| frontier | mastra | 9/11 | 18770 (9085+9685) | $0.1725 | 17.6s |
+| mini | **ra** | **11/11** | 38232 (0+38232) | $0.0229 | 15.7s |
+| mini | mastra | 9/11 | 5145 (3073+2072) | $0.0017 | 6.5s |
+| local | **ra** | **11/11** | 42499 (0+42499) | $0.0000 | 20.5s |
+| local | mastra | 9/11 | 7547 (4534+3013) | $0.0000 | 5.8s |
+
+> RA's `tokens` is total-only (no input/output split surfaced in `result.metadata.tokensUsed`). Cost computed from total × output-rate which inflates the $ comparison against RA. With a proper input/output split, RA's frontier $0.27 would drop closer to ~$0.18 — still above Mastra's $0.17. This is a real RA observability gap, flagged as follow-up.
+
+## Per-category aggregate (across all tiers)
+
+| category | ra pass | mastra pass | ra avg tok | mastra avg tok | ra/mastra tok |
+|---|---|---|---|---|---|
+| knowledge | 9/9 | 9/9 | 526 | 148 | 3.55× |
+| tool-required | **9/9** | 6/9 | 4664 | 1104 | 4.22× |
+| multi-step | **6/6** | 3/6 | 2606 | 1773 | 1.47× |
+| critique | 3/3 | 3/3 | 1651 | 1598 | 1.03× |
+| failure-recovery | 6/6 | 6/6 | 5232 | 795 | 6.58× |
+
+**Three real findings:**
+
+1. **Mastra fails 50% on multi-step + 33% on tool-required.** Both losses are the same shape: agent calls tool, receives `{key, value}` shaped result, then **fails to echo the value verbatim** in final answer. Two tasks, three tiers, six consistent failures.
+2. **RA wins correctness on every tier (11/11 each = 33/33).** Mastra wins only knowledge and critique categories — categories where no tool is involved. The moment a tool result needs to flow into output, RA pulls ahead.
+3. **RA's token overhead collapses from 6× at local → 4× at mini → 1× at frontier.** Frontier Sonnet uses fewer iterations to converge, amortizing RA's kernel overhead. At frontier RA is actually 4% MORE token-efficient than Mastra.
+
+## Per-task winners (frontier tier, for the report's headline)
+
+| task | category | ra | mastra | winner |
+|---|---|---|---|---|
+| k1-france-capital | knowledge | ✓ 428tok 4.6s | ✓ 43tok 0.9s | Mastra (efficiency) |
+| k2-typescript-paradigm | knowledge | ✓ 861tok 13.9s | ✓ 574tok 9.1s | Mastra (efficiency) |
+| k3-rgb-colors | knowledge | ✓ 458tok 5.1s | ✓ 93tok 1.7s | Mastra (efficiency) |
+| t1-calculator-add | tool-required | ✓ 1334tok 15.8s | ✓ 1466tok 2.7s | Mastra (efficiency) |
+| t2-web-search-cite | tool-required | ✓ 2885tok 31.1s | ✓ 2849tok 14.2s | Mastra (efficiency) |
+| **t3-kv-fetch** | tool-required | ✓ 1010tok 13.9s | **✗** 1511tok 3.9s | **RA** |
+| **m1-database-indexes** | multi-step | ✓ 3217tok 63.5s | ✓ 5268tok 95.3s | **RA (efficiency)** |
+| **m2-version-then-cite** | multi-step | ✓ 1163tok 21.7s | **✗** 1698tok 6.3s | **RA** |
+| c1-eventual-vs-strong | critique | ✓ 2586tok 52.4s | ✓ 2486tok 50.6s | tie |
+| f1-web-search-error | failure-recovery | ✓ 3531tok 33.2s | ✓ 2687tok 7.4s | Mastra (efficiency) |
+| f2-no-tool-knowledge-recovery | failure-recovery | ✓ 492tok 5.1s | ✓ 95tok 1.1s | Mastra (efficiency) |
+
+## Mastra's consistent weakness — exact-extract from tool results
+
+Both Mastra failures repeat on every tier:
+
+- **t3-kv-fetch:** task `"fetch value for key 'api-endpoint'. Return only the value."` → tool returns `{key: "api-endpoint", value: "https://api.example.com/v2"}` → Mastra's final answer **doesn't include the URL**. Failed at frontier (Sonnet), mini (gpt-4o-mini), local (qwen3.5).
+- **m2-version-then-cite:** task `"get value for key 'api-version'. ... Final answer should include both the version number AND the explanation."` → tool returns `{key, value: "2.4.1"}` → Mastra explains semver but **omits the version number**. Failed at all 3 tiers.
+
+3-tier consistency = real architectural weakness, not model variance. Mastra agents have a pattern of describing what they found instead of citing it verbatim. Could be in their default system prompt, instruction template, or tool-result framing.
+
+RA handles both cleanly across all tiers (3+3 successes vs Mastra's 0+0).
+
+## RA's consistent weakness — token overhead on simple tasks
+
+Local + mini knowledge tasks: RA uses **3-12× more tokens** for the same single-word answer.
+
+- `k1-france-capital` frontier: RA 428 tokens / 4.6s vs Mastra 43 tokens / 0.9s.
+- `k3-rgb-colors` local: RA 587 tokens / 10.9s vs Mastra 83 tokens / 2.9s.
+
+Root cause: RA's reactive kernel runs a full think→act→verify cycle on every iteration. For pure knowledge recall, the answer is in the first LLM response — kernel iterations + entropy scoring + verifier checks are all overhead.
+
+The earlier improvement-loop session (2026-05-25) named this **affordance leakage** — every framework surface fires by default regardless of per-task relevance. Today's evidence confirms it shows up as token waste on simple tasks.
+
+## RA's spectacular failure on failure-recovery local
+
+`f1-web-search-error` on local tier: RA 12220 tokens / 29.4s vs Mastra 1294 tokens / 4.3s. **9.4× tokens, 6.8× duration**, both pass.
+
+Both produced "cannot/unable" text so the bench verifier passed both. But RA spent 6 iterations retrying the (always-erroring) tool while RI's healing pipeline injected redirects to `crypto-price` (an irrelevant built-in RA tool). Mastra honored the prompt's "stop after 2 attempts" rule cleanly.
+
+Confirms FM-A3 root cause is broader than my PR #141 backstop addresses — the affordance leakage problem applies to RA's healing pipeline too (it suggested `crypto-price` because that's another built-in tool, regardless of task scope).
+
+## Where each framework wins / loses
+
+### Reactive Agents wins
+
+- **Tool-result fidelity** — exact-extract tasks across all 3 tiers (3 wins, 0 losses; Mastra 0 wins, 3 losses)
+- **Multi-step coherence** — m1 + m2 wins at every tier
+- **Frontier-tier token efficiency** — only 1.03× tokens vs Mastra (essentially tied)
+- **Honest never-fail across tiers** — 33/33 perfect score
+- **Trace-grade observability** — `rax-diagnose` lets you replay any run, query event kinds, diff before/after
+- **Strategy diversity available** (reactive, plan-execute-reflect, reflexion, ToT, code-action) — not exercised in this bench but real capability
+
+### Mastra wins
+
+- **Latency** on every category except multi-step — 3-10× faster on knowledge / tool / critique / failure-recovery
+- **Token efficiency** at local + mini tier — 4-7× cheaper across categories
+- **Dollar cost** at every tier — 12-14× cheaper at frontier+mini, free at local
+- **Surface simplicity** — `new Agent({instructions, model, tools}).generate(prompt)` vs RA's `ReactiveAgents.create().withName().withProvider().withModel().withReasoning().withTools().build()`
+- **Honest failure response** on f1 — followed the prompt's "stop after 2 attempts" without RI overreach
+
+### Both lose
+
+- **Mastra:** exact-extract from structured tool results (3-tier consistent)
+- **RA:** token bloat on simple tasks (3-12× on knowledge / tool-required at local + mini tiers); spurious tool engagement (FM-A3) at local tier despite PR #141 backstop
+
+## Recommendation — DO NOT publish v1
+
+Reasons to hold:
+
+1. **N=11 tasks is too small** for HN/Twitter-grade publication. A skeptic will accuse cherry-picking on either side. Need 30-50 tasks.
+2. **Cost comparison is unfair to RA** because RA's `metadata.tokensUsed` doesn't surface input/output split. Cost calculation inflates RA's $ at frontier. Fix the RA metadata before publishing any cost-comparison number.
+3. **Mastra's exact-extract failure is too clean a result.** Public publish would look like we hand-picked a category Mastra is bad at. Need to also test categories Mastra is reputed strong at (workflow orchestration, structured output schemas).
+4. **The "RA wins correctness" headline obscures the affordance-leakage finding** — RA's token overhead is real and consumer-visible. Publishing the win without owning the loss damages credibility.
+
+Reasons to consider publishing later:
+
+- After N≥30 tasks (add workflow-style multi-agent, schema-validated structured output, real web search with TAVILY key, conversational memory across turns)
+- After fixing RA's input/output token metadata split
+- After adding LLM-as-judge verifier so subjective categories (critique quality, long-form depth) aren't gated by substring matchers
+- After landing FM-A3 root cause fix (per-task tool relevance gating) so the local-tier token bloat narrows
+
+## Followup work (filed as tasks)
+
+1. **RA `metadata.tokensUsed` surface input/output split** — current 0+totalTokens is misleading for cost calc. Estimate: ~5 LOC at finalize/telemetry-emit.
+2. **FM-A3 root cause — per-task tool relevance gating** — `find` / `web-search` / `crypto-price` shouldn't auto-inject on tasks with `tools: []` or unrelated tools. Empirical evidence: this bench's f1 local cell.
+3. **Add 20+ tasks to bench corpus** before any public comparison. Categories to add: structured output (Zod schema), workflow (multi-agent handoff), real-web-search (with API key), conversational memory (multi-turn), tool-result piping (multiple tools chained).
+4. **Wire LLM-as-judge verifier** for critique + long-form categories. Optional `@mastra/evals` integration to leverage their pre-built metrics.
+5. **Mastra exact-extract investigation** — possibly an upstream issue worth reporting / blogging about. Reproducible 3-tier failure.
+
+## Files
+
+- `bench/mastra-vs-ra/` — runner + corpus + verifier + tools (private, not in release)
+- `bench/mastra-vs-ra/results/cells-2026-05-26T01-12-15-194Z.json` — frontier raw
+- `bench/mastra-vs-ra/results/cells-2026-05-26T01-08-29-073Z.json` — mini raw
+- `bench/mastra-vs-ra/results/cells-2026-05-26T01-07-38-596Z.json` — local raw
+- `bench/mastra-vs-ra/analyze.ts` — analysis helper
+- `bench/mastra-vs-ra/README.md` — bench operation guide

--- a/wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md
+++ b/wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md
@@ -1,0 +1,230 @@
+# Drift-state baseline — 2026-05-28
+
+**Auditor:** release-warden (Phase 0)
+**Branch:** main
+**HEAD SHA:** `631ecfc31be37f2cdc1cbde5d11a76e11bd72bb3`
+**Adjudicated policy:** (a) history-accurate — tags resolved via `npm view ... gitHead`
+**Scope:** read-only audit; no production files modified.
+
+## ⚠️ Premise correction (must read first)
+
+The MissionBrief stated:
+
+> "git tags max at v0.9.0"
+> "Cannot tag v0.10.6 or v0.11.1 without the actual published gitHead SHAs"
+
+**Both claims are false at HEAD.**
+
+- Tags **v0.10.0, v0.10.1, v0.10.2, v0.10.4, v0.10.6, v0.11.0, v0.11.1** ALL exist locally.
+- The tags **already point to the npm-published `gitHead` commits** (verified for 10/35 packages × 2 versions; perfect consistency).
+- There is therefore **nothing to back-fill**. WS-1's tag-backfill premise needs re-evaluation before any executor acts on it.
+
+The remaining "drift" is *intra-repo*, not tag-vs-npm:
+- Root `VERSION` + root `package.json.version` = **0.11.1**
+- `npm @reactive-agents/core@latest` = **0.11.1**
+- Workspace `packages/*/package.json.version` = **0.10.6** (34 of 35 pkgs) / **0.9.5** (judge-server only)
+
+This pattern is exactly what `release.ts` *produces by design* (per its own comment, lines 205-208): the script writes a new `VERSION` file but **does not** bump the workspace `package.json` files — the publish.yml tag-driven flow is supposed to sync `VERSION` back to main "so `cat VERSION` always matches npm @latest (repo package.json stays unbumped by the tag-driven flow)." In other words: workspace 0.10.6 + VERSION 0.11.1 + npm 0.11.1 is the **expected steady-state** of the release flow, not a defect.
+
+What IS a defect: `@reactive-agents/judge-server` package.json shows `0.9.5` — a drift OF the drift floor (one package out of step with the others' 0.10.6). And the npm registry has no `judge-server` package at all (404 on any version) — it appears to be `"private": true` or simply never published.
+
+---
+
+## 1. All 35 packages × workspace version × npm @latest
+
+`npm view <pkg> version` against the production registry (queried 2026-05-28).
+
+| # | Package | workspace pkg.json | npm @latest | delta |
+|---|---|---|---|---|
+| 1 | @reactive-agents/a2a | 0.10.6 | 0.11.1 | ✔ workspace lag (expected) |
+| 2 | @reactive-agents/benchmarks | 0.10.6 | — (private) | n/a |
+| 3 | @reactive-agents/channels | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 4 | @reactive-agents/compose | 0.10.6 | 0.11.1 | ✔ workspace lag (not at 0.10.6 on npm; first pub at 0.11.1) |
+| 5 | @reactive-agents/core | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 6 | @reactive-agents/cost | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 7 | create-reactive-agent | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 8 | @reactive-agents/diagnose | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 9 | @reactive-agents/eval | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 10 | @reactive-agents/gateway | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 11 | @reactive-agents/guardrails | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 12 | @reactive-agents/health | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 13 | @reactive-agents/identity | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 14 | @reactive-agents/interaction | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 15 | **@reactive-agents/judge-server** | **0.9.5** | **— (not on npm)** | **⚠ DRIFT: 0.10.6 floor missed; never published** |
+| 16 | @reactive-agents/llm-provider | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 17 | @reactive-agents/memory | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 18 | @reactive-agents/observability | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 19 | @reactive-agents/observe | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 20 | @reactive-agents/orchestration | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 21 | @reactive-agents/prompts | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 22 | @reactive-agents/react | 0.10.6 | 0.11.1 | ✔ workspace lag (first pub at 0.11.1) |
+| 23 | @reactive-agents/reactive-intelligence | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 24 | reactive-agents (umbrella) | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 25 | @reactive-agents/reasoning | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 26 | @reactive-agents/replay | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 27 | @reactive-agents/runtime | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 28 | @reactive-agents/runtime-shim | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 29 | @reactive-agents/scenarios | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 30 | @reactive-agents/svelte | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 31 | @reactive-agents/testing | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 32 | @reactive-agents/tools | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 33 | @reactive-agents/trace | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 34 | @reactive-agents/verification | 0.10.6 | 0.11.1 | ✔ workspace lag |
+| 35 | @reactive-agents/vue | 0.10.6 | 0.11.1 | ✔ workspace lag |
+
+`"✔ workspace lag"` = expected by the design of `scripts/release.ts:205-208`: workspace package.json files are intentionally not bumped post-release. The single real anomaly is **judge-server**.
+
+## 2. Root VERSION file
+
+```
+0.11.1
+```
+
+(also `package.json.version` = `0.11.1`, name = `reactive-agents`)
+
+## 3. Git tag state
+
+Full list of `v0.*` tags (sorted with `sort -V`):
+
+```
+v0.1.0    v0.2.0    v0.2.1    v0.3.0    v0.3.1    v0.4.0
+v0.5.0    v0.5.2    v0.5.3    v0.5.4    v0.5.5    v0.5.6
+v0.6.0    v0.6.1    v0.6.2    v0.6.3
+v0.7.0    v0.7.5    v0.7.6    v0.7.8
+v0.8.0
+v0.9.0
+v0.10.0   v0.10.1   v0.10.2   v0.10.4   v0.10.6
+v0.11.0   v0.11.1
+```
+
+**Max tag in repo: `v0.11.1`** (not v0.9.0 as the MissionBrief asserted).
+
+Tag types + the commits they resolve to:
+
+| Tag | type | tag-object SHA | resolved commit (`v^{commit}`) | commit subject |
+|---|---|---|---|---|
+| v0.11.1 | annotated | `cab7ced8588f52a3eddb3b63eb0fc852ef790019` | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` | `docs(agents): note VERSION source-of-truth + release:dry self-clean` |
+| v0.10.6 | lightweight | `f17da8ec159f01ec716c895d6c27e924da01ade4` | `f17da8ec159f01ec716c895d6c27e924da01ade4` | `chore: version packages` |
+
+(`rtk git rev-parse v0.11.1` returns the tag-object SHA, not the commit — that is why a naive comparison against `npm gitHead` appears to mismatch. `v0.11.1^{commit}` dereferences correctly.)
+
+## 4. Per-version `gitHead` resolution (npm registry)
+
+Sample: 10 packages × 2 versions = 20 queries.
+
+### v0.10.6 (`npm view @reactive-agents/<pkg>@0.10.6 gitHead`)
+| package | gitHead |
+|---|---|
+| core | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| runtime | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| reasoning | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| llm-provider | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| memory | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| tools | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| reactive-intelligence | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| diagnose | `f17da8ec159f01ec716c895d6c27e924da01ade4` |
+| compose | NOT PUBLISHED at 0.10.6 (first appeared 0.11.1) |
+| react | NOT PUBLISHED at 0.10.6 (first appeared 0.11.1) |
+
+### v0.11.1 (`npm view @reactive-agents/<pkg>@0.11.1 gitHead`)
+| package | gitHead |
+|---|---|
+| core | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| runtime | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| reasoning | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| llm-provider | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| memory | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| tools | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| compose | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| react | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| reactive-intelligence | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+| diagnose | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` |
+
+**Cross-package consistency:** ✅ Perfect within each version. All sampled packages share one gitHead per release. No structural divergence to adjudicate.
+
+**Tag-vs-npm consistency:**
+- v0.11.1 tag → commit `6bd11d6c…` ≡ npm gitHead `6bd11d6c…` ✅
+- v0.10.6 tag → commit `f17da8ec…` ≡ npm gitHead `f17da8ec…` ✅
+
+## 5. `bun run release:dry 0.12.0` against current main
+
+```
+$ bun scripts/release.ts --dry-run "0.12.0"
+error: not logged in to npm (`npm whoami` failed). Run `npm login` first.
+error: script "release:dry" exited with code 1
+```
+
+Exit code: 1 (the outer `bun run` wrapper masked this as 0 in the shell `$?` but the script itself printed `code 1`).
+
+**Important:** the script fails at the `npm whoami` gate (`scripts/release.ts:65-66`) **before** doing any drift inspection. Reading the script confirms there is no separate "drift gate" prior to auth: drift is "structurally prevented" by the script stamping all packages itself to one version, not detected. So the brief's expectation "FAIL with drift error" is not what this script produces — it fails on auth first, drift never gets inspected. If we want a true drift gate before auth, that's a script change (out of release-warden authority).
+
+## 6. Gate baseline at HEAD
+
+| Gate | Command | Status | Notes |
+|---|---|---|---|
+| Build | `bunx turbo run build` | ✅ PASS | 38/38 successful, 37 cached, 31.95s |
+| Tests | `bun test` | ✅ PASS | 5750 pass / 23 skip / **0 fail**, 14138 expects, 659 files, 76.12s (5773 ran — above brief's ≥3219 expectation) |
+| Typecheck | `bun run typecheck` | ❌ **FAIL** | `@reactive-agents/verification` tests/{hallucination-detection,layers}.test.ts reference outdated `VerificationLLM` shape missing `embed` property — 8+ TS2345 errors |
+| release:dry | `bun run release:dry 0.12.0` | ❌ FAIL (auth) | Cannot exercise drift logic without `npm login`; not a drift signal |
+
+### Typecheck failure detail
+
+```
+packages/verification/tests/hallucination-detection.test.ts(145,9): error TS2345:
+  Argument of type '{ complete: (_req: any) => Effect.Effect<{ content: string; }, never, never>; }'
+  is not assignable to parameter of type 'VerificationLLM'.
+  Property 'embed' is missing ...
+packages/verification/tests/layers.test.ts(76,77): error TS2345: ...same...
+```
+
+8 errors total across two test files. This is *test-file* drift: the production `VerificationLLM` type gained a required `embed` method but the unit-test fakes weren't updated. This blocks the release-warden manifest's "Typecheck clean" gate condition. Either fix the test fakes (one-line `embed: () => Effect.succeed([])`) or escalate.
+
+## 7. Recommendation block
+
+### Tag-backfill SHAs
+
+Given history-accurate policy (a):
+
+| Tag desired | Recommended SHA | Rationale |
+|---|---|---|
+| v0.10.6 | `f17da8ec159f01ec716c895d6c27e924da01ade4` | Matches npm `gitHead` across all 8 sampled packages; **tag already exists at this commit** — no action required |
+| v0.11.1 | `6bd11d6cae905d44cdddf51cd4891572a1e96b99` | Matches npm `gitHead` across all 10 sampled packages; **tag already exists at this commit** (annotated) — no action required |
+
+### Cross-package SHA divergence flag
+
+**None.** Per-version gitHeads are perfectly consistent within the 10-package sample. The lockstep publisher does the right thing.
+
+### Findings the executor MUST consider before WS-1 fires
+
+1. **WS-1's tag-backfill premise is invalid at HEAD.** Tags for both v0.10.6 and v0.11.1 already exist locally and already point to the npm gitHeads. Before WS-1 stamps or pushes anything, re-confirm whether those tags exist on `origin` — they may already be present remotely too. Check with `rtk git ls-remote --tags origin v0.10.6 v0.11.1`. If yes, WS-1 is a no-op and should be closed.
+
+2. **The real drift is `judge-server@0.9.5`.** This package's `version` field never advanced past 0.9.5 and the package isn't on npm. Either:
+   - (a) it's intentionally private and the version is cosmetic — set `"private": true` and lockstep-stamp it
+   - (b) it should publish — fix the publish config + start including it in the lockstep
+   This is a user adjudication, not a warden action.
+
+3. **The drift `release.ts` is supposed to gate against is not gateable at current state.** The script bails on `npm whoami` before reading anything. To actually exercise the drift check via dry-run, either: (a) `npm login` and re-run, or (b) edit `release.ts` to move the drift inspection ahead of the auth check. Both are out of warden authority — escalate if WS-1 needs `release:dry` to actually run.
+
+4. **Typecheck is RED at HEAD.** Per the warden manifest, "Typecheck clean" is a mandatory gate condition. Build is green (and manifest notes build is authoritative for `ignoreDeprecations` false positives), but these `verification` failures are NOT a `"6.0"` false positive — they are real type mismatches in test files. The release-warden gate fails today. A new tag (e.g. v0.12.0) cannot be cut without either fixing the test fakes (`packages/verification/tests/hallucination-detection.test.ts` lines 145, 162, 176, 192 and `packages/verification/tests/layers.test.ts` lines 76, 97, 118, 139) or amending the gate scope. Escalate.
+
+5. **Brief's stated baseline numbers re-confirm.** `bun test` is well above the brief's ≥3219 floor (5750 pass). Build hits 38/38. The repo is "ship-ready" except for the typecheck regression in verification tests.
+
+---
+
+## Appendix — Commands run (verbatim)
+
+```bash
+cat VERSION                                              # → 0.11.1
+grep version package.json (root)                         # → 0.11.1, name reactive-agents
+rtk git tag --list 'v*' | sort -V                        # → 29 tags v0.1.0…v0.11.1
+ls packages/ | wc -l                                     # → 35
+rtk git rev-parse v0.11.1 v0.10.6 HEAD                   # tag-object SHAs + HEAD
+rtk git rev-parse v0.11.1^{commit} v0.10.6^{commit}      # commit SHAs
+rtk git cat-file -t v0.11.1 v0.10.6                      # tag / commit
+npm view @reactive-agents/<pkg>@<ver> version gitHead    # × 20 (10 pkgs × 2 vers)
+bunx turbo run build                                     # → 38/38 PASS, exit 0
+bun run typecheck                                        # → FAIL on @reactive-agents/verification, exit 2
+bun test                                                 # → 5750 pass / 23 skip / 0 fail, exit 0
+bun run release:dry 0.12.0                               # → fails at npm whoami gate, exit 1
+```
+


### PR DESCRIPTION
## Summary

WS-1 revised scope per `wiki/Planning/Implementation-Plans/2026-05-28-ws-1-release-flow-integrity.md` (rewritten 2026-05-28 evening after release-warden Phase 0 audit invalidated original framing).

**Original WS-1 framing was wrong.** Warden audit (`wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md`) verified:
- Workspace `packages/*/package.json` at 0.10.6 vs root VERSION 0.11.1 is INTENTIONAL steady-state per `release.ts:205-208` comment ("so `cat VERSION` always matches npm @latest")
- All v0.10.0–v0.11.1 git tags exist on origin already + deref to npm `gitHead`
- Release flow works in steady state; 4 residual defects exist

This PR ships the 4 residual fixes + 1 bonus (RI typecheck same-class).

## Fixes

### Fix 1 — VerificationLLM mock embed stubs (F2)
- `packages/verification/tests/hallucination-detection.test.ts` (4 mocks at lines 130-200)
- `packages/verification/tests/layers.test.ts` (4 mocks at lines 65-150)
- Each mock missing required `embed` method per `VerificationLLM` type
- Stub: `embed: (_texts: readonly string[], _model?: string) => Effect.succeed([] as readonly (readonly number[])[])`

### Fix 2 — judge-server lockstep (F3)
- `packages/judge-server/package.json`: version 0.9.5 → 0.10.6
- `private: true` already set; stays internal/unpublished

### Fix 3 — release.ts dry-run gate (F4)
- `scripts/release.ts:62-68` guards `npm whoami` with `if (!dryRun && !noPublish)`
- `bun run release:dry <ver>` now functions as drift gate WITHOUT requiring `npm login`
- Real publish path still requires auth (unchanged)

### Fix bonus — reactive-intelligence typecheck stubs
- `packages/reactive-intelligence/tests/controller/dispatcher-compose-bridge.test.ts`
- 8 TS errors resolved (TS2353 stale `token` field, TS7006 implicit any × 5, TS2322 push-returns-number × 4)
- Same class as Fix 1 (mock shape drift); fixed for completeness

## Verified-by table (before / after)

| Gate | Before | After |
|---|---|---|
| `bunx turbo run build` | 38/38 ✅ | 38/38 ✅ |
| `bun test` workspace | 5750 pass / 23 skip / 0 fail | 5750 pass / 23 skip / 0 fail |
| `packages/verification` typecheck | ❌ 8 TS2345 errors | ✅ clean |
| `packages/reactive-intelligence` typecheck | ❌ 8 errors | ✅ clean |
| `packages/testing#typecheck` | ❌ 1 TS2322 error | ❌ STILL RED (out of WS-1 scope; see Residuals) |
| `grep '"version": "0.10.6"' packages/judge-server/package.json` | 0 | 1 ✅ |
| `grep '"private": true' packages/judge-server/package.json` | 1 (already set) | 1 ✅ |
| `bun scripts/release.ts 0.11.1 --dry-run` (no npm login) | ❌ bails at `npm whoami` | ✅ "nothing to do — all 35 packages already at 0.11.1" (clean exit) |

## Residuals (out of WS-1 scope)

- **`packages/testing#typecheck` REMAINS RED.** File: `src/gate/scenarios/cf-24-all-termination-flows-through-arbitrator.ts:100`. The test passes `via: undefined` to `arbitrate({ kind: "agent-final-answer", via: undefined, ... })` per Lever 8 (2026-05-26) but `TerminationIntent` type only accepts `via: "tool" | "regex" | "end-turn"`. This is a design-decision question (widen the type vs change the test semantics) requiring a separate issue — not a mechanical typecheck fix.
- **`gh release delete v0.10.7`** — requires user auth on gh CLI; not yet executed.
- **`gh issue close 159 --comment "..."`** — requires user auth; not yet executed.

## Closes

- Part of WS-1 per master plan §3.4 RC-5 REVISED
- Closes #162 prereq (workspace typecheck must be near-clean for WS-2 to land safely)

## Master plan refs

- `wiki/Planning/Implementation-Plans/2026-05-28-canonical-refactor.md` §3.4 RC-5 REVISED + §4 mechanism table + §6.2 WS-1 summary REVISED + §11 amendment 4
- `wiki/Planning/Implementation-Plans/2026-05-28-ws-1-release-flow-integrity.md` (thin spec, full rewrite)
- `wiki/Research/Release-Audits/0.11.1-current-drift-2026-05-28.md` (warden Phase 0 audit baseline)