### PR TITLE
refactor(reasoning): WS-3 Phase 3 — move makeObservationResult to kernel/utils/ (closes cycle 2)

### DIFF
--- a/packages/reasoning/src/kernel/capabilities/act/act.ts
+++ b/packages/reasoning/src/kernel/capabilities/act/act.ts
@@ -25,7 +25,8 @@ import {
   runHealingPipeline,
 } from "@reactive-agents/tools";
 import { makeStep } from "../sense/step-utils.js";
-import { executeNativeToolCall, makeObservationResult, extractObservationFacts } from "../act/tool-execution.js";
+import { executeNativeToolCall, extractObservationFacts } from "../act/tool-execution.js";
+import { makeObservationResult } from "../../utils/observation-helpers.js";
 // Sprint 3.2 — Verifier promotion: every effector output flows through
 // defaultVerifier.verify() so the structured VerificationResult is
 // attached to the observation step's metadata. Future sprints (Arbitrator

--- a/packages/reasoning/src/kernel/capabilities/act/tool-execution.ts
+++ b/packages/reasoning/src/kernel/capabilities/act/tool-execution.ts
@@ -6,9 +6,11 @@
  * (~130 lines each). This module provides a single canonical implementation.
  *
  * Exports:
- *   - makeObservationResult(toolName, success, displayText) → ObservationResult
  *   - truncateForDisplay(result, maxChars) → string
  *   - executeToolCall(toolServiceOpt, toolRequest, config) → Effect<ToolExecutionResult>
+ *
+ * Note: `makeObservationResult` was moved to `kernel/utils/observation-helpers.ts`
+ * in WS-3 Phase 3 (cycle 2 closure). Pure helpers don't belong to a capability.
  *
  * Internal helpers (not exported):
  *   - normalizeTripleQuotes(input) — Python-style """...""" → JSON string
@@ -20,12 +22,7 @@ import { ObservableLogger } from "@reactive-agents/observability";
 import type { LogEvent } from "@reactive-agents/observability";
 import { LLMService } from "@reactive-agents/llm-provider";
 import type { ObservationResult } from "../../../types/observation.js";
-import {
-  categorizeToolName,
-  deriveResultKind,
-  KNOWN_TRUSTED_TOOL_NAMES,
-  GRANDFATHER_TRUST_JUSTIFICATION,
-} from "../../../types/observation.js";
+import { makeObservationResult } from "../../utils/observation-helpers.js";
 import type { ContextProfile } from "../../../context/context-profile.js";
 import { ToolNotFoundError } from "@reactive-agents/tools";
 import type { ResultCompressionConfig } from "@reactive-agents/tools";
@@ -149,37 +146,10 @@ function storeToolObservationSemantic(
 }
 
 // ── Exported utilities ───────────────────────────────────────────────────────
