### PR TITLE
fix(cortex-ui): type AgentStreamEvent as true discriminated union (#163)

### DIFF
--- a/apps/cortex/ui/src/lib/components/RunChatTab.svelte
+++ b/apps/cortex/ui/src/lib/components/RunChatTab.svelte
@@ -237,7 +237,7 @@
             try {
               const event = JSON.parse(jsonStr) as AgentStreamEvent;
               if (event._tag === "TextDelta") {
-                const delta = (event as any).text as string;
+                const delta = event.text;
                 turns = turns.map((t) => {
                   if (t.id !== assistantTurnId) return t;
 
@@ -274,9 +274,9 @@
                   };
                 });
               } else if (event._tag === "IterationProgress") {
-                const iter = (event as any).iteration as number;
-                const max = (event as any).maxIterations as number;
-                const tools = (event as any).toolsCalledThisStep as string[] | undefined;
+                const iter = event.iteration;
+                const max = event.maxIterations;
+                const tools = event.toolsCalledThisStep;
                 const step: ReasoningStep = { iteration: iter, maxIterations: max, ...(tools?.length ? { toolsCalledThisStep: tools } : {}) };
                 turns = turns.map((t) => {
                   if (t.id !== assistantTurnId) return t;
@@ -295,9 +295,8 @@
                   return { ...t, streamProgress: { iteration: iter, maxIterations: max }, reasoningSteps: steps };
                 });
               } else if (event._tag === "ThoughtEmitted") {
-                const thoughtEvent = event as { _tag: "ThoughtEmitted"; content: string; iteration: number };
-                const iter = thoughtEvent.iteration;
-                const thought = thoughtEvent.content;
+                const iter = event.iteration;
+                const thought = event.content;
                 turns = turns.map((t) => {
                   if (t.id !== assistantTurnId) return t;
                   const existing = t.reasoningSteps ?? [];
@@ -313,24 +312,24 @@
                   return { ...t, reasoningSteps: [...existing, { iteration: iter, maxIterations: 0, thought }] };
                 });
               } else if (event._tag === "StreamCompleted") {
-                const done = event as {
-                    metadata?: { tokensUsed?: number; iterations?: number; stepsCount?: number };
-                  toolSummary?: Array<{ name: string }>;
-                  output?: string;
+                const metadata = event.metadata as {
+                  tokensUsed?: number;
+                  iterations?: number;
+                  stepsCount?: number;
                 };
-                tokensUsed = done.metadata?.tokensUsed ?? 0;
-                  steps = done.metadata?.iterations ?? done.metadata?.stepsCount ?? 0;
-                if (done.toolSummary && done.toolSummary.length > 0) {
-                  toolsUsed = done.toolSummary.map((t: { name: string }) => t.name);
+                tokensUsed = metadata.tokensUsed ?? 0;
+                steps = metadata.iterations ?? metadata.stepsCount ?? 0;
+                if (event.toolSummary && event.toolSummary.length > 0) {
+                  toolsUsed = event.toolSummary.map((t) => t.name);
                 }
-                const output = done.output;
+                const output = event.output;
                 if (output?.trim()) {
                   turns = turns.map((t) =>
                     t.id === assistantTurnId ? { ...t, content: output } : t,
                   );
                 }
               } else if (event._tag === "StreamError") {
-                error = (event as any).cause ?? "Stream error";
+                error = event.cause ?? "Stream error";
               }
             } catch { /* ignore parse errors */ }
           }

--- a/apps/cortex/ui/src/lib/stores/chat-store.ts
+++ b/apps/cortex/ui/src/lib/stores/chat-store.ts
@@ -1,19 +1,57 @@
 import { writable } from "svelte/store";
 import { CORTEX_SERVER_URL } from "$lib/constants.js";
 
+/**
+ * Faithful mirror of the `AgentStreamEvent` SSE wire union emitted by
+ * `agent.runStream()` (canonical source: `@reactive-agents/runtime`
+ * `stream-types.ts`). This is a true discriminated union on `_tag` with
+ * every variant's fields declared — narrowing on `event._tag` gives typed
+ * field access with no casts.
+ *
+ * NOTE (divergence, GH #163): three copies of this union exist —
+ * runtime/stream-types.ts (canonical), packages/svelte/src/types.ts (lossy
+ * mirror), and this one. cortex-ui depends only on `@reactive-agents/svelte`,
+ * which has no built dist and itself carries a lossy mirror, so this file
+ * keeps its own complete copy rather than importing cross-package. A
+ * follow-up should dedup these (svelte + chat-store re-export runtime).
+ * `metadata` is kept as `Record<string, unknown>` to avoid importing
+ * `AgentResultMetadata` across packages.
+ */
 export type AgentStreamEvent =
-  | { _tag: "TextDelta"; text: string }
-  | { _tag: "StreamCompleted"; output: string; metadata: Record<string, unknown>; toolSummary?: Array<{ name: string; calls: number; avgMs: number }> }
-  | { _tag: "StreamError"; cause: string }
-  | { _tag: "IterationProgress"; iteration: number; maxIterations: number; status: string }
-  | { _tag: "ThoughtEmitted"; content: string; iteration: number }
-  | { _tag: "StreamCancelled"; reason: string; iterationsCompleted: number }
-  | Record<string, unknown>; // for other event types
+  | { readonly _tag: "TextDelta"; readonly text: string }
+  | {
+      readonly _tag: "StreamCompleted";
+      readonly output: string;
+      readonly metadata: Record<string, unknown>;
+      readonly taskId?: string;
+      readonly agentId?: string;
+      readonly toolSummary?: ReadonlyArray<{ readonly name: string; readonly calls: number; readonly avgMs: number }>;
+    }
+  | { readonly _tag: "StreamError"; readonly cause: string }
+  | {
+      readonly _tag: "IterationProgress";
+      readonly iteration: number;
+      readonly maxIterations: number;
+      readonly toolsCalledThisStep?: readonly string[];
+      readonly status: string;
+    }
+  | { readonly _tag: "StreamCancelled"; readonly reason: string; readonly iterationsCompleted: number }
+  | { readonly _tag: "PhaseStarted"; readonly phase: string; readonly timestamp: number }
+  | { readonly _tag: "PhaseCompleted"; readonly phase: string; readonly durationMs: number }
+  | { readonly _tag: "ThoughtEmitted"; readonly content: string; readonly iteration: number }
+  | { readonly _tag: "ToolCallStarted"; readonly toolName: string; readonly callId: string }
+  | {
+      readonly _tag: "ToolCallCompleted";
+      readonly toolName: string;
+      readonly callId: string;
+      readonly durationMs: number;
+      readonly success: boolean;
+    };
 
 export type ReasoningStep = {
   iteration: number;
   maxIterations: number;
-  toolsCalledThisStep?: string[];
+  toolsCalledThisStep?: readonly string[];
   thought?: string;
 };
 
@@ -404,9 +442,9 @@ function createChatStore() {
                     ),
                   }));
                 } else if (event._tag === "IterationProgress") {
-                  const iter = (event as any).iteration as number;
-                  const max = (event as any).maxIterations as number;
-                  const tools = (event as any).toolsCalledThisStep as string[] | undefined;
+                  const iter = event.iteration;
+                  const max = event.maxIterations;
+                  const tools = event.toolsCalledThisStep;
                   const step: ReasoningStep = {
                     iteration: iter,
                     maxIterations: max,
@@ -432,8 +470,8 @@ function createChatStore() {
                     }),
                   }));
                 } else if (event._tag === "ThoughtEmitted") {
-                  const iter = (event as any).iteration as number;
-                  const thought = (event as any).content as string;
+                  const iter = event.iteration;
+                  const thought = event.content;
                   update((s) => ({
                     ...s,
                     activeTurns: s.activeTurns.map((t) => {
@@ -467,7 +505,7 @@ function createChatStore() {
                     toolsUsed = event.toolSummary.map((t) => t.name);
                   }
                   // StreamCompleted.output is authoritative final output after verification/retries.
-                  const output = (event as any).output as string | undefined;
+                  const output: string | undefined = event.output;
                   if (output?.trim()) {
                     update((s) => {
                       return {
@@ -480,10 +518,10 @@ function createChatStore() {
                   }
                 } else if (event._tag === "StreamError") {
                   // Handle stream errors
-                  console.error("[Chat Stream] Stream error:", (event as any).cause);
+                  console.error("[Chat Stream] Stream error:", event.cause);
                   update((s) => ({
                     ...s,
-                    error: (event as any).cause ?? "Stream error",
+                    error: event.cause ?? "Stream error",
                   }));
                 }
               } catch (e) {


### PR DESCRIPTION
## Closes #163

**Root cause was different than the issue stated** (issue named `AgentEvent`; the cast sites actually consume the SSE wire type `AgentStreamEvent`). `apps/cortex/ui/src/lib/stores/chat-store.ts` defined a hand-rolled local copy of `AgentStreamEvent` with a `| Record<string, unknown>` escape-hatch member that widened every `_tag`-narrowed branch back to a loose object — forcing the `(event as any).X` casts. Core's `AgentEvent` was already a correct discriminated union and needed **zero changes**.

Fix (cortex/ui only): replaced the local type with an escape-hatch-free faithful mirror of runtime's `stream-types.ts` (all variants, every field declared); replaced every `(event as any).X` with `_tag`-narrowed access.

## Verification
- Casts: `chat-store.ts` 8 → 0; `RunChatTab.svelte` 5 → 0 (`grep 'as any'` clean in both)
- `bun run check` (svelte-check — authoritative for .ts + .svelte): the 2 files' errors 8 → 0
- `bunx turbo typecheck --filter=@reactive-agents/core` ✅ green; `bun test packages/core/` ✅ 149/0; core DTS build green
- ⚠️ `turbo typecheck --filter=<cortex>` does NOT pass — but for a **pre-existing, unrelated** reason: a DTS error in `@reactive-agents/observability` (`OTLPTraceExporter` not assignable to `SpanExporter`, otlp-exporter.ts) that turbo hits while building deps, before reaching cortex's tsc step. Not in this change's import path (git diff = 2 UI files). Filed separately. UI files verified via svelte-check instead.

## Follow-up
`AgentStreamEvent` is now diverged 3 ways (runtime canonical / `@reactive-agents/svelte` mirror / this chat-store copy) — filed as a separate dedup issue.