### PR TITLE
fix(reactive-intelligence): telemetry sink-health counter — close #152

### DIFF
--- a/packages/reactive-intelligence/src/telemetry/telemetry-client.ts
+++ b/packages/reactive-intelligence/src/telemetry/telemetry-client.ts
@@ -21,6 +21,8 @@ export function resolveDefaultReportsEndpoint(): string {
 export class TelemetryClient {
   private noticePrinted = false;
   private readonly installId: string;
+  private sinkAttempts = 0;
+  private sinkFailures = 0;
 
   constructor(private readonly endpoint: string = resolveDefaultReportsEndpoint()) {
     this.installId = getOrCreateInstallId();
@@ -29,6 +31,17 @@ export class TelemetryClient {
   /** Get the install ID (useful for building RunReports). */
   getInstallId(): string {
     return this.installId;
+  }
+
+  /**
+   * Sink-health snapshot for the otherwise-silent fire-and-forget reporter.
+   * `failures` counts real (non-test) sends dropped by a network or
+   * serialization error; the sink still never throws or blocks. Lets callers
+   * and tests observe a degraded telemetry sink instead of it failing
+   * invisibly (HS-B-03, #152).
+   */
+  getSinkHealth(): { readonly attempts: number; readonly failures: number } {
+    return { attempts: this.sinkAttempts, failures: this.sinkFailures };
   }
 
   /** Check if this is a test run — never send telemetry for test runs. */
@@ -51,6 +64,7 @@ export class TelemetryClient {
       // See execution-engine.ts for the NoticesManager integration.
       this.noticePrinted = true;
     }
+    this.sinkAttempts++;
     try {
       const body = JSON.stringify(report);
       const signature = signPayload(body);
@@ -62,9 +76,13 @@ export class TelemetryClient {
           "X-RA-Client-Signature": signature,
         },
         body,
-      }).catch(() => {}); // fire-and-forget
+      }).catch(() => {
+        // fire-and-forget — never rethrow, but count the dropped send
+        this.sinkFailures++;
+      });
     } catch {
-      // silent — telemetry must never affect agent
+      // silent — telemetry must never affect agent, but count the drop
+      this.sinkFailures++;
     }
   }
 }

--- a/packages/reactive-intelligence/tests/telemetry/telemetry-client.test.ts
+++ b/packages/reactive-intelligence/tests/telemetry/telemetry-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { TelemetryClient } from "../../src/telemetry/telemetry-client.js";
 import type { RunReport } from "../../src/telemetry/types.js";
 
@@ -65,5 +65,35 @@ describe("TelemetryClient", () => {
     expect((client as unknown as { noticePrinted: boolean }).noticePrinted).toBe(false);
     client.send(mockReport);
     expect((client as unknown as { noticePrinted: boolean }).noticePrinted).toBe(true);
+  });
+});
+
+describe("TelemetryClient sink health (HS-B-03 / #152)", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  test("test runs are not counted as sink attempts", () => {
+    const client = new TelemetryClient("http://localhost:9999");
+    client.send({ ...mockReport, provider: "test" });
+    expect(client.getSinkHealth()).toEqual({ attempts: 0, failures: 0 });
+  });
+
+  test("a successful send increments attempts but not failures", async () => {
+    globalThis.fetch = (() => Promise.resolve(new Response("ok"))) as unknown as typeof fetch;
+    const client = new TelemetryClient("http://localhost:9999");
+    client.send(mockReport);
+    await Promise.resolve();
+    expect(client.getSinkHealth()).toEqual({ attempts: 1, failures: 0 });
+  });
+
+  test("a failed fetch is counted as a sink failure (no longer silent)", async () => {
+    globalThis.fetch = (() => Promise.reject(new Error("network down"))) as unknown as typeof fetch;
+    const client = new TelemetryClient("http://localhost:9999");
+    client.send(mockReport);
+    // let the rejected fetch's .catch microtask settle
+    await new Promise((r) => setTimeout(r, 0));
+    expect(client.getSinkHealth()).toEqual({ attempts: 1, failures: 1 });
   });
 });


### PR DESCRIPTION
## Closes #152

Completes the last open leg (HS-B-03) of the #152 honesty-pass. The other two legs (HS-B-01 `console.error` in runner.ts, HS-B-02 gateway-bootstrap swallow) were already fixed in prior work (verified in the 2026-06-05 re-audit).

### HS-B-03 — telemetry fire-and-forget had no sink-health signal
`TelemetryClient.send()` did `fetch(...).catch(() => {})` + a sync `catch {}`, dropping failures invisibly. Added `sinkAttempts`/`sinkFailures` counters (incremented on both failure paths) and a `getSinkHealth(): { attempts, failures }` accessor. The sink still **never throws or blocks** — behavior unchanged, just observable.

## Verification
- `bun test packages/reactive-intelligence/tests/telemetry/` → 20/0 (3 new: test-runs not counted, success increments attempts-only, failed fetch counted as failure)
- `tsc --noEmit` on reactive-intelligence → clean
- Behavior-neutral: `send()` contract (never throws/blocks, skips test runs) preserved