### PR TITLE
Sweep residues: ResultMetadata fields, getLastDebrief accessor, metrics test wiring (#79, #158, #166)

### DIFF
--- a/apps/cli/src/commands/playground.ts
+++ b/apps/cli/src/commands/playground.ts
@@ -400,7 +400,7 @@ export async function runPlayground(args: string[]): Promise<void> {
           }
 
           case "/debrief": {
-            showDebrief((agent as any)._lastDebrief as AgentDebrief | undefined);
+            showDebrief(agent.getLastDebrief());
             console.log();
             continue;
           }

--- a/packages/core/src/types/result.ts
+++ b/packages/core/src/types/result.ts
@@ -67,6 +67,10 @@ export const ResultMetadataSchema = Schema.Struct({
   strategyUsed: Schema.optional(Schema.String),
   stepsCount: Schema.optional(Schema.Number),
   iterations: Schema.optional(Schema.Number),
+  /** Derived task-complexity bucket ("trivial" | "moderate" | "complex" | "expert"). */
+  complexity: Schema.optional(Schema.String),
+  /** Total LLM calls made across this execution. */
+  llmCalls: Schema.optional(Schema.Number),
 });
 export type ResultMetadata = typeof ResultMetadataSchema.Type;
 

--- a/packages/observability/tests/_observability-test-layer.ts
+++ b/packages/observability/tests/_observability-test-layer.ts
@@ -1,0 +1,21 @@
+import { Layer } from "effect";
+import { EventBusLive } from "@reactive-agents/core";
+import { ObservabilityServiceLive } from "../src/observability-service.js";
+import { MetricsCollectorLive } from "../src/metrics/metrics-collector.js";
+
+/**
+ * ObservabilityService test layer with `MetricsCollectorTag` provided (#166).
+ *
+ * Bare `ObservabilityServiceLive()` omits the collector, so the service falls
+ * back to a fresh one and logs the "MetricsCollectorTag not provided in Layer
+ * — ExecutionEngine writes and ObservabilityService reads will diverge" WARN
+ * on every run. This helper wires `MetricsCollectorLive` (with its `EventBus`
+ * dependency), mirroring the shared-layer wiring the runtime uses in prod, so
+ * tests exercise the supported configuration and the WARN no longer fires.
+ */
+export const makeObservabilityTestLayer = (
+  config?: Parameters<typeof ObservabilityServiceLive>[0],
+) =>
+  ObservabilityServiceLive(config).pipe(
+    Layer.provide(MetricsCollectorLive.pipe(Layer.provide(EventBusLive))),
+  );

--- a/packages/observability/tests/exporters.test.ts
+++ b/packages/observability/tests/exporters.test.ts
@@ -2,7 +2,8 @@ import { describe, test, expect, mock } from "bun:test";
 import { Effect, Layer } from "effect";
 import { makeConsoleExporter, formatMetricsDashboard, formatDuration, type DashboardData } from "../src/exporters/console-exporter.js";
 import { makeFileExporter } from "../src/exporters/file-exporter.js";
-import { ObservabilityService, ObservabilityServiceLive } from "../src/observability-service.js";
+import { ObservabilityService } from "../src/observability-service.js";
+import { makeObservabilityTestLayer } from "./_observability-test-layer.js";
 import type { LogEntry, Span, Metric } from "../src/types.js";
 import { readFileSync, existsSync, unlinkSync } from "fs";
 
@@ -231,7 +232,7 @@ describe("ObservabilityService flush() (Phase 0.3)", () => {
     let spansCalled = false;
     let metricsCalled = false;
 
-    const TestLayer = ObservabilityServiceLive({
+    const TestLayer = makeObservabilityTestLayer({
       console: false,
       file: false,
     });
@@ -269,7 +270,7 @@ describe("ObservabilityService flush() (Phase 0.3)", () => {
     console.log = (...args: any[]) => lines.push(args.join(" "));
 
     try {
-      const TestLayer = ObservabilityServiceLive({
+      const TestLayer = makeObservabilityTestLayer({
         console: { showSpans: true, showLogs: true, showMetrics: true },
         file: false,
       });
@@ -294,7 +295,7 @@ describe("ObservabilityService flush() (Phase 0.3)", () => {
   });
 
   test("getLogs() returns filtered logs", async () => {
-    const TestLayer = ObservabilityServiceLive();
+    const TestLayer = makeObservabilityTestLayer();
     const logs = await Effect.runPromise(
       Effect.provide(
         Effect.gen(function* () {
@@ -313,7 +314,7 @@ describe("ObservabilityService flush() (Phase 0.3)", () => {
   });
 
   test("getSpans() returns recorded spans", async () => {
-    const TestLayer = ObservabilityServiceLive();
+    const TestLayer = makeObservabilityTestLayer();
     const spans = await Effect.runPromise(
       Effect.provide(
         Effect.gen(function* () {

--- a/packages/observability/tests/live-streaming.test.ts
+++ b/packages/observability/tests/live-streaming.test.ts
@@ -2,7 +2,8 @@ import { describe, test, expect, mock } from "bun:test";
 import { Effect } from "effect";
 import { makeStructuredLogger } from "../src/logging/structured-logger.js";
 import { formatLogEntryLive, makeLiveLogWriter } from "../src/exporters/console-exporter.js";
-import { ObservabilityService, ObservabilityServiceLive } from "../src/observability-service.js";
+import { ObservabilityService } from "../src/observability-service.js";
+import { makeObservabilityTestLayer } from "./_observability-test-layer.js";
 import type { LogEntry } from "../src/types.js";
 
 // ─── makeStructuredLogger liveWriter tests ───
@@ -128,7 +129,7 @@ describe("makeLiveLogWriter", () => {
 
 describe("ObservabilityServiceLive with live: true", () => {
   test("verbosity getter returns configured value", async () => {
-    const layer = ObservabilityServiceLive({ verbosity: "verbose", live: false });
+    const layer = makeObservabilityTestLayer({ verbosity: "verbose", live: false });
     const verbosity = await Effect.runPromise(
       Effect.gen(function* () {
         const obs = yield* ObservabilityService;
@@ -139,7 +140,7 @@ describe("ObservabilityServiceLive with live: true", () => {
   });
 
   test("verbosity defaults to normal when not specified", async () => {
-    const layer = ObservabilityServiceLive();
+    const layer = makeObservabilityTestLayer();
     const verbosity = await Effect.runPromise(
       Effect.gen(function* () {
         const obs = yield* ObservabilityService;
@@ -150,7 +151,7 @@ describe("ObservabilityServiceLive with live: true", () => {
   });
 
   test("logs are buffered even in live mode (getLogs returns them)", async () => {
-    const layer = ObservabilityServiceLive({ live: false });
+    const layer = makeObservabilityTestLayer({ live: false });
     const logs = await Effect.runPromise(
       Effect.gen(function* () {
         const obs = yield* ObservabilityService;

--- a/packages/observability/tests/observability-service.test.ts
+++ b/packages/observability/tests/observability-service.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from "bun:test";
 import { Effect } from "effect";
-import { ObservabilityService, ObservabilityServiceLive } from "../src/observability-service.js";
+import { ObservabilityService } from "../src/observability-service.js";
+import { makeObservabilityTestLayer } from "./_observability-test-layer.js";
 
-const TestLayer = ObservabilityServiceLive();
+const TestLayer = makeObservabilityTestLayer();
 
 const run = <A>(effect: Effect.Effect<A, any, ObservabilityService>) =>
   Effect.runPromise(Effect.provide(effect, TestLayer));

--- a/packages/runtime/src/execution-engine.ts
+++ b/packages/runtime/src/execution-engine.ts
@@ -1130,15 +1130,13 @@ export const ExecutionEngineLive = (config: ReactiveAgentsConfig) =>
                     } : {}),
                     ...(rr?.metadata?.strategyFallback === true ? { strategyFallback: true } : {}),
                     ...(ctx.metadata.budgetExceeded ? { budgetExceeded: true } : {}),
-                    // TODO(T11-followup): TaskResult.metadata type is missing 'complexity' — add it to the schema
-                    ...({ complexity: ctx.metadata.taskComplexity ?? classifyComplexity(
+                    complexity: ctx.metadata.taskComplexity ?? classifyComplexity(
                       ctx.iteration,
                       entropyLog.length > 0 ? entropyLog[entropyLog.length - 1] : undefined,
                       toolCallLog.length,
                       terminatedByRaw,
-                    ) } as Record<string, unknown>),
-                    // TODO(T11-followup): TaskResult.metadata type is missing 'llmCalls' — add it to the schema
-                    ...({ llmCalls: rr?.metadata?.llmCalls ?? ctx.metadata.llmCalls ?? 0 } as Record<string, unknown>),
+                    ),
+                    llmCalls: rr?.metadata?.llmCalls ?? ctx.metadata.llmCalls ?? 0,
                   },
                   completedAt: new Date(),
                   format: "text",

--- a/packages/runtime/src/reactive-agent.ts
+++ b/packages/runtime/src/reactive-agent.ts
@@ -965,6 +965,15 @@ export class ReactiveAgent {
     }
 
     /**
+     * The debrief from this agent's most recent completed run, if any.
+     * Populated after each `run()` / `runStream()` and reused as chat context.
+     * @returns The last `AgentDebrief`, or `undefined` if no run has completed.
+     */
+    getLastDebrief(): AgentDebrief | undefined {
+        return this._lastDebrief
+    }
+
+    /**
      * Send a conversational message to the agent.
      *
      * Automatically routes between two paths based on message intent:


### PR DESCRIPTION
Three small verified-real sweep residues (disjoint).

### #79 — TaskResult.metadata missing complexity/llmCalls
`execution-engine` wrote `complexity` + `llmCalls` via `...({ x } as Record<string, unknown>)` casts with `TODO(T11-followup)` markers because `ResultMetadataSchema` lacked them. Added both as optional schema fields (core) and removed the casts + TODOs (runtime). Values now typed.

### #158 — playground reads private `_lastDebrief` via cast
Added a public `ReactiveAgent.getLastDebrief(): AgentDebrief | undefined` accessor (the field was already tracked for chat context) and routed playground's `/debrief` through it — no more `(agent as any)` cast.

### #166 — MetricsCollectorTag not wired in test Layers
3 observability test files built `ObservabilityServiceLive()` without the collector → "MetricsCollectorTag not provided — writes and reads will diverge" WARN on every run. Added a shared `makeObservabilityTestLayer()` helper providing `MetricsCollectorLive` (+ EventBus), mirroring prod wiring.

## Verification
- #79: core typecheck clean; core `.d.ts` carries `complexity`/`llmCalls`; engine decast removed. (runtime/cli consumer-typecheck is CI-gated — local full build blocked by the known cold-worktree `@reactive-agents/observe` OTLP DTS condition, unrelated.)
- #158: accessor returns the typed private field; playground uses it.
- #166: `bun test packages/observability/` → **204/0, WARN count 0** (was N>0); new helper + test files typecheck clean.

## Closes
Closes #79
Closes #158
Closes #166

(Also closed this session: #78 — its 4 stale `@deprecated` are already gone; the 1 survivor is a live Capability-port deprecation, not a sweep target.)