### PR TITLE
P1 honesty cluster: confidenceFloor doc-lie, template as-any, HITL phantom method (#154, #160, #164)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Foundation (no reactive-agents deps)
 ├── @reactive-agents/judge-server  — LLM-as-judge HTTP server backing @reactive-agents/eval
 │   └── depends on: core, eval, llm-provider, runtime-shim
 │
-├── @reactive-agents/compose       — Harness composition + 6 killswitches (maxIterations, budgetLimit, timeoutAfter, watchdog, requireApprovalFor, confidenceFloor)
+├── @reactive-agents/compose       — Harness composition + 5 killswitches (maxIterations, budgetLimit, timeoutAfter, watchdog, requireApprovalFor)
 │   └── depends on: core, runtime
 │
 ├── @reactive-agents/replay        — Deterministic trace replay: loadRecordedRun, makeReplayController, makeReplayToolLayer, diffTraces
@@ -131,7 +131,7 @@ Foundation (no reactive-agents deps)
 | `gateway`       | `src/services/gateway-service.ts`       | `GatewayService`, `PolicyEngine`, `WebhookService`          |
 | `eval`          | `src/services/eval-service.ts`          | `EvalService`, `EvalStore`, `EvalSuite`                     |
 | `runtime-shim`  | `src/index.ts`                          | `Database`, `spawn`, `serve`, `glob`, `hash`, `isMain`, `isBun`, `isNode` |
-| `compose`       | `src/killswitches/index.ts`             | `maxIterations`, `budgetLimit`, `timeoutAfter`, `watchdog`, `requireApprovalFor`, `confidenceFloor`, `killswitches` |
+| `compose`       | `src/killswitches/index.ts`             | `maxIterations`, `budgetLimit`, `timeoutAfter`, `watchdog`, `requireApprovalFor`, `killswitches` |
 | `replay`        | `src/index.ts`                          | `loadRecordedRun`, `replay`, `makeReplayController`, `makeReplayToolLayer`, `diffTraces` |
 | `observe`       | `src/index.ts`                          | `OpenInferenceTracerLayer`, `setupOpenInferenceExporter`, `autoConfigureExporter` |
 | `runtime`       | `src/builder.ts`                        | `ReactiveAgents`, `ReactiveAgentBuilder`, `createRuntime()` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ This roadmap is the public-facing milestone tracker. The internal authoritative 
   - Harness pipeline registry + tag catalog (7 tags) + `.compose()` builder method
   - 7 live chokepoints: `prompt.system`, `nudge.loop-detected`, `nudge.healing-failure`, `message.tool-result`, `observation.tool-result`, `lifecycle.failure`, `control.strategy-evaluated`
   - `RunHandle` / `RunController` with pause/resume/stop/terminate
-  - `packages/compose` with 6 killswitches: `maxIterations`, `budgetLimit`, `timeoutAfter`, `watchdog`, `requireApprovalFor`, `confidenceFloor`
+  - `packages/compose` with 5 killswitches: `maxIterations`, `budgetLimit`, `timeoutAfter`, `watchdog`, `requireApprovalFor`
   - `.withX()` sugar desugars through harness; backward compatible
   - Docs: `compose-api.mdx`, `harness-tags.mdx`, `composition-recipes.mdx`
 - **Phase 1.5 mechanism improvements** in flight (M3 REWORK shipped; M6 skill persistence shipped; M7/M8/M10/M14 ongoing).

--- a/apps/cli/src/templates/sdk-server.ts
+++ b/apps/cli/src/templates/sdk-server.ts
@@ -35,11 +35,15 @@ let requestCount = 0;
 
 import { ReactiveAgents, registerShutdownHandlers } from "reactive-agents";
 
+// Validate LLM_PROVIDER against supported providers — no unsafe cast.
+const LLM_PROVIDERS = ["anthropic", "openai", "ollama", "gemini", "litellm"] as const;
+const provider = LLM_PROVIDERS.find((p) => p === process.env.LLM_PROVIDER) ?? "anthropic";
+
 async function buildAgent() {
   // TODO: Customize your agent builder here
   const a = await ReactiveAgents.create()
     .withName("${agentName}")
-    .withProvider(process.env.LLM_PROVIDER as any ?? "anthropic")
+    .withProvider(provider)
     .withModel(process.env.LLM_MODEL ?? "claude-sonnet-4-20250514")
     .withReasoning()
     .withTools()

--- a/apps/examples/src/interaction/hitl-approval-gate.ts
+++ b/apps/examples/src/interaction/hitl-approval-gate.ts
@@ -118,22 +118,18 @@ export async function run(_opts?: { provider?: string; model?: string }): Promis
       .withMaxIterations(3)
       .build();
 
-    let approvalInvoked = false;
-    // The minimum witness: the handler must reach the approval gate. The exact
-    // approval surface (callback, queue, event) is part of the design — accept
-    // any signal. Until the design lands, this will not be observed.
-    (agent as any).onApprovalRequest?.((_req: unknown) => {
-      approvalInvoked = true;
-      return { approved: true };
-    });
-
+    // The minimum witness would be the handler reaching the approval gate. The
+    // approval-observation surface (callback, queue, event) is UNDESIGNED — there
+    // is no public API to subscribe to yet (`onApprovalRequest` was never shipped
+    // and HITL is not on the roadmap), so this probe cannot observe an approval
+    // and therefore cannot pass until that surface is designed.
     const r = await agent.run("Please review this risky action and approve.");
-    const passed = approvalInvoked === true;
+    const passed = false;
     return {
       passed,
-      output: passed
-        ? "human-escalate controller decision routed through interaction-manager.approvalGate."
-        : "Wiring exists but approval gate was not invoked for a task that should escalate.",
+      output:
+        "Wiring exists but the approval-observation surface is undesigned; " +
+        "the approval gate could not be witnessed.",
       steps: r?.metadata?.stepsCount ?? 0,
       tokens: r?.metadata?.tokensUsed ?? 0,
       durationMs: Date.now() - start,


### PR DESCRIPTION
## Closes #154
## Closes #160
## Closes #164

Three small, verified-VALID P1 honesty/correctness fixes (disjoint files).

### #164 — cli template ships `as any`
`apps/cli/src/templates/sdk-server.ts`: every scaffolded user project inherited `process.env.LLM_PROVIDER as any`. Replaced with a typed provider allow-list + clean default (no cast). Emitted user code is now clean-types compliant.

### #160 — confidenceFloor doc-lie
`confidenceFloor` was unshipped 2026-05-19 (compose exports exactly 5 killswitches). Docs still listed 6 → fresh agents risk re-adding the removed anti-pattern. Fixed `AGENTS.md` (×2) + `ROADMAP.md`. Runtime guard already exists (`killswitches.test.ts` asserts the list excludes `confidenceFloor` — 21/0 green), so no new test needed.

### #154 — HITL phantom method
The aspirational HITL probe called `(agent as any).onApprovalRequest` — a method never shipped, not on the roadmap. Removed the dead approval-observation block; the probe remains an honest gap-reporter. Incidentally fixes a **pre-existing** TS2367 at that line (const-narrowed `false === true`).

## Verification
- #164: `tsc --noEmit` on apps/cli → clean (exit 0)
- #160: `bun test packages/compose/test/killswitches.test.ts` → 21/0 (guard green)
- #154: `hitl-approval-gate.ts` now error-free under `tsc` (was TS2367 on main)
- Note: `apps/examples` has unrelated pre-existing tsc noise (eval-framework, otel-export, rootDir) present on main — none touched here.

Each change is independent and trivial; bundled as one PR for review efficiency.