### PR TITLE
refactor(reasoning): WS-3 Phase 2 — move tool-gating Act→Decide (RC-2)

### DIFF
--- a/packages/reasoning/src/context/context-manager.ts
+++ b/packages/reasoning/src/context/context-manager.ts
@@ -22,7 +22,7 @@ import {
 } from "../kernel/capabilities/attend/context-utils.js";
 import {
   type ToolElaborationInjectionConfig,
-} from "../kernel/capabilities/act/tool-gating.js";
+} from "../kernel/capabilities/decide/tool-gating.js";
 import { classifyTask } from "../kernel/capabilities/comprehend/task-classification.js";
 import { composePrompt } from "./prompt-composer.js";
 import {

--- a/packages/reasoning/src/context/prompt-sections-default.ts
+++ b/packages/reasoning/src/context/prompt-sections-default.ts
@@ -33,7 +33,7 @@ import {
 import {
   buildToolElaborationInjection,
   type ToolElaborationInjectionConfig,
-} from "../kernel/capabilities/act/tool-gating.js";
+} from "../kernel/capabilities/decide/tool-gating.js";
 import { buildStaticContext } from "./context-engine.js";
 import type { GuidanceContext } from "./context-manager.js";
 import type {

--- a/packages/reasoning/src/index.ts
+++ b/packages/reasoning/src/index.ts
@@ -161,7 +161,7 @@ export type { KernelMetaToolsConfig } from "./types/kernel-meta-tools.js";
 
 // ─── Shared Utilities ───
 export { filterToolsByRelevance } from "./kernel/capabilities/attend/tool-formatting.js";
-export { planNextMoveBatches } from "./kernel/capabilities/act/tool-gating.js";
+export { planNextMoveBatches } from "./kernel/capabilities/decide/tool-gating.js";
 export type { ToolSchema, ToolParamSchema } from "./kernel/capabilities/attend/tool-formatting.js";
 export type { KernelMessage, EntropyScoreLike } from "./kernel/state/kernel-state.js";
 export { META_TOOLS, INTROSPECTION_META_TOOLS } from "./kernel/state/kernel-constants.js";

--- a/packages/reasoning/src/kernel/capabilities/act/act.ts
+++ b/packages/reasoning/src/kernel/capabilities/act/act.ts
@@ -49,7 +49,7 @@ import {
 } from "../../../kernel/state/kernel-state.js";
 import { runPhaseHooks, killswitchTerminatedBy } from "../../../kernel/loop/phase-hooks.js";
 import { emitToCompose } from "@reactive-agents/core";
-import { planNextMoveBatches } from "../act/tool-gating.js";
+import { planNextMoveBatches } from "../decide/tool-gating.js";
 import {
   buildSuccessfulToolCallCounts,
   getMissingRequiredToolsByCount,

--- a/packages/reasoning/src/kernel/capabilities/act/guard.ts
+++ b/packages/reasoning/src/kernel/capabilities/act/guard.ts
@@ -9,7 +9,7 @@
  */
 import type { KernelState, KernelInput } from "../../../kernel/state/kernel-state.js";
 import type { ToolCallSpec } from "@reactive-agents/tools";
-import { isParallelBatchSafeTool } from "../act/tool-gating.js";
+import { isParallelBatchSafeTool } from "../decide/tool-gating.js";
 import {
   buildSuccessfulToolCallCounts,
   getMissingRequiredToolsByCount,

--- a/packages/reasoning/src/kernel/capabilities/decide/tool-gating.ts
+++ b/packages/reasoning/src/kernel/capabilities/decide/tool-gating.ts
@@ -1,4 +1,17 @@
 /**
+ * Tool gating — Decide capability concern (pre-Act selection).
+ *
+ * Tool gating answers "which subset of permitted tools is the agent
+ * allowed to fire on this iter?" That is a Decide concern (pre-Act
+ * filtering), per Mission Pillar 5: the Arbitrator integrates signals
+ * into one Verdict; tool gating narrows the candidate set the Verdict
+ * applies to.
+ *
+ * Moved from kernel/capabilities/act/tool-gating.ts in WS-3 Phase 2
+ * (ADR: wiki/Decisions/2026-05-28-tool-gating-disposition.md option (a)).
+ */
+
+/**
  * kernel/utils/tool-gating.ts — Parallel-batch safety, required-tool gating,
  * per-tool quota enforcement, tool-elaboration injection, and next-move
  * batching plans.

--- a/packages/reasoning/src/kernel/capabilities/reason/think-guards.ts
+++ b/packages/reasoning/src/kernel/capabilities/reason/think-guards.ts
@@ -26,7 +26,7 @@ import {
   buildEvidenceCorpusFromSteps,
   validateOutputGroundedInEvidence,
 } from "../verify/evidence-grounding.js";
-import { gateNativeToolCallsForRequiredTools } from "../act/tool-gating.js";
+import { gateNativeToolCallsForRequiredTools } from "../decide/tool-gating.js";
 import {
   buildSuccessfulToolCallCounts,
   getMissingRequiredToolsFromSteps,

--- a/packages/reasoning/src/kernel/capabilities/reason/think.ts
+++ b/packages/reasoning/src/kernel/capabilities/reason/think.ts
@@ -46,7 +46,7 @@ import {
 } from "../act/tool-parsing.js";
 import {
   gateNativeToolCallsForRequiredTools,
-} from "../act/tool-gating.js";
+} from "../decide/tool-gating.js";
 import {
   buildSuccessfulToolCallCounts,
   getMissingRequiredToolsFromSteps,

--- a/packages/reasoning/src/kernel/state/kernel-state.ts
+++ b/packages/reasoning/src/kernel/state/kernel-state.ts
@@ -19,7 +19,7 @@ import type { KernelMetaToolsConfig } from "../../types/kernel-meta-tools.js";
 import type {
   ToolElaborationInjectionConfig,
   NextMovesPlanningConfig,
-} from "../../kernel/capabilities/act/tool-gating.js";
+} from "../../kernel/capabilities/decide/tool-gating.js";
 import type { HarnessPipeline, KernelStateLike } from "@reactive-agents/core";
 
 // ── Cross-package state bridge ───────────────────────────────────────────────

--- a/packages/reasoning/tests/strategies/kernel/utils/tool-utils.test.ts
+++ b/packages/reasoning/tests/strategies/kernel/utils/tool-utils.test.ts
@@ -15,7 +15,7 @@ import {
   gateNativeToolCallsForRequiredTools,
   buildToolElaborationInjection,
   planNextMoveBatches,
-} from "../../../../src/kernel/capabilities/act/tool-gating.js";
+} from "../../../../src/kernel/capabilities/decide/tool-gating.js";
 
 describe("hasFinalAnswer", () => {
   it("returns true for FINAL ANSWER: prefix", () => {

--- a/wiki/Decisions/2026-05-28-tool-gating-disposition.md
+++ b/wiki/Decisions/2026-05-28-tool-gating-disposition.md
@@ -1,7 +1,7 @@
 ---
 title: ADR — `act/tool-gating.ts` Disposition (WS-3 Phase 2)
 date: 2026-05-28
-status: PROPOSED (awaiting user/architecture-warden adjudication)
+status: DECIDED 2026-05-28 — option (a) move to `decide/tool-gating.ts`
 decision-driver: WS-3 Phase 2 thin spec — `wiki/Planning/Implementation-Plans/2026-05-28-ws-3-kernel-capability-dag.md` §Phase 2
 related-anchor: architecture-model §2.3 (leaf principle) + §6 capability boundary contracts
 prerequisite: WS-3 Phase 1 shipped (PR #175 — `tool-parsing.ts` extracted to `kernel/utils/`)
@@ -125,7 +125,7 @@ Reasoning chain:
 
 ## Decision
 
-**Pending user / architecture-warden adjudication.**
+**2026-05-28 (evening) — Option (a) ADJUDICATED.** Move `act/tool-gating.ts` → `decide/tool-gating.ts`. WS-3 Phase 2 dispatch authorized.
 
 If adjudicated as option (a): WS-3 Phase 2 dispatch covers the move + 4 inbound + 2 same-dir import updates. Predicted impact:
 - `act/` LOC: 2798 → 2528
@@ -154,3 +154,4 @@ If adjudicated as option (b) or (c): thin spec updates accordingly before re-dis
 | Date | Change | Reason |
 |---|---|---|
 | 2026-05-28 | Initial draft. | WS-3 Phase 2 prerequisite per thin spec; option (a) recommended. |
+| 2026-05-28 (evening) | Option (a) ADJUDICATED. | User decision. WS-3 Phase 2 dispatch authorized; kernel-warden to execute move + 6+ import-site updates. |


### PR DESCRIPTION
## Summary

WS-3 Phase 2 per `wiki/Planning/Implementation-Plans/2026-05-28-ws-3-kernel-capability-dag.md` §Phase 2 + ADR adjudication at `wiki/Decisions/2026-05-28-tool-gating-disposition.md` (option a — DECIDED 2026-05-28).

Tool gating moved Act → Decide per Mission Pillar 5 (gating IS pre-Act selection → Decide's domain).

## Mechanism

- **File moved** (git rename, history preserved): `act/tool-gating.ts` → `decide/tool-gating.ts`
- **+13-line architectural docstring** at top of moved file (cites Mission Pillar 5 + ADR option a)
- **10 import-path-only updates** (5 newly-surfaced via corrected methodology, 4 originally identified, 1 backward-compat re-export):
  - `act/act.ts:52`, `act/guard.ts:12` (same-dir consumers)
  - `reason/think.ts`, `reason/think-guards.ts` (cross-cap consumers)
  - `context/context-manager.ts:25`, `context/prompt-sections-default.ts:36` (newly-surfaced — outside kernel/capabilities/)
  - `kernel/state/kernel-state.ts:22` (newly-surfaced — type imports)
  - `index.ts:164` (newly-surfaced — public re-export, path updated, re-export preserved)
  - `tests/strategies/kernel/utils/tool-utils.test.ts:18` (newly-surfaced — test import)

## Verification gates (warden first-hand + main thread cross-check)

| Gate | Output |
|---|---|
| `decide/tool-gating.ts` exists | ✅ 10.8K (+13 docstring) |
| `act/tool-gating.ts` gone | ✅ "No such file" |
| Stale `act/tool-gating` refs | ✅ 0 import refs (1 historical-note in moved file's own docstring) |
| Build | ✅ 38/38 |
| Tests | ✅ 5750 pass / 0 fail / 23 skip |
| Typecheck | ✅ Baseline preserved (cf-24 Lever 8 pre-existing per #173) |
| Tool-gating targeted suite | ✅ 46/46 in tool-utils.test.ts |

## Cycle status (cumulative WS-3 progress)

**On this PR alone (off main pre-Phase-1):** Cycles same as baseline (3) because Phase 1's tool-parsing move isn't here.

**Post-merge of PR #175 (Phase 1) + this PR (Phase 2) to main:**

| Cycle | Status |
|---|---|
| `act ↔ decide` | ✅ **CLOSED** (Phase 1 closed via tool-parsing move; Phase 2 doesn't re-introduce — decide imports tool-gating from itself) |
| `act ↔ reason` | 🔄 still open (`reason/think-guards.ts ↔ act/tool-execution.ts` — Phase 3 ToolExecutionService Tag target) |
| `reason ↔ verify` | 🔄 still open (Phase 4 audit target) |

**LOC impact (per warden UpwardReport):**
- `act/`: 2798 → 2528 (Phase 2 contribution: -270 LOC for tool-gating move; total 3053 → 2528 across Phase 1+2)
- `decide/`: 1247 → 1517 (+270 LOC from tool-gating; +13 docstring)

## Out of scope (next dispatches)

- **Phase 3** — ToolExecutionService Tag (closes Cycle 2 — note warden flagged the brief's "1-edge" projection was actually 2-module residual via `tool-parsing` + `tool-execution`; recheck before Phase 3 dispatch)
- **Phase 4** — Cycle 3 audit (reason↔verify) + ESLint boundary rule + transitionState() lint
- **Phase 5** — runner.ts emit relocation

## Closes / part of

- ✅ Tool-gating disposition adjudicated + executed
- Part of #169 (kernel mesh cycles)
- Part of RC-2 per master plan §4

## Refs

- Thin spec: `wiki/Planning/Implementation-Plans/2026-05-28-ws-3-kernel-capability-dag.md` §Phase 2
- ADR: `wiki/Decisions/2026-05-28-tool-gating-disposition.md` (option a DECIDED)
- Master plan: §4 RC-2 + §3.6 F2
- Architecture model: §2.3 leaf principle + §6 Decide capability boundary
- Evidence dump: `wiki/Research/Refactor-Reports/2026-05-28-ws-3-import-graph.md` (amended with corrected methodology)

Stacked on top of #175 (WS-3 Phase 1). Recommend merging #175 first, then this PR.