-
-/**
- * Build an ObservationResult from tool name + success flag + display text.
- */
-export function makeObservationResult(
-  toolName: string,
-  success: boolean,
-  displayText: string,
-  options?: { readonly delegatedToolsUsed?: readonly string[] },
-): ObservationResult {
-  const category = categorizeToolName(toolName);
-  const resultKind = deriveResultKind(category, success);
-  const preserveOnCompaction = !success || category === "error";
-  // Phase 1 S2.3 — derive trustLevel from KNOWN_TRUSTED_TOOL_NAMES set in
-  // observation.ts. ContextCurator (S2.5) consumes this to decide whether
-  // to render the observation inline or in a <tool_output> block.
-  const isTrusted = KNOWN_TRUSTED_TOOL_NAMES.has(toolName);
-  return {
-    success,
-    toolName,
-    displayText,
-    category,
-    resultKind,
-    preserveOnCompaction,
-    ...(options?.delegatedToolsUsed && options.delegatedToolsUsed.length > 0
-      ? { delegatedToolsUsed: [...new Set(options.delegatedToolsUsed)] }
-      : {}),
-    trustLevel: isTrusted ? "trusted" : "untrusted",
-    ...(isTrusted ? { trustJustification: GRANDFATHER_TRUST_JUSTIFICATION } : {}),
-  };
-}
+//
+// `makeObservationResult` lives in kernel/utils/observation-helpers.ts as of
+// WS-3 Phase 3 (cycle 2 closure). It is re-imported above for the internal
+// call sites in `executeToolCall` / `executeNativeToolCall` below.
 
 function extractDelegatedToolsUsed(result: unknown): readonly string[] | undefined {
   if (typeof result !== "object" || result === null || Array.isArray(result)) return undefined;

--- a/packages/reasoning/src/kernel/capabilities/reason/think-guards.ts
+++ b/packages/reasoning/src/kernel/capabilities/reason/think-guards.ts
@@ -32,7 +32,7 @@ import {
   getMissingRequiredToolsFromSteps,
 } from "../verify/requirement-state.js";
 import { makeStep } from "../sense/step-utils.js";
-import { makeObservationResult } from "../act/tool-execution.js";
+import { makeObservationResult } from "../../utils/observation-helpers.js";
 import type { ContextProfile } from "../../../context/context-profile.js";
 import {
   transitionState,

--- a/packages/reasoning/src/kernel/capabilities/reason/think.ts
+++ b/packages/reasoning/src/kernel/capabilities/reason/think.ts
@@ -61,7 +61,7 @@ import {
 import { assembleOutput } from "../../../kernel/loop/output-assembly.js";
 import { extractThinking, rescueFromThinking } from "../reason/stream-parser.js";
 import { makeStep } from "../sense/step-utils.js";
-import { makeObservationResult } from "../act/tool-execution.js";
+import { makeObservationResult } from "../../utils/observation-helpers.js";
 import {
   transitionState,
   asKernelStateLike,

--- a/packages/reasoning/src/kernel/utils/observation-helpers.ts
+++ b/packages/reasoning/src/kernel/utils/observation-helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * observation-helpers.ts — Pure observation helpers extracted from
+ * act/tool-execution.ts in WS-3 Phase 3 (cycle 2 closure).
+ *
+ * `makeObservationResult` is a pure, deterministic builder for ObservationResult
+ * values. It has no Effect/LLMService/kernel-state coupling, so it belongs in
+ * `kernel/utils/` (substrate) rather than the Act capability. Living here lets
+ * Reason capability (think.ts, think-guards.ts) construct observations without
+ * importing Act, eliminating the reason → act cross-capability edge.
+ *
+ * Same extraction pattern as Phase 1's `tool-parsing.ts`.
+ */
+import type { ObservationResult } from "../../types/observation.js";
+import {
+  categorizeToolName,
+  deriveResultKind,
+  KNOWN_TRUSTED_TOOL_NAMES,
+  GRANDFATHER_TRUST_JUSTIFICATION,
+} from "../../types/observation.js";
+
+/**
+ * Build an ObservationResult from tool name + success flag + display text.
+ */
+export function makeObservationResult(
+  toolName: string,
+  success: boolean,
+  displayText: string,
+  options?: { readonly delegatedToolsUsed?: readonly string[] },
+): ObservationResult {
+  const category = categorizeToolName(toolName);
+  const resultKind = deriveResultKind(category, success);
+  const preserveOnCompaction = !success || category === "error";
+  // Phase 1 S2.3 — derive trustLevel from KNOWN_TRUSTED_TOOL_NAMES set in
+  // observation.ts. ContextCurator (S2.5) consumes this to decide whether
+  // to render the observation inline or in a <tool_output> block.
+  const isTrusted = KNOWN_TRUSTED_TOOL_NAMES.has(toolName);
+  return {
+    success,
+    toolName,
+    displayText,
+    category,
+    resultKind,
+    preserveOnCompaction,
+    ...(options?.delegatedToolsUsed && options.delegatedToolsUsed.length > 0
+      ? { delegatedToolsUsed: [...new Set(options.delegatedToolsUsed)] }
+      : {}),
+    trustLevel: isTrusted ? "trusted" : "untrusted",
+    ...(isTrusted ? { trustJustification: GRANDFATHER_TRUST_JUSTIFICATION } : {}),
+  };
+}

--- a/packages/reasoning/tests/strategies/kernel/phases/think-guards.test.ts
+++ b/packages/reasoning/tests/strategies/kernel/phases/think-guards.test.ts
@@ -17,7 +17,7 @@ import type { ContextProfile } from "../../../../src/context/context-profile.js"
 import type { ProviderAdapter } from "@reactive-agents/llm-provider";
 import type { ToolCallSpec } from "@reactive-agents/tools";
 import { makeStep } from "../../../../src/kernel/capabilities/sense/step-utils.js";
-import { makeObservationResult } from "../../../../src/kernel/capabilities/act/tool-execution.js";
+import { makeObservationResult } from "../../../../src/kernel/utils/observation-helpers.js";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 

--- a/packages/reasoning/tests/strategies/kernel/utils/tool-execution.test.ts
+++ b/packages/reasoning/tests/strategies/kernel/utils/tool-execution.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import { Effect, Ref } from "effect";
 import {
-  makeObservationResult,
   truncateForDisplay,
   executeToolCall,
   executeNativeToolCall,
   type ToolExecutionResult,
 } from "../../../../src/kernel/capabilities/act/tool-execution.js";
+import { makeObservationResult } from "../../../../src/kernel/utils/observation-helpers.js";
 import type { MaybeService, ToolServiceInstance } from "../../../../src/kernel/state/kernel-state.js";
 import { scratchpadStoreRef, makeRecallHandler } from "@reactive-agents/tools";
 

--- a/packages/reasoning/tests/types/observation-trust-level.test.ts
+++ b/packages/reasoning/tests/types/observation-trust-level.test.ts
@@ -17,7 +17,7 @@ import {
   ObservationResultSchema,
   KNOWN_TRUSTED_TOOL_NAMES,
 } from "../../src/types/observation.js";
-import { makeObservationResult } from "../../src/kernel/capabilities/act/tool-execution.js";
+import { makeObservationResult } from "../../src/kernel/utils/observation-helpers.js";
 
 describe("ObservationResult.trustLevel (Phase 1 S2.3)", () => {
   it("schema requires trustLevel field (one of 'trusted' | 'untrusted')", () => {


### PR DESCRIPTION
## Summary

WS-3 Phase 3 — REVISED FROM ORIGINAL SPEC. Pre-flight workspace audit revealed cross-cap consumers of `act/tool-execution.ts` from `reason/` import ONLY the pure helper `makeObservationResult`, NOT effectful primitives. Tag-based DI is overkill; pure-helper extraction matches Phase 1 pattern.

## Mechanism

- **New file:** `packages/reasoning/src/kernel/utils/observation-helpers.ts` — contains `makeObservationResult` (26 LOC function + docstring + imports from `types/observation.js`)
- **Removed** from `act/tool-execution.ts`: the `export function makeObservationResult` definition (lines 156-184)
- **`act/tool-execution.ts`** imports `makeObservationResult` from `../../utils/observation-helpers.js` for its 3 internal call sites (lines 523, 573, 591)
- **7 import-site updates** across consumers + tests

## Cycle status

**On this PR alone (off main pre-Phase-1+2):** Cycle 2 partially reduced (makeObservationResult edge closed; tool-gating + tool-parsing edges remain because Phase 1+2 not merged here).

**Post-merge of PR #175 (Phase 1) + #176 (Phase 2) + this PR to main:**

| Cycle | Status |
|---|---|
| `act ↔ decide` | ✅ CLOSED (Phase 1) |
| `act ↔ reason` | ✅ **CLOSED** (Phase 1 + 2 + 3 combined — all 3 reason→act helper edges eliminated) |
| `reason ↔ verify` | 🔄 remains (Phase 4 audit) |

**Total cycles post-merge of all 3 PRs: 1.**

## Verification gates

| Gate | Output |
|---|---|
| `kernel/utils/observation-helpers.ts` exists | ✅ 50 LOC |
| `makeObservationResult` removed from tool-execution.ts | ✅ 0 export-defs |
| tool-execution.ts imports from utils/ | ✅ 1 import (internal call sites resolve) |
| reason/* imports `makeObservationResult` from act/ | ✅ 0 (cycle 2 edge closed) |
| Build | ✅ 38/38 |
| Tests | ✅ 5750 pass / 0 fail / 23 skip |
| Typecheck | ✅ baseline preserved (#173 + #172 fix other pre-existing reds) |

## Why pure-helper move, not Tag

Architecture model §6.5 (effectful capabilities) said Act exposes `ToolExecutionService` via Tag. That's correct for effectful primitives (`executeToolCall`, `executeNativeToolCall`) — but pre-flight audit revealed:

- `reason/think-guards.ts:35` imports ONLY `makeObservationResult` (pure)
- `reason/think.ts:64` imports ONLY `makeObservationResult` (pure)

So the cross-cap consumption is purely-functional. Tag overhead would add DI machinery for nothing. The architecturally correct move is: pure helpers go to `kernel/utils/` (substrate), effectful primitives stay in `act/`.

**Deferred to later WS:** if/when an effectful primitive needs cross-cap consumption, the `ToolExecutionService` Tag becomes appropriate.

## Out of scope

- **Phase 4** — Cycle 3 (reason↔verify) audit + ESLint boundary rule + transitionState() lint
- **Phase 5** — runner.ts emit relocation
- `executeToolCall` / `executeNativeToolCall` Tag exposure (deferred — no current consumer needs it)

## Closes / part of

- ✅ makeObservationResult cross-cap edge eliminated (cycle 2 contribution)
- Part of #169 (kernel mesh cycles)
- Part of RC-2 per master plan §4

## Refs

- Thin spec: `wiki/Planning/Implementation-Plans/2026-05-28-ws-3-kernel-capability-dag.md` §Phase 3 (revised inline via dispatch brief)
- Architecture model: §2.3 leaf principle + §2.4 substrate distinction
- Master plan: §4 RC-2 + §3.6 F2

**Stacked on top of:** #175 (Phase 1) + #176 (Phase 2). Recommend merging #175 → #176 → this PR in order.