### PR TITLE
refactor(llm-provider): de-duplicate schema deep-clone via shared helper (#156)

### DIFF
--- a/packages/llm-provider/src/providers/gemini.ts
+++ b/packages/llm-provider/src/providers/gemini.ts
@@ -19,6 +19,7 @@ import { calculateCost, estimateTokenCount } from "../token-counter.js";
 import { retryPolicy } from "../retry.js";
 import { emitToolCallComplete } from "../streaming-helpers.js";
 import { selectAdapter } from "../adapter.js";
+import { deepClone } from "../schema-utils.js";
 
 // ─── Gemini Message Conversion Helpers ───
 
@@ -589,7 +590,7 @@ export const GeminiProviderLive = Layer.effect(
       completeStructured: (request) =>
         Effect.gen(function* () {
           const jsonSchema = Schema.encodedSchema(request.outputSchema);
-          const schemaObj = JSON.parse(JSON.stringify(jsonSchema));
+          const schemaObj = deepClone<Record<string, unknown>>(jsonSchema);
           const schemaStr = JSON.stringify(schemaObj, null, 2);
 
           const client = yield* Effect.promise(() => getClient());

--- a/packages/llm-provider/src/providers/local.ts
+++ b/packages/llm-provider/src/providers/local.ts
@@ -21,6 +21,7 @@ import { warnCapabilityFallback } from '../capability-resolver.js'
 import type { Capability } from '../capability.js'
 import { emitToolCallComplete } from '../streaming-helpers.js'
 import { selectAdapter } from '../adapter.js'
+import { deepClone } from '../schema-utils.js'
 
 // Module-scope cache so the inline probe runs at most once per (baseUrl, model)
 // per process. CalibrationStore write-through (cross-process) lands in S2.4.
@@ -769,7 +770,7 @@ export const LocalProviderLive = Layer.effect(
                     const encodedSchema = Schema.encodedSchema(
                         request.outputSchema
                     )
-                    const schemaObj = JSON.parse(JSON.stringify(encodedSchema))
+                    const schemaObj = deepClone<Record<string, unknown>>(encodedSchema)
                     const schemaStr = JSON.stringify(schemaObj, null, 2)
 
                     // Build Ollama-native format constraint.

--- a/packages/llm-provider/src/providers/openai.ts
+++ b/packages/llm-provider/src/providers/openai.ts
@@ -22,6 +22,7 @@ import type { CacheUsage } from "../token-counter.js";
 import { retryPolicy } from "../retry.js";
 import { emitToolUseDelta, emitToolUseStart } from "../streaming-helpers.js";
 import { selectAdapter } from "../adapter.js";
+import { deepClone } from "../schema-utils.js";
 
 // ─── OpenAI Message Conversion ───
 
@@ -135,7 +136,8 @@ export const isStrictToolCallingSupported = (model: string): boolean => {
 /** @internal Exported for testing only */
 export const toStrictToolSchema = (schema: any): any => {
   if (!schema || typeof schema !== "object") return schema;
-  const newSchema = JSON.parse(JSON.stringify(schema));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- toStrictToolSchema is a pre-existing `(schema: any): any` mutator; the clone keeps that local shape.
+  const newSchema = deepClone<any>(schema);
 
   if (newSchema.type === "object" && newSchema.properties) {
     const originalRequired = new Set<string>(newSchema.required ?? []);
@@ -484,7 +486,7 @@ export const OpenAIProviderLive = Layer.effect(
       completeStructured: (request) =>
         Effect.gen(function* () {
           const jsonSchema = Schema.encodedSchema(request.outputSchema);
-          const schemaObj = JSON.parse(JSON.stringify(jsonSchema));
+          const schemaObj = deepClone<Record<string, unknown>>(jsonSchema);
           const schemaStr = JSON.stringify(schemaObj, null, 2);
           const model = typeof request.model === 'string'
             ? request.model

--- a/packages/llm-provider/src/schema-utils.ts
+++ b/packages/llm-provider/src/schema-utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared schema utilities for provider adapters.
+ *
+ * `deepClone` replaces the `JSON.parse(JSON.stringify(...))` idiom that was
+ * copy-pasted across the providers' `completeStructured` paths (gemini, openai,
+ * local) and `toStrictToolSchema` (openai). Centralizing it removes the
+ * copy-paste hazard (GH #156) while keeping behavior identical: a structural
+ * deep copy of a JSON-serializable value.
+ *
+ * Inputs are always JSON-serializable schema objects (the output of
+ * `Schema.encodedSchema(...)` or a plain JSON Schema), so the round-trip is
+ * lossless. Do NOT use this for values containing functions, `undefined`,
+ * `Date`, `Map`/`Set`, or cyclic references.
+ *
+ * The parameter is `unknown` (callers pass `Schema` instances whose compile-time
+ * type does not match their runtime JSON shape); the caller supplies `T` to
+ * describe the runtime shape of the cloned value.
+ */
+export const deepClone = <T>(value: unknown): T =>
+  JSON.parse(JSON.stringify(value)) as T;


### PR DESCRIPTION
## Closes #156

Extracted the repeated `JSON.parse(JSON.stringify(...))` schema deep-clone idiom (4 sites / 3 providers) into a single `deepClone` helper in `schema-utils.ts`. Runtime expression byte-identical — behavior-neutral.

Sites routed: `openai.ts:139,488`, `gemini.ts:593`, `local.ts:773`.

## Verification
- `grep 'JSON.parse(JSON.stringify' packages/llm-provider/src` call-sites: 4 → 0 (only the helper's single impl remains)
- `bunx turbo typecheck --filter=@reactive-agents/llm-provider` ✅ green
- `bun test packages/llm-provider/` ✅ 276/0 (baseline 276/0)
- `bunx turbo build --filter=@reactive-agents/llm-provider` ✅ green (DTS)
- Helper is `any`-free: `deepClone<T>(value: unknown): T`