### PR TITLE
fix(testing): cf-24 via:undefined → via:'end-turn' (closes #173)

### DIFF
--- a/packages/testing/src/gate/scenarios/cf-24-all-termination-flows-through-arbitrator.ts
+++ b/packages/testing/src/gate/scenarios/cf-24-all-termination-flows-through-arbitrator.ts
@@ -92,12 +92,14 @@ export const scenario: ScenarioModule = {
 
     // 1b: corpus failure pattern (≥2 stall-detect + tool-failure evidence,
     // no escalation) → veto fires (Sprint 3.3 refinement: requires tool failure)
-    // Lever 8 (2026-05-26) — switched to via:undefined. Tool-mediated
-    // final answers are deliberate and bypass the veto; the corpus pattern
-    // is preserved on the end_turn path where silent mid-loop drops are
-    // the original veto target.
+    // Lever 8 (2026-05-26) — Tool-mediated final answers are deliberate
+    // and bypass the veto; the corpus pattern is preserved on the
+    // end_turn path where silent mid-loop drops are the original veto
+    // target. Test uses `via: "end-turn"` to exercise that path.
+    // (Fix #173 — was `via: undefined` which violates TerminationIntent
+    // type; the comment's framing aligns with `end-turn` semantically.)
     const fa2 = arbitrate(
-      { kind: "agent-final-answer", via: undefined, output: "fake answer" },
+      { kind: "agent-final-answer", via: "end-turn", output: "fake answer" },
       {
         ...ctxWithFailure,
         controllerDecisionLog: [


### PR DESCRIPTION
## Summary

Closes #173. One-line semantic fix to unblock `@reactive-agents/testing#typecheck`.

## Before

\`\`\`typescript
const fa2 = arbitrate(
  { kind: "agent-final-answer", via: undefined, output: "fake answer" },
  ...
);
\`\`\`

❌ TS2322 at cf-24-all-termination-flows-through-arbitrator.ts:100 — `undefined` not assignable to `"tool" | "regex" | "end-turn"`.

## After

\`\`\`typescript
const fa2 = arbitrate(
  { kind: "agent-final-answer", via: "end-turn", output: "fake answer" },
  ...
);
\`\`\`

✅ Per #173 option (b) — semantically matches the inline comment's own framing:
> "the corpus pattern is preserved on the end_turn path where silent mid-loop drops are the original veto target"

## Gates

| Gate | Output |
|---|---|
| `packages/testing` typecheck | ✅ clean (was 1 TS2322 error) |
| `packages/testing` tests | ✅ 53 pass / 0 fail / 7 files |
| `bunx turbo run build` | ✅ 38/38 |
| Workspace typecheck | ⚠️ still fails on `@reactive-agents/reactive-intelligence` on this branch — PR #172 fixes that; not yet merged. After PR #172 + this PR both merge → workspace typecheck fully clean. |

## Closes

- #173 (testing#typecheck Lever 8 via:undefined design-decision follow-up)

## Surfaced by

- PR #172 (WS-1 release-flow residual fixes) — verification + RI typecheck red fixed; testing#typecheck flagged as out-of-scope design-decision territory
- Warden #173 ADR option (b) preferred

## Refs

- Issue #173 (the question + options)
- Inline comment at cf-24-all-termination-flows-through-arbitrator.ts:93-98 (the framing)