### PR TITLE
fix(memory): instrument 4 silent swallow sites in bootstrap (#157)

### DIFF
--- a/packages/memory/src/services/memory-service.ts
+++ b/packages/memory/src/services/memory-service.ts
@@ -110,17 +110,17 @@ export const MemoryServiceLive = (config: MemoryConfig, memoryLLM?: MemoryLLM) =
             // Generate semantic context from live SQLite (not stale memory.md)
             const semanticContext = yield* semantic
               .generateMarkdown(agentId, config.semantic.maxMarkdownLines)
-              .pipe(Effect.catchAll(() => Effect.succeed("")));
+              .pipe(Effect.catchAll((err) => emitErrorSwallowed({ site: "memory/src/services/memory-service.ts:112", tag: errorTag(err) }).pipe(Effect.as(""))));
 
             // Get recent episodic entries (last 20)
             const recentEpisodes = yield* episodic
               .getRecent(agentId, 20)
-              .pipe(Effect.catchAll(() => Effect.succeed([] as DailyLogEntry[])));
+              .pipe(Effect.catchAll((err) => emitErrorSwallowed({ site: "memory/src/services/memory-service.ts:117", tag: errorTag(err) }).pipe(Effect.as([] as DailyLogEntry[]))));
 
             // Get active workflows
             const activeWorkflows = yield* _procedural
               .listActive(agentId)
-              .pipe(Effect.catchAll(() => Effect.succeed([] as never[])));
+              .pipe(Effect.catchAll((err) => emitErrorSwallowed({ site: "memory/src/services/memory-service.ts:122", tag: errorTag(err) }).pipe(Effect.as([] as never[]))));
 
             // Get current working memory
             const workingMemory = yield* working.get();
@@ -191,7 +191,7 @@ export const MemoryServiceLive = (config: MemoryConfig, memoryLLM?: MemoryLLM) =
                   entry.agentId,
                   config.zettelkasten.linkingThreshold,
                 )
-                .pipe(Effect.catchAll(() => Effect.succeed([])));
+                .pipe(Effect.catchAll((err) => emitErrorSwallowed({ site: "memory/src/services/memory-service.ts:188", tag: errorTag(err) }).pipe(Effect.as([]))));
             }
             return id;
           }),


### PR DESCRIPTION
## Closes #157

4 silent error-swallow sites in the memory-service bootstrap path now emit `emitErrorSwallowed` telemetry, mirroring the 3 already-instrumented siblings in the same file. Swallow semantics preserved (errors stay non-fatal via `Effect.as(<fallback>)`) — only observability added.

Sites: `memory-service.ts:112` (generateMarkdown), `:117` (getRecent), `:122` (listActive), `:188` (autoLinkText).

## Verification
- `emitErrorSwallowed` call-site count: 3 → 7 (+4, as required)
- `bunx turbo typecheck --filter=@reactive-agents/memory` ✅ green
- `bun test packages/memory/` ✅ 155/0 (baseline 155/0, zero net-new)
- Behavior-neutral; no signature change

Coverage note: existing suite proves behavior-neutrality but does not exercise the catchAll path with an EventBus attached, so the new emit firing is not directly regression-tested (honest gap, non-blocking).