### PR TITLE
test(replay): return replayed steps through harness handle

### DIFF
--- a/packages/replay/src/e2e.test.ts
+++ b/packages/replay/src/e2e.test.ts
@@ -38,6 +38,12 @@ interface CapturedTask {
     readonly outcome: AgentRunOutcome
 }
 
+interface ReplayHarnessHandle {
+    readonly run: (task: string) => Promise<AgentRunOutcome>
+    readonly dispose: () => Promise<void>
+    readonly steps: () => readonly SemanticStep[]
+}
+
 /**
  * The replay contract intentionally compares semantic steps, not invocation
  * envelopes. Timestamps, UUID-shaped run IDs, and wall-clock durations vary
@@ -328,29 +334,34 @@ function mutateRecordedToolResult(captured: CapturedTask): RecordedRun {
     return toRecordedRun({ ...captured, events })
 }
 
+function makeReplayHarnessHandle(recordedRun: RecordedRun): ReplayHarnessHandle {
+    const replayLayers = Layer.mergeAll(
+        makeReplayLLMLayer(recordedRun.llmTable),
+        makeReplayToolLayer(makeReplayController(recordedRun.toolTable)),
+        TraceRecorderServiceLive({ dir: null }),
+    )
+    let replayedSteps: readonly SemanticStep[] = []
+
+    return {
+        run: async (task: string) => {
+            const replayed = await Effect.runPromise(
+                runSeededTask(`replay-${randomUUID()}`, task).pipe(Effect.provide(replayLayers)),
+            )
+            replayedSteps = replayed.steps
+            return replayed.outcome
+        },
+        dispose: async () => {},
+        steps: () => replayedSteps,
+    }
+}
+
 async function replayRecordedRun(recordedRun: RecordedRun): Promise<{
     readonly result: Awaited<ReturnType<typeof replay>>
     readonly steps: readonly SemanticStep[]
 }> {
-    let replayedSteps: readonly SemanticStep[] = []
-    const result = await replay(recordedRun, async () => {
-        const replayLayers = Layer.mergeAll(
-            makeReplayLLMLayer(recordedRun.llmTable),
-            makeReplayToolLayer(makeReplayController(recordedRun.toolTable)),
-            TraceRecorderServiceLive({ dir: null }),
-        )
-        return {
-            run: async (task: string) => {
-                const replayed = await Effect.runPromise(
-                    runSeededTask(`replay-${randomUUID()}`, task).pipe(Effect.provide(replayLayers)),
-                )
-                replayedSteps = replayed.steps
-                return replayed.outcome
-            },
-            dispose: async () => {},
-        }
-    })
-    return { result, steps: replayedSteps }
+    const replayHandle = makeReplayHarnessHandle(recordedRun)
+    const result = await replay(recordedRun, async () => replayHandle)
+    return { result, steps: replayHandle.steps() }
 }
 
 describe("replay end-to-end determinism", () => {


### PR DESCRIPTION
## Summary

- addresses the non-blocking follow-up from PR #196 by moving replayed semantic-step capture into a small replay harness handle
- keeps the replay factory free of direct `replayedSteps` closure mutation
- preserves the existing deterministic replay assertions and negative-control divergence assertion

## Context

Follow-up to the maintainer note in #196: the previous implementation captured `replayedSteps` by mutating a variable inside the `replay()` builder factory. This keeps the same behavior but makes the handle own the replayed-step state via `steps()`.

## Verification

- `npm.cmd exec --yes bun@1.3.10 -- test packages/replay/src/e2e.test.ts --timeout 15000`
- `npm.cmd exec --yes bun@1.3.10 -- test packages/replay --timeout 15000`
- `npm.cmd exec --yes bun@1.3.10 -- run build --filter=@reactive-agents/replay`
- `npm.cmd exec --yes bun@1.3.10 -- run --filter @reactive-agents/replay typecheck`
- `git diff --check`

Note: the first typecheck attempt was run before dependency declaration outputs existed in this fresh worktree and failed on unresolved internal package imports; after the scoped package build generated dependency DTS outputs, the same replay typecheck exited cleanly.
